### PR TITLE
Add UniFFI derives to ValidationMode and custom_type for Network

### DIFF
--- a/dash-spv/Cargo.toml
+++ b/dash-spv/Cargo.toml
@@ -56,7 +56,7 @@ tempfile = { version = "3.0", optional = true }
 dashcore-rpc = { path = "../rpc-client", optional = true }
 
 # UniFFI (optional, for mobile bridge validation)
-uniffi = { version = "0.28", optional = true }
+uniffi = { version = "0.31.0", optional = true }
 
 # DNS (trust-dns-resolver was renamed to hickory_resolver)
 hickory-resolver = "0.25"

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -14,7 +14,7 @@ use dashcore::Network;
 uniffi::custom_type!(Network, String, {
     remote,
     lower: |n| n.to_string(),
-    try_lift: |s| s.parse().map_err(|e| uniffi::deps::anyhow::anyhow!(e)),
+    try_lift: |s| s.parse().map_err(|e: String| uniffi::deps::anyhow::anyhow!(e)),
 });
 
 /// A simple sync function that returns a greeting string.

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -9,7 +9,9 @@
 
 use std::sync::Arc;
 
-uniffi::custom_type!(dashcore::Network, String, {
+use dashcore::Network;
+
+uniffi::custom_type!(Network, String, {
     remote,
     lower: |n| n.to_string(),
     try_lift: |s| s.parse().map_err(Into::into),

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -14,7 +14,7 @@ use dashcore::Network;
 uniffi::custom_type!(Network, String, {
     remote,
     lower: |n| n.to_string(),
-    try_lift: |s| s.parse().map_err(Into::into),
+    try_lift: |s| s.parse().map_err(|e| uniffi::deps::anyhow::anyhow!(e)),
 });
 
 /// A simple sync function that returns a greeting string.

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -11,11 +11,19 @@ use std::sync::Arc;
 
 use dashcore::Network;
 
-uniffi::custom_type!(Network, String, {
-    remote,
-    lower: |n| n.to_string(),
-    try_lift: |s| s.parse().map_err(Into::into),
-});
+uniffi::custom_type!(Network, String);
+
+impl uniffi::UniffiCustomTypeConverter for Network {
+    type Builtin = String;
+
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+        val.parse().map_err(|e| anyhow::anyhow!("Invalid network: {e}").into())
+    }
+
+    fn from_custom(obj: Self) -> Self::Builtin {
+        obj.to_string()
+    }
+}
 
 /// A simple sync function that returns a greeting string.
 #[uniffi::export]

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -11,7 +11,11 @@ use std::sync::Arc;
 
 use dashcore::Network;
 
-uniffi::custom_type!(Network, String);
+uniffi::custom_type!(Network, String, {
+    remote,
+    lower: |n| n.to_string(),
+    try_lift: |s| s.parse().map_err(Into::into),
+});
 
 /// A simple sync function that returns a greeting string.
 #[uniffi::export]

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -13,18 +13,6 @@ use dashcore::Network;
 
 uniffi::custom_type!(Network, String);
 
-impl uniffi::UniffiCustomTypeConverter for Network {
-    type Builtin = String;
-
-    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-        val.parse().map_err(|e| anyhow::anyhow!("Invalid network: {e}").into())
-    }
-
-    fn from_custom(obj: Self) -> Self::Builtin {
-        obj.to_string()
-    }
-}
-
 /// A simple sync function that returns a greeting string.
 #[uniffi::export]
 pub fn hello() -> String {

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -9,6 +9,12 @@
 
 use std::sync::Arc;
 
+uniffi::custom_type!(dashcore::Network, String, {
+    remote,
+    lower: |n| n.to_string(),
+    try_lift: |s| s.parse().map_err(Into::into),
+});
+
 /// A simple sync function that returns a greeting string.
 #[uniffi::export]
 pub fn hello() -> String {

--- a/dash-spv/src/types.rs
+++ b/dash-spv/src/types.rs
@@ -159,6 +159,7 @@ impl std::fmt::Display for PeerId {
 
 /// Validation mode for the SPV client.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum ValidationMode {
     /// Validate only basic structure and signatures.
     Basic,


### PR DESCRIPTION
## Summary
- Adds `#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]` to `ValidationMode`
- Adds `custom_type!` bridge for `dashcore::Network` to `String` in `bridge/mod.rs`
- First step toward direct UniFFI integration on existing types

Partial progress on #6 — subsequent PRs will add derives to `ClientConfig`, event types, etc.