### PR TITLE
ci: add allowed_tools to Claude Code Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,15 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           assignee_trigger: "claude"
-          allowed_tools: "Bash(cargo *),Bash(rustup *),Bash(git *)"
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(cargo *)",
+                  "Bash(rustup *)",
+                  "Bash(git *)"
+                ]
+              }
+            }
           claude_args: |
             --max-turns 50

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,5 +38,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           assignee_trigger: "claude"
+          allowed_tools: "Bash(cargo *),Bash(rustup *),Bash(git *)"
           claude_args: |
             --max-turns 50


### PR DESCRIPTION
## Summary
- Add `allowed_tools` config to the Claude Code Action workflow so it can run `cargo`, `rustup`, and `git` commands without being blocked by tool approval

## Why
The action was unable to run `cargo fmt --all` on PR #13 because no `allowed_tools` were configured, causing it to fail silently.