### PR TITLE
feat: wire get_balance() to wallet implementation

### DIFF
--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -531,14 +531,18 @@ impl SpvClient {
         matches!(self.inner.sync_progress().await.state(), SyncState::Syncing)
     }
 
-    /// Returns the wallet balance.
+    /// Returns the wallet balance aggregated across all managed wallets.
     ///
-    /// TODO: delegate to `self.inner.wallet()` once wallet integration is complete.
+    /// Reads the wallet state under a shared lock and maps the internal
+    /// `WalletCoreBalance` breakdown to the UniFFI `WalletBalance` record.
+    /// All amounts are in duffs.
     pub async fn get_balance(&self) -> WalletBalance {
+        let wallet = self.inner.wallet().read().await;
+        let balance = wallet.get_aggregated_balance();
         WalletBalance {
-            confirmed: 0,
-            unconfirmed: 0,
-            immature: 0,
+            confirmed: balance.spendable(),
+            unconfirmed: balance.unconfirmed(),
+            immature: balance.immature(),
         }
     }
 
@@ -1051,6 +1055,44 @@ mod tests {
         };
         assert_eq!(
             balance,
+            WalletBalance {
+                confirmed: 0,
+                unconfirmed: 0,
+                immature: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_wallet_balance_mapping_from_wallet_core_balance() {
+        use key_wallet::WalletCoreBalance;
+        // Verify: confirmed=spendable, unconfirmed=unconfirmed, immature=immature.
+        // The `locked` field in WalletCoreBalance is intentionally excluded from
+        // WalletBalance (locked funds are not part of the spendable/pending/immature view).
+        let core = WalletCoreBalance::new(1_000_000, 250_000, 50_000, 999);
+        let mapped = WalletBalance {
+            confirmed: core.spendable(),
+            unconfirmed: core.unconfirmed(),
+            immature: core.immature(),
+        };
+        assert_eq!(mapped.confirmed, 1_000_000);
+        assert_eq!(mapped.unconfirmed, 250_000);
+        assert_eq!(mapped.immature, 50_000);
+    }
+
+    #[test]
+    fn test_get_aggregated_balance_empty_manager() {
+        use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
+        use key_wallet_manager::wallet_manager::WalletManager;
+        let manager = WalletManager::<ManagedWalletInfo>::new(dashcore::Network::Testnet);
+        let balance = manager.get_aggregated_balance();
+        let wallet_balance = WalletBalance {
+            confirmed: balance.spendable(),
+            unconfirmed: balance.unconfirmed(),
+            immature: balance.immature(),
+        };
+        assert_eq!(
+            wallet_balance,
             WalletBalance {
                 confirmed: 0,
                 unconfirmed: 0,

--- a/key-wallet-manager/src/wallet_manager/event_tests.rs
+++ b/key-wallet-manager/src/wallet_manager/event_tests.rs
@@ -705,3 +705,32 @@ async fn test_check_transaction_populates_totals() {
         "involved_addresses should contain the target address"
     );
 }
+
+// ============ get_aggregated_balance tests ============
+
+#[test]
+fn test_get_aggregated_balance_empty_manager() {
+    let manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
+    let balance = manager.get_aggregated_balance();
+    assert_eq!(balance.spendable(), 0);
+    assert_eq!(balance.unconfirmed(), 0);
+    assert_eq!(balance.immature(), 0);
+    assert_eq!(balance.total(), 0);
+}
+
+#[test]
+fn test_get_aggregated_balance_fresh_wallet_is_zero() {
+    let (manager, _wallet_id, _addr) = setup_manager_with_wallet();
+    let balance = manager.get_aggregated_balance();
+    assert_eq!(balance.spendable(), 0);
+    assert_eq!(balance.unconfirmed(), 0);
+    assert_eq!(balance.immature(), 0);
+    assert_eq!(balance.total(), 0);
+}
+
+#[test]
+fn test_get_aggregated_balance_matches_get_total_balance() {
+    let (manager, _wallet_id, _addr) = setup_manager_with_wallet();
+    let aggregated = manager.get_aggregated_balance();
+    assert_eq!(aggregated.total(), manager.get_total_balance());
+}

--- a/key-wallet-manager/src/wallet_manager/mod.rs
+++ b/key-wallet-manager/src/wallet_manager/mod.rs
@@ -984,6 +984,18 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         self.wallet_infos.values().map(|info| info.balance().total()).sum()
     }
 
+    /// Get aggregated balance breakdown across all wallets.
+    ///
+    /// Returns the sum of confirmed (spendable), unconfirmed, and immature
+    /// balances across every managed wallet.
+    pub fn get_aggregated_balance(&self) -> WalletCoreBalance {
+        let mut total = WalletCoreBalance::default();
+        for info in self.wallet_infos.values() {
+            total += info.balance();
+        }
+        total
+    }
+
     /// Get balance for a specific wallet
     pub fn get_wallet_balance(
         &self,


### PR DESCRIPTION
## Summary
- Add get_aggregated_balance() to WalletManager for total balance across accounts
- Wire UniFFI get_balance() to return real wallet balance (confirmed, unconfirmed, immature)
- Tests for balance bridge method

Closes #27

## Test plan
- [ ] get_balance returns wallet balance data
- [ ] Balance reflects confirmed/unconfirmed/immature correctly
- [ ] Returns zeros when wallet has no funds