### PR TITLE
Ignore RUSTSEC-2024-0436 (paste unmaintained, transitive via uniffi)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,8 @@ ignore = [
     # bincode is unmaintained but used throughout the codebase, need to find a solution here.
     # https://rustsec.org/advisories/RUSTSEC-2025-0141.html
     "RUSTSEC-2025-0141",
+    # paste is unmaintained, pulled in transitively by uniffi
+    "RUSTSEC-2024-0436",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary
- Adds `RUSTSEC-2024-0436` to cargo-deny ignore list
- The `paste` crate is flagged as unmaintained but is only a transitive dependency from `uniffi`, not a security issue

Closes #10