### PR TITLE
feat: wire get_network_info() with real peer data

### DIFF
--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -1199,11 +1199,7 @@ mod tests {
         assert_eq!(info.network, "regtest", "network name should be 'regtest'");
         assert_eq!(info.peer_count, 0, "peer count should be 0 before start");
         assert!(info.peers.is_empty(), "peers list should be empty when no peers are connected");
-        assert_eq!(
-            info.peer_count as usize,
-            info.peers.len(),
-            "peer_count must equal peers.len()"
-        );
+        assert_eq!(info.peer_count as usize, info.peers.len(), "peer_count must equal peers.len()");
     }
 
     // ---- MasternodeInfo / GovernanceProposal record tests ----

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -208,8 +208,6 @@ pub struct NetworkInfo {
     /// Number of currently connected peers.
     pub peer_count: u32,
     /// Details for each connected peer.
-    ///
-    /// TODO: populate with real peer data from `PeerNetworkManager`.
     pub peers: Vec<PeerInfo>,
 }
 
@@ -544,18 +542,26 @@ impl SpvClient {
 
     /// Returns network and peer information.
     ///
-    /// Currently returns a stub with the network name, peer count, and an empty
-    /// peer list.  Peer details will be wired up once `PeerNetworkManager`
-    /// exposes per-peer metadata.
-    ///
-    /// TODO: populate `peers` with real data from `PeerNetworkManager`.
+    /// Queries `PeerNetworkManager` for a snapshot of all currently connected
+    /// peers and maps each entry to a [`PeerInfo`] record.
     pub async fn get_network_info(&self) -> NetworkInfo {
         let network = self.inner.network().await;
-        let peer_count = self.inner.peer_count().await as u32;
+        let snapshots = self.inner.peers_snapshot().await;
+        let peer_count = snapshots.len() as u32;
+        let peers = snapshots
+            .into_iter()
+            .map(|s| PeerInfo {
+                address: s.address.to_string(),
+                user_agent: s.user_agent,
+                best_height: s.best_height,
+                connected_since: s.connected_since,
+                services: s.services,
+            })
+            .collect();
         NetworkInfo {
             network: network.to_string(),
             peer_count,
-            peers: vec![], // TODO: populate with real peer data
+            peers,
         }
     }
 }
@@ -1177,10 +1183,10 @@ mod tests {
         assert_eq!(info.peers[1].best_height, 501);
     }
 
-    /// Verify that `get_network_info` returns a stub with the correct network
-    /// name and zero peers before the client is started.
+    /// Verify that `get_network_info` returns the correct network name and an
+    /// empty peer list when the client has not been started (no connections).
     #[tokio::test]
-    async fn test_get_network_info_stub() {
+    async fn test_get_network_info_no_peers_when_not_started() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let config = ClientConfig::regtest()
             .without_filters()
@@ -1192,7 +1198,12 @@ mod tests {
 
         assert_eq!(info.network, "regtest", "network name should be 'regtest'");
         assert_eq!(info.peer_count, 0, "peer count should be 0 before start");
-        assert!(info.peers.is_empty(), "peers should be empty in stub implementation");
+        assert!(info.peers.is_empty(), "peers list should be empty when no peers are connected");
+        assert_eq!(
+            info.peer_count as usize,
+            info.peers.len(),
+            "peer_count must equal peers.len()"
+        );
     }
 
     // ---- MasternodeInfo / GovernanceProposal record tests ----

--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -27,6 +27,23 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         self.network.lock().await.peer_count()
     }
 
+    /// Return a snapshot of all currently connected peers.
+    ///
+    /// Delegates to [`crate::network::manager::PeerNetworkManager::get_peers_snapshot`]
+    /// via a downcast.  Returns an empty `Vec` when the underlying network
+    /// manager is not a `PeerNetworkManager`.
+    pub async fn peers_snapshot(&self) -> Vec<crate::network::manager::PeerSnapshot> {
+        let network_guard = self.network.lock().await;
+        if let Some(network) = network_guard
+            .as_any()
+            .downcast_ref::<crate::network::manager::PeerNetworkManager>()
+        {
+            network.get_peers_snapshot().await
+        } else {
+            vec![]
+        }
+    }
+
     /// Disconnect a specific peer.
     pub async fn disconnect_peer(&self, addr: &std::net::SocketAddr, reason: &str) -> Result<()> {
         // Cast network manager to PeerNetworkManager to access disconnect_peer

--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -34,9 +34,8 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
     /// manager is not a `PeerNetworkManager`.
     pub async fn peers_snapshot(&self) -> Vec<crate::network::manager::PeerSnapshot> {
         let network_guard = self.network.lock().await;
-        if let Some(network) = network_guard
-            .as_any()
-            .downcast_ref::<crate::network::manager::PeerNetworkManager>()
+        if let Some(network) =
+            network_guard.as_any().downcast_ref::<crate::network::manager::PeerNetworkManager>()
         {
             network.get_peers_snapshot().await
         } else {

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -37,6 +37,23 @@ use tokio_util::sync::CancellationToken;
 
 const DEFAULT_NETWORK_EVENT_CAPACITY: usize = 10000;
 
+/// Point-in-time snapshot of a single connected peer's state.
+///
+/// Returned by [`PeerNetworkManager::get_peers_snapshot`].
+#[derive(Debug, Clone)]
+pub struct PeerSnapshot {
+    /// Remote socket address of the peer.
+    pub address: SocketAddr,
+    /// User-agent string reported during the handshake (empty if not yet received).
+    pub user_agent: String,
+    /// Best block height reported by the peer (0 if not yet received).
+    pub best_height: u32,
+    /// Unix timestamp (seconds) of when the peer connected (0 if unknown).
+    pub connected_since: u64,
+    /// Raw services bitmask advertised by the peer (0 if not yet received).
+    pub services: u64,
+}
+
 /// Peer network manager
 pub struct PeerNetworkManager {
     /// Peer pool
@@ -1171,6 +1188,31 @@ impl PeerNetworkManager {
         .await;
 
         Ok(())
+    }
+
+    /// Return a point-in-time snapshot of all currently connected peers.
+    ///
+    /// Each entry captures the address, user-agent, best height, connection
+    /// timestamp, and services bitmask as they were at the moment of the call.
+    pub async fn get_peers_snapshot(&self) -> Vec<PeerSnapshot> {
+        let peers = self.pool.get_all_peers().await;
+        let mut result = Vec::with_capacity(peers.len());
+        for (addr, peer_lock) in peers {
+            let peer = peer_lock.read().await;
+            let connected_since = peer
+                .connected_since()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            result.push(PeerSnapshot {
+                address: addr,
+                user_agent: peer.user_agent().unwrap_or("").to_owned(),
+                best_height: peer.best_height().unwrap_or(0),
+                connected_since,
+                services: peer.services_bits().unwrap_or(0),
+            });
+        }
+        result
     }
 
     /// Get reputation information for all peers

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -31,7 +31,7 @@ use dashcore::network::message_sml::GetMnListDiff;
 use dashcore::BlockHash;
 use dashcore_hashes::Hash;
 pub use handshake::{HandshakeManager, HandshakeState};
-pub use manager::PeerNetworkManager;
+pub use manager::{PeerNetworkManager, PeerSnapshot};
 pub use message_dispatcher::{Message, MessageDispatcher};
 pub use message_type::MessageType;
 pub use peer::Peer;

--- a/dash-spv/src/network/peer.rs
+++ b/dash-spv/src/network/peer.rs
@@ -133,6 +133,21 @@ impl Peer {
         self.best_height
     }
 
+    /// Get the user-agent string reported by this peer during the handshake.
+    pub fn user_agent(&self) -> Option<&str> {
+        self.user_agent.as_deref()
+    }
+
+    /// Get the `SystemTime` at which this peer connected.
+    pub fn connected_since(&self) -> Option<std::time::SystemTime> {
+        self.connected_at
+    }
+
+    /// Get the raw services bitmask advertised by this peer.
+    pub fn services_bits(&self) -> Option<u64> {
+        self.services
+    }
+
     /// Check if peer supports compact filters (BIP 157/158).
     pub fn supports_compact_filters(&self) -> bool {
         self.has_service(ServiceFlags::COMPACT_FILTERS)


### PR DESCRIPTION
## Summary
- Add peer info accessor to PeerNetworkManager and Peer
- Wire get_network_info() to return real peer data (address, user_agent, best_height, connected_since, services)
- Wire get_peer_count() to return real connected peer count
- Tests for network info bridge methods

Closes #28

## Test plan
- [ ] get_network_info returns network name and peer data
- [ ] get_peer_count returns actual connected count
- [ ] PeerInfo fields populated from Peer data