### PR TITLE
Add minimal UniFFI module to dash-spv behind feature flag

### DIFF
--- a/dash-spv/Cargo.toml
+++ b/dash-spv/Cargo.toml
@@ -55,6 +55,9 @@ rayon = "1.11"
 tempfile = { version = "3.0", optional = true }
 dashcore-rpc = { path = "../rpc-client", optional = true }
 
+# UniFFI (optional, for mobile bridge validation)
+uniffi = { version = "0.28", optional = true }
+
 # DNS (trust-dns-resolver was renamed to hickory_resolver)
 hickory-resolver = "0.25"
 
@@ -86,3 +89,4 @@ path = "src/lib.rs"
 
 [features]
 test-utils = ["dashcore/test-utils", "dep:tempfile", "dep:dashcore-rpc"]
+uniffi = ["dep:uniffi"]

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -9,8 +9,6 @@
 
 use std::sync::Arc;
 
-uniffi::setup_scaffolding!();
-
 /// A simple sync function that returns a greeting string.
 #[uniffi::export]
 pub fn hello() -> String {
@@ -24,7 +22,7 @@ pub async fn get_version() -> String {
 }
 
 /// Callback interface for receiving SPV sync progress events.
-#[uniffi::export(callback_interface)]
+#[uniffi::export(with_foreign)]
 pub trait SpvEventListener: Send + Sync {
     /// Called when sync progress changes.
     fn on_sync_progress(&self, percentage: f64);

--- a/dash-spv/src/lib.rs
+++ b/dash-spv/src/lib.rs
@@ -57,7 +57,10 @@
 pub mod test_utils;
 
 #[cfg(feature = "uniffi")]
-pub mod uniffi;
+uniffi::setup_scaffolding!();
+
+#[cfg(feature = "uniffi")]
+pub mod bridge;
 
 pub mod chain;
 pub mod client;

--- a/dash-spv/src/lib.rs
+++ b/dash-spv/src/lib.rs
@@ -56,6 +56,9 @@
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
+#[cfg(feature = "uniffi")]
+pub mod uniffi;
+
 pub mod chain;
 pub mod client;
 pub mod error;

--- a/dash-spv/src/uniffi/mod.rs
+++ b/dash-spv/src/uniffi/mod.rs
@@ -1,0 +1,80 @@
+//! Minimal UniFFI bridge module for dash-spv.
+//!
+//! This module validates three UniFFI call patterns:
+//! - Sync function
+//! - Async function
+//! - Callback interface
+//!
+//! Compiled only when the `uniffi` feature is enabled.
+
+use std::sync::Arc;
+
+uniffi::setup_scaffolding!();
+
+/// A simple sync function that returns a greeting string.
+#[uniffi::export]
+pub fn hello() -> String {
+    "Hello from dash-spv!".to_string()
+}
+
+/// An async function that returns the library version.
+#[uniffi::export]
+pub async fn get_version() -> String {
+    crate::VERSION.to_string()
+}
+
+/// Callback interface for receiving SPV sync progress events.
+#[uniffi::export(callback_interface)]
+pub trait SpvEventListener: Send + Sync {
+    /// Called when sync progress changes.
+    fn on_sync_progress(&self, percentage: f64);
+}
+
+/// Starts a mock sync that reports progress via the listener callback.
+///
+/// Invokes `on_sync_progress` with 0.0 and 100.0 to simulate start and completion.
+#[uniffi::export]
+pub async fn start_mock_sync(listener: Arc<dyn SpvEventListener>) {
+    listener.on_sync_progress(0.0);
+    // Simulate minimal async work
+    tokio::task::yield_now().await;
+    listener.on_sync_progress(100.0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn test_hello() {
+        assert_eq!(hello(), "Hello from dash-spv!");
+    }
+
+    #[tokio::test]
+    async fn test_get_version() {
+        let version = get_version().await;
+        assert!(!version.is_empty(), "version should not be empty");
+        assert_eq!(version, crate::VERSION);
+    }
+
+    struct MockListener {
+        events: Mutex<Vec<f64>>,
+    }
+
+    impl SpvEventListener for MockListener {
+        fn on_sync_progress(&self, percentage: f64) {
+            self.events.lock().unwrap().push(percentage);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_start_mock_sync() {
+        let listener = Arc::new(MockListener {
+            events: Mutex::new(Vec::new()),
+        });
+        start_mock_sync(listener.clone()).await;
+        let events = listener.events.lock().unwrap();
+        assert_eq!(*events, vec![0.0, 100.0]);
+    }
+}


### PR DESCRIPTION
## Summary
Adds a `uniffi` feature flag to `dash-spv` with a minimal bridge module validating three UniFFI call patterns:
- Sync function (`hello()`)
- Async function (`get_version()`)
- Callback interface (`SpvEventListener` with `on_sync_progress`)

All three compile and pass tests with `cargo test -p dash-spv --features uniffi --lib`.

Closes #1