### PR TITLE
feat: expose mempool transaction data in UniFFI bridge

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,5 +38,15 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           assignee_trigger: "claude"
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(cargo *)",
+                  "Bash(rustup *)",
+                  "Bash(git *)"
+                ]
+              }
+            }
           claude_args: |
             --max-turns 50

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,42 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned' && github.event.assignee.login == 'claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          assignee_trigger: "claude"
+          claude_args: |
+            --max-turns 50

--- a/dash-spv-ffi/FFI_API.md
+++ b/dash-spv-ffi/FFI_API.md
@@ -4,7 +4,7 @@ This document provides a comprehensive reference for all FFI (Foreign Function I
 
 **Auto-generated**: This documentation is automatically generated from the source code. Do not edit manually.
 
-**Total Functions**: 49
+**Total Functions**: 50
 
 ## Table of Contents
 
@@ -13,6 +13,7 @@ This document provides a comprehensive reference for all FFI (Foreign Function I
 - [Synchronization](#synchronization)
 - [Wallet Operations](#wallet-operations)
 - [Transaction Management](#transaction-management)
+- [Mempool Operations](#mempool-operations)
 - [Platform Integration](#platform-integration)
 - [Event Callbacks](#event-callbacks)
 - [Error Handling](#error-handling)
@@ -81,6 +82,14 @@ Functions: 1
 | Function | Description | Module |
 |----------|-------------|--------|
 | `dash_spv_ffi_client_broadcast_transaction` | Broadcasts a transaction to the Dash network via connected peers | client |
+
+### Mempool Operations
+
+Functions: 1
+
+| Function | Description | Module |
+|----------|-------------|--------|
+| `dash_spv_ffi_mempool_progress_destroy` | Destroy an `FFIMempoolProgress` object | types |
 
 ### Platform Integration
 
@@ -555,6 +564,24 @@ Broadcasts a transaction to the Dash network via connected peers.  # Safety  - `
 - `client` must be a valid, non-null pointer to an initialized FFIDashSpvClient - `tx_bytes` must be a valid, non-null pointer to the transaction data - `length` must be the length of the transaction data in bytes
 
 **Module:** `client`
+
+---
+
+### Mempool Operations - Detailed
+
+#### `dash_spv_ffi_mempool_progress_destroy`
+
+```c
+dash_spv_ffi_mempool_progress_destroy(progress: *mut FFIMempoolProgress) -> ()
+```
+
+**Description:**
+Destroy an `FFIMempoolProgress` object.  # Safety - `progress` must be a pointer returned from this crate, or null.
+
+**Safety:**
+- `progress` must be a pointer returned from this crate, or null.
+
+**Module:** `types`
 
 ---
 

--- a/dash-spv-ffi/include/dash_spv_ffi.h
+++ b/dash-spv-ffi/include/dash_spv_ffi.h
@@ -311,6 +311,14 @@ typedef void (*OnManagerErrorCallback)(enum FFIManagerId manager_id,
                                        void *user_data);
 
 /**
+ * Callback for SyncEvent::MempoolActivated
+ *
+ * The `peer` string pointer is borrowed and only valid for the duration
+ * of the callback. Callers must copy the string if they need to retain it.
+ */
+typedef void (*OnMempoolActivatedCallback)(const char *peer, void *user_data);
+
+/**
  * Callback for SyncEvent::SyncComplete
  */
 typedef void (*OnSyncCompleteCallback)(uint32_t header_tip, uint32_t cycle, void *user_data);
@@ -338,6 +346,7 @@ typedef struct FFISyncEventCallbacks {
   OnChainLockReceivedCallback on_chainlock_received;
   OnInstantLockReceivedCallback on_instantlock_received;
   OnManagerErrorCallback on_manager_error;
+  OnMempoolActivatedCallback on_mempool_activated;
   OnSyncCompleteCallback on_sync_complete;
   void *user_data;
 } FFISyncEventCallbacks;

--- a/dash-spv-ffi/include/dash_spv_ffi.h
+++ b/dash-spv-ffi/include/dash_spv_ffi.h
@@ -38,6 +38,7 @@ typedef enum FFIManagerId {
   Masternodes = 4,
   ChainLocks = 5,
   InstantSend = 6,
+  Mempool = 7,
 } FFIManagerId;
 
 typedef enum FFIMempoolStrategy {
@@ -145,6 +146,18 @@ typedef struct FFIInstantSendProgress {
 } FFIInstantSendProgress;
 
 /**
+ * Progress for mempool transaction monitoring.
+ */
+typedef struct FFIMempoolProgress {
+  enum FFISyncState state;
+  uint32_t received;
+  uint32_t relevant;
+  uint32_t tracked;
+  uint32_t removed;
+  uint64_t last_activity;
+} FFIMempoolProgress;
+
+/**
  * Aggregate progress for all sync managers.
  * Provides a complete view of the parallel sync system's state.
  */
@@ -162,6 +175,7 @@ typedef struct FFISyncProgress {
   struct FFIMasternodesProgress *masternodes;
   struct FFIChainLockProgress *chainlocks;
   struct FFIInstantSendProgress *instantsend;
+  struct FFIMempoolProgress *mempool;
 } FFISyncProgress;
 
 /**
@@ -249,6 +263,8 @@ typedef void (*OnBlocksNeededCallback)(const struct FFIBlockNeeded *blocks,
 typedef void (*OnBlockProcessedCallback)(uint32_t height,
                                          const uint8_t (*hash)[32],
                                          uint32_t new_address_count,
+                                         const uint8_t (*confirmed_txids)[32],
+                                         uint32_t confirmed_txid_count,
                                          void *user_data);
 
 /**
@@ -375,11 +391,21 @@ typedef struct FFINetworkEventCallbacks {
  * copy any data they need to retain after the callback returns.
  */
 typedef void (*OnTransactionReceivedCallback)(const char *wallet_id,
+                                              FFITransactionContext status,
                                               uint32_t account_index,
                                               const uint8_t (*txid)[32],
                                               int64_t amount,
                                               const char *addresses,
                                               void *user_data);
+
+/**
+ * Callback for WalletEvent::TransactionStatusChanged
+ *
+ * The `txid` pointer is borrowed and only valid for the duration of the callback.
+ */
+typedef void (*OnTransactionStatusChangedCallback)(const uint8_t (*txid)[32],
+                                                   FFITransactionContext status,
+                                                   void *user_data);
 
 /**
  * Callback for WalletEvent::BalanceUpdated
@@ -406,6 +432,7 @@ typedef void (*OnBalanceUpdatedCallback)(const char *wallet_id,
  */
 typedef struct FFIWalletEventCallbacks {
   OnTransactionReceivedCallback on_transaction_received;
+  OnTransactionStatusChangedCallback on_transaction_status_changed;
   OnBalanceUpdatedCallback on_balance_updated;
   void *user_data;
 } FFIWalletEventCallbacks;
@@ -962,6 +989,14 @@ struct FFIResult ffi_dash_spv_get_platform_activation_height(struct FFIDashSpvCl
  * - `progress` must be a pointer returned from this crate, or null.
  */
  void dash_spv_ffi_instantsend_progress_destroy(struct FFIInstantSendProgress *progress) ;
+
+/**
+ * Destroy an `FFIMempoolProgress` object.
+ *
+ * # Safety
+ * - `progress` must be a pointer returned from this crate, or null.
+ */
+ void dash_spv_ffi_mempool_progress_destroy(struct FFIMempoolProgress *progress) ;
 
 /**
  * Destroy an `FFISyncProgress` object and all its nested pointers.

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -5,6 +5,7 @@ use std::ptr;
 use clap::{Arg, ArgAction, Command};
 
 use dash_spv_ffi::*;
+use key_wallet_ffi::types::FFITransactionContext;
 use key_wallet_ffi::wallet_manager::wallet_manager_add_wallet_from_mnemonic;
 use key_wallet_ffi::{FFIError, FFINetwork};
 
@@ -28,6 +29,7 @@ extern "C" fn on_sync_start(manager_id: FFIManagerId, _user_data: *mut c_void) {
         FFIManagerId::Masternodes => "Masternodes",
         FFIManagerId::ChainLocks => "ChainLocks",
         FFIManagerId::InstantSend => "InstantSend",
+        FFIManagerId::Mempool => "Mempool",
     };
     println!("[Sync] Manager started: {}", manager_name);
 }
@@ -75,9 +77,14 @@ extern "C" fn on_block_processed(
     height: u32,
     _hash: *const [u8; 32],
     new_address_count: u32,
+    _confirmed_txids: *const [u8; 32],
+    confirmed_txid_count: u32,
     _user_data: *mut c_void,
 ) {
-    println!("[Sync] Block processed: height={}, new_addresses={}", height, new_address_count);
+    println!(
+        "[Sync] Block processed: height={}, new_addresses={}, confirmed_txs={}",
+        height, new_address_count, confirmed_txid_count
+    );
 }
 
 extern "C" fn on_masternode_state_updated(height: u32, _user_data: *mut c_void) {
@@ -150,6 +157,7 @@ extern "C" fn on_peers_updated(connected_count: u32, best_height: u32, _user_dat
 
 extern "C" fn on_transaction_received(
     wallet_id: *const c_char,
+    status: FFITransactionContext,
     account_index: u32,
     txid: *const [u8; 32],
     amount: i64,
@@ -165,9 +173,18 @@ extern "C" fn on_transaction_received(
     };
     let txid_hex = unsafe { hex::encode(*txid) };
     println!(
-        "[Wallet] TX received: wallet={}..., txid={}, account={}, amount={} duffs, addresses={}",
-        wallet_short, txid_hex, account_index, amount, addr_str
+        "[Wallet] TX received: wallet={}..., txid={}, account={}, amount={} duffs, status={:?}, addresses={}",
+        wallet_short, txid_hex, account_index, amount, status, addr_str
     );
+}
+
+extern "C" fn on_transaction_status_changed(
+    txid: *const [u8; 32],
+    status: FFITransactionContext,
+    _user_data: *mut c_void,
+) {
+    let txid_hex = unsafe { hex::encode(*txid) };
+    println!("[Wallet] TX status changed: txid={}, status={:?}", txid_hex, status);
 }
 
 extern "C" fn on_balance_updated(
@@ -431,6 +448,7 @@ fn main() {
 
         let wallet_callbacks = FFIWalletEventCallbacks {
             on_transaction_received: Some(on_transaction_received),
+            on_transaction_status_changed: Some(on_transaction_status_changed),
             on_balance_updated: Some(on_balance_updated),
             user_data: ptr::null_mut(),
         };

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -129,6 +129,11 @@ extern "C" fn on_manager_error(
     println!("[Sync] Manager error: {:?} - {}", manager_id, error_str);
 }
 
+extern "C" fn on_mempool_activated(peer: *const c_char, _user_data: *mut c_void) {
+    let peer_str = ffi_string_to_rust(peer);
+    println!("[Sync] Mempool activated on peer: {}", peer_str);
+}
+
 extern "C" fn on_sync_complete(header_tip: u32, cycle: u32, _user_data: *mut c_void) {
     println!("[Sync] Sync complete at height: {} (cycle {})", header_tip, cycle);
 }
@@ -435,6 +440,7 @@ fn main() {
             on_chainlock_received: Some(on_chainlock_received),
             on_instantlock_received: Some(on_instantlock_received),
             on_manager_error: Some(on_manager_error),
+            on_mempool_activated: Some(on_mempool_activated),
             on_sync_complete: Some(on_sync_complete),
             user_data: ptr::null_mut(),
         };

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -8,6 +8,7 @@
 
 use crate::{dash_spv_ffi_sync_progress_destroy, FFISyncProgress};
 use dashcore::hashes::Hash;
+use key_wallet_ffi::types::FFITransactionContext;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 
@@ -26,6 +27,7 @@ pub enum FFIManagerId {
     Masternodes = 4,
     ChainLocks = 5,
     InstantSend = 6,
+    Mempool = 7,
 }
 
 impl From<dash_spv::sync::ManagerIdentifier> for FFIManagerId {
@@ -38,6 +40,7 @@ impl From<dash_spv::sync::ManagerIdentifier> for FFIManagerId {
             dash_spv::sync::ManagerIdentifier::Masternode => FFIManagerId::Masternodes,
             dash_spv::sync::ManagerIdentifier::ChainLock => FFIManagerId::ChainLocks,
             dash_spv::sync::ManagerIdentifier::InstantSend => FFIManagerId::InstantSend,
+            dash_spv::sync::ManagerIdentifier::Mempool => FFIManagerId::Mempool,
         }
     }
 }
@@ -161,6 +164,8 @@ pub type OnBlockProcessedCallback = Option<
         height: u32,
         hash: *const [u8; 32],
         new_address_count: u32,
+        confirmed_txids: *const [u8; 32],
+        confirmed_txid_count: u32,
         user_data: *mut c_void,
     ),
 >;
@@ -349,13 +354,18 @@ impl FFISyncEventCallbacks {
                 block_hash,
                 height,
                 new_addresses,
+                confirmed_txids,
             } => {
                 if let Some(cb) = self.on_block_processed {
                     let hash_bytes = block_hash.as_byte_array();
+                    let txid_bytes: Vec<[u8; 32]> =
+                        confirmed_txids.iter().map(|txid| *txid.as_byte_array()).collect();
                     cb(
                         *height,
                         hash_bytes as *const [u8; 32],
                         new_addresses.len() as u32,
+                        txid_bytes.as_ptr(),
+                        txid_bytes.len() as u32,
                         self.user_data,
                     );
                 }
@@ -522,12 +532,20 @@ impl FFINetworkEventCallbacks {
 pub type OnTransactionReceivedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
+        status: FFITransactionContext,
         account_index: u32,
         txid: *const [u8; 32],
         amount: i64,
         addresses: *const c_char,
         user_data: *mut c_void,
     ),
+>;
+
+/// Callback for WalletEvent::TransactionStatusChanged
+///
+/// The `txid` pointer is borrowed and only valid for the duration of the callback.
+pub type OnTransactionStatusChangedCallback = Option<
+    extern "C" fn(txid: *const [u8; 32], status: FFITransactionContext, user_data: *mut c_void),
 >;
 
 /// Callback for WalletEvent::BalanceUpdated
@@ -557,6 +575,7 @@ pub type OnBalanceUpdatedCallback = Option<
 #[derive(Clone)]
 pub struct FFIWalletEventCallbacks {
     pub on_transaction_received: OnTransactionReceivedCallback,
+    pub on_transaction_status_changed: OnTransactionStatusChangedCallback,
     pub on_balance_updated: OnBalanceUpdatedCallback,
     pub user_data: *mut c_void,
 }
@@ -569,6 +588,7 @@ impl Default for FFIWalletEventCallbacks {
     fn default() -> Self {
         Self {
             on_transaction_received: None,
+            on_transaction_status_changed: None,
             on_balance_updated: None,
             user_data: std::ptr::null_mut(),
         }
@@ -625,6 +645,7 @@ impl FFIWalletEventCallbacks {
         match event {
             WalletEvent::TransactionReceived {
                 wallet_id,
+                status,
                 account_index,
                 txid,
                 amount,
@@ -639,10 +660,24 @@ impl FFIWalletEventCallbacks {
                     let c_addresses = CString::new(addresses_str.join(",")).unwrap_or_default();
                     cb(
                         c_wallet_id.as_ptr(),
+                        FFITransactionContext::from(*status),
                         *account_index,
                         txid_bytes as *const [u8; 32],
                         *amount,
                         c_addresses.as_ptr(),
+                        self.user_data,
+                    );
+                }
+            }
+            WalletEvent::TransactionStatusChanged {
+                txid,
+                status,
+            } => {
+                if let Some(cb) = self.on_transaction_status_changed {
+                    let txid_bytes = txid.as_byte_array();
+                    cb(
+                        txid_bytes as *const [u8; 32],
+                        FFITransactionContext::from(*status),
                         self.user_data,
                     );
                 }

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -213,6 +213,13 @@ pub type OnInstantLockReceivedCallback = Option<
 pub type OnManagerErrorCallback =
     Option<extern "C" fn(manager_id: FFIManagerId, error: *const c_char, user_data: *mut c_void)>;
 
+/// Callback for SyncEvent::MempoolActivated
+///
+/// The `peer` string pointer is borrowed and only valid for the duration
+/// of the callback. Callers must copy the string if they need to retain it.
+pub type OnMempoolActivatedCallback =
+    Option<extern "C" fn(peer: *const c_char, user_data: *mut c_void)>;
+
 /// Callback for SyncEvent::SyncComplete
 pub type OnSyncCompleteCallback =
     Option<extern "C" fn(header_tip: u32, cycle: u32, user_data: *mut c_void)>;
@@ -240,6 +247,7 @@ pub struct FFISyncEventCallbacks {
     pub on_chainlock_received: OnChainLockReceivedCallback,
     pub on_instantlock_received: OnInstantLockReceivedCallback,
     pub on_manager_error: OnManagerErrorCallback,
+    pub on_mempool_activated: OnMempoolActivatedCallback,
     pub on_sync_complete: OnSyncCompleteCallback,
     pub user_data: *mut c_void,
 }
@@ -272,6 +280,7 @@ impl Default for FFISyncEventCallbacks {
             on_chainlock_received: None,
             on_instantlock_received: None,
             on_manager_error: None,
+            on_mempool_activated: None,
             on_sync_complete: None,
             user_data: std::ptr::null_mut(),
         }
@@ -416,6 +425,14 @@ impl FFISyncEventCallbacks {
                 if let Some(cb) = self.on_manager_error {
                     let c_error = CString::new(error.as_str()).unwrap_or_default();
                     cb((*manager).into(), c_error.as_ptr(), self.user_data);
+                }
+            }
+            SyncEvent::MempoolActivated {
+                peer,
+            } => {
+                if let Some(cb) = self.on_mempool_activated {
+                    let c_peer = CString::new(peer.to_string()).unwrap_or_default();
+                    cb(c_peer.as_ptr(), self.user_data);
                 }
             }
             SyncEvent::SyncComplete {

--- a/dash-spv-ffi/src/types.rs
+++ b/dash-spv-ffi/src/types.rs
@@ -1,8 +1,8 @@
 use dash_spv::client::config::MempoolStrategy;
 use dash_spv::sync::{
     BlockHeadersProgress, BlocksProgress, ChainLockProgress, FilterHeadersProgress,
-    FiltersProgress, InstantSendProgress, MasternodesProgress, ProgressPercentage, SyncProgress,
-    SyncState,
+    FiltersProgress, InstantSendProgress, MasternodesProgress, MempoolProgress, ProgressPercentage,
+    SyncProgress, SyncState,
 };
 use dash_spv::types::MempoolRemovalReason;
 use std::ffi::{CStr, CString};
@@ -259,6 +259,31 @@ impl From<&InstantSendProgress> for FFIInstantSendProgress {
     }
 }
 
+/// Progress for mempool transaction monitoring.
+#[repr(C)]
+#[derive(Debug, Clone, Default)]
+pub struct FFIMempoolProgress {
+    pub state: FFISyncState,
+    pub received: u32,
+    pub relevant: u32,
+    pub tracked: u32,
+    pub removed: u32,
+    pub last_activity: u64,
+}
+
+impl From<&MempoolProgress> for FFIMempoolProgress {
+    fn from(progress: &MempoolProgress) -> Self {
+        FFIMempoolProgress {
+            state: progress.state().into(),
+            received: progress.received(),
+            relevant: progress.relevant(),
+            tracked: progress.tracked(),
+            removed: progress.removed(),
+            last_activity: progress.last_activity().elapsed().as_secs(),
+        }
+    }
+}
+
 /// Aggregate progress for all sync managers.
 /// Provides a complete view of the parallel sync system's state.
 #[repr(C)]
@@ -274,6 +299,7 @@ pub struct FFISyncProgress {
     pub masternodes: *mut FFIMasternodesProgress,
     pub chainlocks: *mut FFIChainLockProgress,
     pub instantsend: *mut FFIInstantSendProgress,
+    pub mempool: *mut FFIMempoolProgress,
 }
 
 impl From<SyncProgress> for FFISyncProgress {
@@ -320,6 +346,12 @@ impl From<SyncProgress> for FFISyncProgress {
             .map(|p| Box::into_raw(Box::new(FFIInstantSendProgress::from(p))))
             .unwrap_or(std::ptr::null_mut());
 
+        let mempool = progress
+            .mempool()
+            .ok()
+            .map(|p| Box::into_raw(Box::new(FFIMempoolProgress::from(p))))
+            .unwrap_or(std::ptr::null_mut());
+
         Self {
             state: progress.state().into(),
             percentage: progress.percentage(),
@@ -331,6 +363,7 @@ impl From<SyncProgress> for FFISyncProgress {
             masternodes,
             chainlocks,
             instantsend,
+            mempool,
         }
     }
 }
@@ -486,6 +519,17 @@ pub unsafe extern "C" fn dash_spv_ffi_instantsend_progress_destroy(
     }
 }
 
+/// Destroy an `FFIMempoolProgress` object.
+///
+/// # Safety
+/// - `progress` must be a pointer returned from this crate, or null.
+#[no_mangle]
+pub unsafe extern "C" fn dash_spv_ffi_mempool_progress_destroy(progress: *mut FFIMempoolProgress) {
+    if !progress.is_null() {
+        let _ = Box::from_raw(progress);
+    }
+}
+
 /// Destroy an `FFISyncProgress` object and all its nested pointers.
 ///
 /// # Safety
@@ -516,6 +560,9 @@ pub unsafe extern "C" fn dash_spv_ffi_sync_progress_destroy(progress: *mut FFISy
         }
         if !p.instantsend.is_null() {
             dash_spv_ffi_instantsend_progress_destroy(p.instantsend);
+        }
+        if !p.mempool.is_null() {
+            dash_spv_ffi_mempool_progress_destroy(p.mempool);
         }
     }
 }

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -282,6 +282,15 @@ extern "C" fn on_manager_error(
     tracker.errors.lock().unwrap_or_else(|e| e.into_inner()).push(error_str);
 }
 
+extern "C" fn on_mempool_activated(peer: *const c_char, user_data: *mut c_void) {
+    let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
+        return;
+    };
+    let peer_str = unsafe { cstr_or_unknown(peer) };
+    tracing::info!("on_mempool_activated: peer={}", peer_str);
+    let _ = tracker;
+}
+
 extern "C" fn on_sync_complete(header_tip: u32, cycle: u32, user_data: *mut c_void) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
@@ -412,6 +421,7 @@ pub(super) fn create_sync_callbacks(tracker: &Arc<CallbackTracker>) -> FFISyncEv
         on_chainlock_received: Some(on_chainlock_received),
         on_instantlock_received: Some(on_instantlock_received),
         on_manager_error: Some(on_manager_error),
+        on_mempool_activated: Some(on_mempool_activated),
         on_sync_complete: Some(on_sync_complete),
         user_data: Arc::as_ptr(tracker) as *mut c_void,
     }

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use dash_spv_ffi::*;
+use key_wallet_ffi::types::FFITransactionContext;
 
 /// Tracks callback invocations for verification.
 ///
@@ -35,6 +36,7 @@ pub(super) struct CallbackTracker {
 
     // Wallet event tracking
     pub(super) transaction_received_count: AtomicU32,
+    pub(super) transaction_status_changed_count: AtomicU32,
     pub(super) balance_updated_count: AtomicU32,
 
     // Data from callbacks
@@ -211,6 +213,8 @@ extern "C" fn on_block_processed(
     height: u32,
     _hash: *const [u8; 32],
     new_address_count: u32,
+    _confirmed_txids: *const [u8; 32],
+    confirmed_txid_count: u32,
     user_data: *mut c_void,
 ) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
@@ -220,7 +224,12 @@ extern "C" fn on_block_processed(
     if let Ok(mut heights) = tracker.processed_block_heights.lock() {
         heights.push(height);
     }
-    tracing::debug!("on_block_processed: height={}, new_addresses={}", height, new_address_count);
+    tracing::debug!(
+        "on_block_processed: height={}, new_addresses={}, confirmed_txs={}",
+        height,
+        new_address_count,
+        confirmed_txid_count
+    );
 }
 
 extern "C" fn on_masternode_state_updated(height: u32, user_data: *mut c_void) {
@@ -318,6 +327,7 @@ extern "C" fn on_peers_updated(connected_count: u32, best_height: u32, user_data
 
 extern "C" fn on_transaction_received(
     wallet_id: *const c_char,
+    _status: FFITransactionContext,
     account_index: u32,
     txid: *const [u8; 32],
     amount: i64,
@@ -344,6 +354,18 @@ extern "C" fn on_transaction_received(
         account_index,
         amount
     );
+}
+
+extern "C" fn on_transaction_status_changed(
+    _txid: *const [u8; 32],
+    status: FFITransactionContext,
+    user_data: *mut c_void,
+) {
+    let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
+        return;
+    };
+    tracker.transaction_status_changed_count.fetch_add(1, Ordering::SeqCst);
+    tracing::debug!("on_transaction_status_changed: status={:?}", status);
 }
 
 extern "C" fn on_balance_updated(
@@ -415,6 +437,7 @@ pub(super) fn create_network_callbacks(tracker: &Arc<CallbackTracker>) -> FFINet
 pub(super) fn create_wallet_callbacks(tracker: &Arc<CallbackTracker>) -> FFIWalletEventCallbacks {
     FFIWalletEventCallbacks {
         on_transaction_received: Some(on_transaction_received),
+        on_transaction_status_changed: Some(on_transaction_status_changed),
         on_balance_updated: Some(on_balance_updated),
         user_data: Arc::as_ptr(tracker) as *mut c_void,
     }

--- a/dash-spv-ffi/tests/unit/test_async_operations.rs
+++ b/dash-spv-ffi/tests/unit/test_async_operations.rs
@@ -288,6 +288,7 @@ mod tests {
                 on_chainlock_received: None,
                 on_instantlock_received: None,
                 on_manager_error: None,
+                on_mempool_activated: None,
                 on_sync_complete: Some(on_sync_complete),
                 user_data: &event_data as *const _ as *mut c_void,
             };

--- a/dash-spv/Cargo.toml
+++ b/dash-spv/Cargo.toml
@@ -56,7 +56,7 @@ tempfile = { version = "3.0", optional = true }
 dashcore-rpc = { path = "../rpc-client", optional = true }
 
 # UniFFI (optional, for mobile bridge validation)
-uniffi = { version = "0.28", optional = true }
+uniffi = { version = "0.31.0", optional = true }
 
 # DNS (trust-dns-resolver was renamed to hickory_resolver)
 hickory-resolver = "0.25"

--- a/dash-spv/Cargo.toml
+++ b/dash-spv/Cargo.toml
@@ -55,6 +55,9 @@ rayon = "1.11"
 tempfile = { version = "3.0", optional = true }
 dashcore-rpc = { path = "../rpc-client", optional = true }
 
+# UniFFI (optional, for mobile bridge validation)
+uniffi = { version = "0.28", optional = true }
+
 # DNS (trust-dns-resolver was renamed to hickory_resolver)
 hickory-resolver = "0.25"
 
@@ -86,3 +89,4 @@ path = "src/lib.rs"
 
 [features]
 test-utils = ["dashcore/test-utils", "dep:tempfile", "dep:dashcore-rpc"]
+uniffi = ["dep:uniffi"]

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -610,20 +610,62 @@ pub struct GovernanceProposal {
 impl SpvClient {
     /// Returns the number of masternodes in the current masternode list.
     ///
-    /// TODO: wire up to `MasternodeListEngine` once the engine is accessible
-    /// from `DashSpvClient`.
+    /// Reads the latest masternode list from the engine and returns its entry
+    /// count.  Returns `0` when masternodes are disabled or no list has been
+    /// received yet.
     pub async fn get_masternode_count(&self) -> u32 {
-        // TODO: return self.inner.masternode_list_engine()?.read().await.count()
-        0
+        let Some(engine) = self.inner.masternode_engine().await else {
+            return 0;
+        };
+        let guard = engine.read().await;
+        guard.latest_masternode_list().map(|list| list.masternodes.len() as u32).unwrap_or(0)
     }
 
     /// Returns all masternodes from the current masternode list.
     ///
-    /// TODO: wire up to `MasternodeListEngine` once the engine is accessible
-    /// from `DashSpvClient`.
+    /// Iterates the latest masternode list from the engine and maps each
+    /// [`dashcore::sml::masternode_list_entry::MasternodeListEntry`] to a
+    /// [`MasternodeInfo`] record.  Returns an empty `Vec` when masternodes are
+    /// disabled or no list has been received yet.
+    ///
+    /// # Field mapping
+    ///
+    /// | `MasternodeListEntry` field | `MasternodeInfo` field |
+    /// |---|---|
+    /// | `pro_reg_tx_hash` | `pro_tx_hash` |
+    /// | `service_address` | `address` |
+    /// | `is_valid` | `status` (`"Enabled"` / `"PoSeBanned"`) |
+    /// | — | `pose_penalty` (always `0`; not in SML diff) |
+    /// | — | `last_paid_height` (always `0`; not in SML diff) |
+    /// | — | `registered_height` (always `0`; not in SML diff) |
     pub async fn get_masternodes(&self) -> Vec<MasternodeInfo> {
-        // TODO: map MasternodeListEntry fields to MasternodeInfo
-        vec![]
+        let Some(engine) = self.inner.masternode_engine().await else {
+            return vec![];
+        };
+        let guard = engine.read().await;
+        let Some(list) = guard.latest_masternode_list() else {
+            return vec![];
+        };
+        list.masternodes
+            .values()
+            .map(|entry| {
+                let mn = &entry.masternode_list_entry;
+                MasternodeInfo {
+                    pro_tx_hash: mn.pro_reg_tx_hash.to_string(),
+                    address: mn.service_address.to_string(),
+                    status: if mn.is_valid {
+                        "Enabled".to_string()
+                    } else {
+                        "PoSeBanned".to_string()
+                    },
+                    // The SML diff does not carry PoSe penalty, last-paid height, or
+                    // registered height — default to 0 until richer data sources are wired up.
+                    pose_penalty: 0,
+                    last_paid_height: 0,
+                    registered_height: 0,
+                }
+            })
+            .collect()
     }
 }
 
@@ -1237,8 +1279,9 @@ mod tests {
         assert_eq!(proposal.abstain_count, 1);
     }
 
+    /// `get_masternode_count` returns 0 when masternodes are disabled (no engine).
     #[tokio::test]
-    async fn test_get_masternode_count_stub() {
+    async fn test_get_masternode_count_no_engine() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let config = ClientConfig::regtest()
             .without_filters()
@@ -1246,11 +1289,12 @@ mod tests {
             .with_storage_path(temp_dir.path());
 
         let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
-        assert_eq!(client.get_masternode_count().await, 0, "stub should return 0");
+        assert_eq!(client.get_masternode_count().await, 0, "should return 0 when engine is None");
     }
 
+    /// `get_masternodes` returns an empty vec when masternodes are disabled (no engine).
     #[tokio::test]
-    async fn test_get_masternodes_stub() {
+    async fn test_get_masternodes_no_engine() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let config = ClientConfig::regtest()
             .without_filters()
@@ -1258,7 +1302,39 @@ mod tests {
             .with_storage_path(temp_dir.path());
 
         let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
-        let masternodes = client.get_masternodes().await;
-        assert!(masternodes.is_empty(), "stub should return empty vec");
+        assert!(
+            client.get_masternodes().await.is_empty(),
+            "should return empty vec when engine is None"
+        );
+    }
+
+    /// `get_masternode_count` returns 0 when masternodes are enabled but no list
+    /// has been received yet (engine is Some but empty).
+    #[tokio::test]
+    async fn test_get_masternode_count_empty_engine() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        // Default regtest config has enable_masternodes = true
+        let config = ClientConfig::regtest().without_filters().with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert_eq!(
+            client.get_masternode_count().await,
+            0,
+            "should return 0 when engine has no list yet"
+        );
+    }
+
+    /// `get_masternodes` returns an empty vec when masternodes are enabled but no
+    /// list has been received yet (engine is Some but empty).
+    #[tokio::test]
+    async fn test_get_masternodes_empty_engine() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest().without_filters().with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert!(
+            client.get_masternodes().await.is_empty(),
+            "should return empty vec when engine has no list yet"
+        );
     }
 }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -5,13 +5,42 @@
 //!
 //! Compiled only when the `uniffi` feature is enabled.
 
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use dashcore::Network;
+use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
+use key_wallet_manager::wallet_manager::WalletManager;
+use tokio::sync::RwLock;
+
+use crate::client::{ClientConfig, DashSpvClient};
+use crate::error::SpvError;
+use crate::network::PeerNetworkManager;
+use crate::storage::DiskStorageManager;
+use crate::sync::SyncState;
+
+// ============ custom_type! mappings ============
 
 uniffi::custom_type!(Network, String, {
     remote,
     lower: |n| n.to_string(),
     try_lift: |s| s.parse().map_err(|e: String| uniffi::deps::anyhow::anyhow!(e)),
 });
+
+uniffi::custom_type!(SocketAddr, String, {
+    remote,
+    lower: |a| a.to_string(),
+    try_lift: |s| s.parse::<SocketAddr>().map_err(|e| uniffi::deps::anyhow::anyhow!(e)),
+});
+
+uniffi::custom_type!(PathBuf, String, {
+    remote,
+    lower: |p| p.to_string_lossy().into_owned(),
+    try_lift: |s| Ok::<PathBuf, uniffi::deps::anyhow::Error>(PathBuf::from(s)),
+});
+
+// ============ Event types ============
 
 /// UniFFI-compatible representation of a sync event.
 ///
@@ -178,6 +207,144 @@ pub trait SpvEventListener: Send + Sync {
     fn on_sync_progress(&self, percentage: f64, current_height: u32, target_height: u32);
 }
 
+// ============ Error type ============
+
+/// Error type for the UniFFI SpvClient wrapper.
+#[derive(Debug, uniffi::Error, thiserror::Error)]
+pub enum SpvClientError {
+    #[error("Configuration error: {message}")]
+    Config {
+        message: String,
+    },
+    #[error("Network error: {message}")]
+    Network {
+        message: String,
+    },
+    #[error("Storage error: {message}")]
+    Storage {
+        message: String,
+    },
+    #[error("Sync error: {message}")]
+    Sync {
+        message: String,
+    },
+    #[error("General error: {message}")]
+    General {
+        message: String,
+    },
+}
+
+impl From<SpvError> for SpvClientError {
+    fn from(err: SpvError) -> Self {
+        match err {
+            SpvError::Config(msg) => SpvClientError::Config {
+                message: msg,
+            },
+            SpvError::Network(e) => SpvClientError::Network {
+                message: e.to_string(),
+            },
+            SpvError::Storage(e) => SpvClientError::Storage {
+                message: e.to_string(),
+            },
+            SpvError::Sync(e) => SpvClientError::Sync {
+                message: e.to_string(),
+            },
+            other => SpvClientError::General {
+                message: other.to_string(),
+            },
+        }
+    }
+}
+
+// ============ Concrete type alias ============
+
+type ConcreteClient =
+    DashSpvClient<WalletManager<ManagedWalletInfo>, PeerNetworkManager, DiskStorageManager>;
+
+// ============ SpvClient wrapper ============
+
+/// Concrete UniFFI-compatible wrapper for the Dash SPV client.
+///
+/// `DashSpvClient` is generic and cannot be exported via UniFFI directly.
+/// This wrapper fixes the type parameters to the standard production
+/// implementations and exposes lifecycle and state-query methods.
+#[derive(uniffi::Object)]
+pub struct SpvClient {
+    inner: ConcreteClient,
+}
+
+#[uniffi::export]
+impl SpvClient {
+    /// Create a new `SpvClient` from the given configuration.
+    ///
+    /// Constructs the network manager, storage manager, and wallet, then
+    /// hands them to `DashSpvClient::new`.
+    #[uniffi::constructor]
+    pub async fn new(config: ClientConfig) -> Result<Arc<Self>, SpvClientError> {
+        let network = PeerNetworkManager::new(&config).await.map_err(SpvClientError::from)?;
+        let storage =
+            DiskStorageManager::new(&config).await.map_err(|e| SpvClientError::Storage {
+                message: e.to_string(),
+            })?;
+        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
+
+        let inner = DashSpvClient::new(config, network, storage, wallet)
+            .await
+            .map_err(SpvClientError::from)?;
+
+        Ok(Arc::new(Self {
+            inner,
+        }))
+    }
+
+    /// Start the client — connect to the network and begin syncing.
+    pub async fn start(&self) -> Result<(), SpvClientError> {
+        self.inner.start().await.map_err(SpvClientError::from)
+    }
+
+    /// Stop the client — disconnect from the network and flush storage.
+    pub async fn stop(&self) -> Result<(), SpvClientError> {
+        self.inner.stop().await.map_err(SpvClientError::from)
+    }
+
+    /// Shutdown the client (alias for `stop`).
+    pub async fn shutdown(&self) -> Result<(), SpvClientError> {
+        self.inner.shutdown().await.map_err(SpvClientError::from)
+    }
+
+    /// Returns `true` if the client is currently running.
+    pub async fn is_running(&self) -> bool {
+        self.inner.is_running().await
+    }
+
+    /// Returns the current chain tip height (0 if no headers yet).
+    pub async fn tip_height(&self) -> u32 {
+        self.inner.tip_height().await
+    }
+
+    /// Returns the current chain tip hash as a hex string, or `None` if unavailable.
+    pub async fn tip_hash(&self) -> Option<String> {
+        self.inner.tip_hash().await.map(|h| h.to_string())
+    }
+
+    /// Returns the number of connected peers.
+    pub async fn peer_count(&self) -> u64 {
+        self.inner.peer_count().await as u64
+    }
+
+    /// Returns the overall sync completion percentage in the range `[0.0, 1.0]`.
+    pub async fn sync_progress(&self) -> f64 {
+        self.inner.sync_progress().await.percentage()
+    }
+
+    /// Returns `true` when the client is actively downloading and processing blocks.
+    pub async fn is_syncing(&self) -> bool {
+        matches!(self.inner.sync_progress().await.state(), SyncState::Syncing)
+    }
+}
+
+// ============ Stub functions ============
+
 /// Returns a greeting string (sanity-check export).
 #[uniffi::export]
 pub fn hello() -> String {
@@ -193,6 +360,8 @@ pub async fn get_version() -> String {
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
+
+    use tempfile::TempDir;
 
     use super::*;
 
@@ -278,7 +447,6 @@ mod tests {
 
     #[test]
     fn test_sync_event_variants() {
-        // Verify all variants can be constructed and cloned.
         let events: Vec<SyncEvent> = vec![
             SyncEvent::SyncStart {
                 identifier: "BlockHeader".to_string(),
@@ -332,7 +500,6 @@ mod tests {
                 cycle: 0,
             },
         ];
-        // Clone succeeds for all variants.
         let _cloned: Vec<SyncEvent> = events.to_vec();
         assert_eq!(events.len(), 14);
     }
@@ -359,5 +526,43 @@ mod tests {
         ];
         let _cloned: Vec<NetworkEvent> = events.to_vec();
         assert_eq!(events.len(), 4);
+    }
+
+    /// Verify that `SpvClient` can be constructed from a minimal regtest config.
+    #[tokio::test]
+    async fn test_spv_client_construction() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await;
+        assert!(client.is_ok(), "SpvClient construction should succeed");
+
+        let client = client.unwrap();
+        assert!(!client.is_running().await, "Client should not be running after construction");
+        assert_eq!(client.tip_height().await, 0, "Tip height should start at 0 (genesis)");
+        assert_eq!(client.peer_count().await, 0, "Peer count should be 0 before start");
+    }
+
+    /// Verify that `sync_progress` and `is_syncing` return sensible defaults.
+    #[tokio::test]
+    async fn test_spv_client_state_queries() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+
+        let progress = client.sync_progress().await;
+        assert!(
+            (0.0..=1.0).contains(&progress),
+            "sync_progress should be in [0.0, 1.0], got {progress}"
+        );
+
+        assert!(!client.is_syncing().await, "Client should not be syncing before start()");
     }
 }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -379,6 +379,10 @@ pub enum SpvClientError {
     Sync {
         message: String,
     },
+    #[error("Transaction error: {message}")]
+    Transaction {
+        message: String,
+    },
     #[error("General error: {message}")]
     General {
         message: String,
@@ -405,6 +409,17 @@ impl From<SpvError> for SpvClientError {
             },
         }
     }
+}
+
+// ============ Send result type ============
+
+/// UniFFI-compatible result record for a broadcasted transaction.
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct SendResult {
+    /// Transaction ID (txid) of the broadcasted transaction, as a hex string.
+    pub txid: String,
+    /// Broadcast status: `"broadcasted"` on success.
+    pub status: String,
 }
 
 // ============ Wallet record types ============
@@ -766,6 +781,50 @@ impl SpvClient {
     pub async fn get_governance_proposal(&self, hash: String) -> Option<GovernanceProposal> {
         let _ = hash;
         None
+    }
+}
+
+// ============ Send transaction ============
+
+#[uniffi::export]
+impl SpvClient {
+    /// Broadcast a raw transaction to the Dash network.
+    ///
+    /// Decodes `raw_tx_hex` (a hex-encoded serialised Dash transaction), broadcasts
+    /// it to all connected peers via `DashSpvClient::broadcast_transaction`, and
+    /// returns a [`SendResult`] containing the transaction ID on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpvClientError::Transaction`] when:
+    /// * `raw_tx_hex` is not valid hexadecimal.
+    /// * The decoded bytes cannot be deserialised as a `dashcore::Transaction`.
+    ///
+    /// Returns [`SpvClientError::Network`] when:
+    /// * No peers are connected.
+    /// * All peers reject or fail to receive the message.
+    pub async fn send_transaction(&self, raw_tx_hex: String) -> Result<SendResult, SpvClientError> {
+        use dashcore::consensus::Decodable;
+        use hex::FromHex;
+
+        let bytes = Vec::<u8>::from_hex(&raw_tx_hex).map_err(|e| SpvClientError::Transaction {
+            message: format!("Invalid hex: {e}"),
+        })?;
+
+        let tx = dashcore::Transaction::consensus_decode(&mut bytes.as_slice()).map_err(|e| {
+            SpvClientError::Transaction {
+                message: format!("Failed to deserialise transaction: {e}"),
+            }
+        })?;
+
+        let txid = tx.txid().to_string();
+
+        self.inner.broadcast_transaction(&tx).await.map_err(SpvClientError::from)?;
+
+        Ok(SendResult {
+            txid,
+            status: "broadcasted".to_string(),
+        })
     }
 }
 
@@ -1680,6 +1739,120 @@ mod tests {
         assert!(
             client.get_transaction("abcd1234".to_string()).await.is_none(),
             "get_transaction should return None (stub)"
+        );
+    }
+
+    // ---- SendResult record tests ----
+
+    #[test]
+    fn test_send_result_fields() {
+        let result = SendResult {
+            txid: "abcd1234efgh5678".to_string(),
+            status: "broadcasted".to_string(),
+        };
+        assert_eq!(result.txid, "abcd1234efgh5678");
+        assert_eq!(result.status, "broadcasted");
+    }
+
+    #[test]
+    fn test_send_result_clone_and_eq() {
+        let result = SendResult {
+            txid: "txid001".to_string(),
+            status: "broadcasted".to_string(),
+        };
+        let cloned = result.clone();
+        assert_eq!(result, cloned);
+    }
+
+    // ---- send_transaction error-path tests ----
+
+    /// `send_transaction` with invalid hex returns `SpvClientError::Transaction`.
+    #[tokio::test]
+    async fn test_send_transaction_invalid_hex() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let err = client
+            .send_transaction("not-valid-hex!!".to_string())
+            .await
+            .expect_err("should fail on invalid hex");
+
+        assert!(
+            matches!(err, SpvClientError::Transaction { .. }),
+            "expected Transaction error, got: {err:?}"
+        );
+    }
+
+    /// `send_transaction` with valid hex that is not a valid transaction returns
+    /// `SpvClientError::Transaction`.
+    #[tokio::test]
+    async fn test_send_transaction_invalid_tx_bytes() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        // Valid hex but random bytes — not a parseable transaction.
+        let err = client
+            .send_transaction("deadbeefcafe".to_string())
+            .await
+            .expect_err("should fail on non-transaction bytes");
+
+        assert!(
+            matches!(err, SpvClientError::Transaction { .. }),
+            "expected Transaction error, got: {err:?}"
+        );
+    }
+
+    /// `send_transaction` with a well-formed transaction but no connected peers
+    /// returns `SpvClientError::Network`.
+    #[tokio::test]
+    async fn test_send_transaction_no_peers() {
+        use dashcore::consensus::Encodable;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+
+        // Build a minimal coinbase-style transaction (version=1, 1 input, 1 output).
+        let tx = dashcore::Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![dashcore::TxIn {
+                previous_output: dashcore::OutPoint::null(),
+                script_sig: dashcore::ScriptBuf::new(),
+                sequence: 0xFFFF_FFFF,
+                witness: dashcore::Witness::default(),
+            }],
+            output: vec![dashcore::TxOut {
+                value: 50_000_000,
+                script_pubkey: dashcore::ScriptBuf::new(),
+            }],
+            special_transaction_payload: None,
+        };
+
+        let mut raw = Vec::new();
+        tx.consensus_encode(&mut raw).expect("encode must succeed");
+        let raw_hex = hex::encode(&raw);
+
+        let err = client
+            .send_transaction(raw_hex)
+            .await
+            .expect_err("should fail when no peers are connected");
+
+        assert!(
+            matches!(err, SpvClientError::Network { .. }),
+            "expected Network error when no peers connected, got: {err:?}"
         );
     }
 }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -215,6 +215,50 @@ pub struct NetworkInfo {
     pub peers: Vec<PeerInfo>,
 }
 
+/// UniFFI-compatible representation of a wallet event.
+///
+/// This is a flattened version of the internal [`key_wallet_manager::WalletEvent`]
+/// that uses only types expressible across the UniFFI boundary.  Complex fields
+/// such as `WalletId`, `Txid`, and `Address` are represented as `String` values.
+#[derive(uniffi::Enum, Clone, Debug)]
+pub enum WalletEvent {
+    /// A transaction relevant to the wallet was received for the first time.
+    TransactionReceived {
+        /// Hex-encoded wallet ID of the affected wallet.
+        wallet_id: String,
+        /// Transaction context as a string (e.g. `"mempool"`, `"instant send"`, `"block 100"`).
+        status: String,
+        /// Account index within the wallet.
+        account_index: u32,
+        /// Hex-encoded transaction ID.
+        txid: String,
+        /// Net amount change in duffs (positive for incoming, negative for outgoing).
+        amount_sats: i64,
+        /// Addresses involved in the transaction (Base58Check encoded).
+        addresses: Vec<String>,
+    },
+    /// The confirmation status of a previously seen transaction has changed.
+    TransactionStatusChanged {
+        /// Hex-encoded transaction ID.
+        txid: String,
+        /// New transaction context as a string.
+        status: String,
+    },
+    /// The wallet balance has changed.
+    BalanceUpdated {
+        /// Hex-encoded wallet ID of the affected wallet.
+        wallet_id: String,
+        /// New spendable balance in duffs (confirmed and mature).
+        spendable_sats: u64,
+        /// New unconfirmed balance in duffs.
+        unconfirmed_sats: u64,
+        /// New immature balance (coinbase UTXOs not yet mature) in duffs.
+        immature_sats: u64,
+        /// New locked balance in duffs.
+        locked_sats: u64,
+    },
+}
+
 /// Callback interface for receiving SPV client events on the foreign side.
 ///
 /// Implement this trait in React Native / Swift and register it via
@@ -230,6 +274,9 @@ pub trait SpvEventListener: Send + Sync {
 
     /// Called whenever a network event occurs (peer connected / disconnected).
     fn on_network_event(&self, event: NetworkEvent);
+
+    /// Called whenever a wallet event occurs (transaction received, balance updated, etc.).
+    fn on_wallet_event(&self, event: WalletEvent);
 
     /// Called when overall sync progress changes.
     ///
@@ -1178,6 +1225,48 @@ fn convert_network_event(event: crate::network::NetworkEvent) -> NetworkEvent {
     }
 }
 
+/// Convert an internal [`key_wallet_manager::WalletEvent`] to the bridge [`WalletEvent`].
+fn convert_wallet_event(event: key_wallet_manager::WalletEvent) -> WalletEvent {
+    use key_wallet_manager::WalletEvent as I;
+    match event {
+        I::TransactionReceived {
+            wallet_id,
+            status,
+            account_index,
+            txid,
+            amount,
+            addresses,
+        } => WalletEvent::TransactionReceived {
+            wallet_id: hex::encode(wallet_id),
+            status: status.to_string(),
+            account_index,
+            txid: txid.to_string(),
+            amount_sats: amount,
+            addresses: addresses.iter().map(|a| a.to_string()).collect(),
+        },
+        I::TransactionStatusChanged {
+            txid,
+            status,
+        } => WalletEvent::TransactionStatusChanged {
+            txid: txid.to_string(),
+            status: status.to_string(),
+        },
+        I::BalanceUpdated {
+            wallet_id,
+            spendable,
+            unconfirmed,
+            immature,
+            locked,
+        } => WalletEvent::BalanceUpdated {
+            wallet_id: hex::encode(wallet_id),
+            spendable_sats: spendable,
+            unconfirmed_sats: unconfirmed,
+            immature_sats: immature,
+            locked_sats: locked,
+        },
+    }
+}
+
 // ============ Subscription methods ============
 
 #[uniffi::export]
@@ -1198,6 +1287,7 @@ impl SpvClient {
         let mut sync_rx = self.inner.subscribe_sync_events().await;
         let mut net_rx = self.inner.subscribe_network_events().await;
         let mut progress_rx = self.inner.subscribe_progress().await;
+        let mut wallet_rx = self.inner.wallet().read().await.subscribe_events();
 
         let handle = tokio::spawn(async move {
             loop {
@@ -1227,6 +1317,20 @@ impl SpvClient {
                                 tracing::warn!(
                                     skipped = n,
                                     "SPV network-event subscriber lagged; some events were dropped"
+                                );
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                        }
+                    }
+                    result = wallet_rx.recv() => {
+                        match result {
+                            Ok(event) => {
+                                listener.on_wallet_event(convert_wallet_event(event));
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                                tracing::warn!(
+                                    skipped = n,
+                                    "SPV wallet-event subscriber lagged; some events were dropped"
                                 );
                             }
                             Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
@@ -1439,6 +1543,7 @@ mod tests {
     struct MockListener {
         sync_events: Mutex<Vec<SyncEvent>>,
         network_events: Mutex<Vec<NetworkEvent>>,
+        wallet_events: Mutex<Vec<WalletEvent>>,
         progress_events: Mutex<Vec<(f64, u32, u32)>>,
     }
 
@@ -1447,6 +1552,7 @@ mod tests {
             Self {
                 sync_events: Mutex::new(Vec::new()),
                 network_events: Mutex::new(Vec::new()),
+                wallet_events: Mutex::new(Vec::new()),
                 progress_events: Mutex::new(Vec::new()),
             }
         }
@@ -1459,6 +1565,10 @@ mod tests {
 
         fn on_network_event(&self, event: NetworkEvent) {
             self.network_events.lock().unwrap().push(event);
+        }
+
+        fn on_wallet_event(&self, event: WalletEvent) {
+            self.wallet_events.lock().unwrap().push(event);
         }
 
         fn on_sync_progress(&self, percentage: f64, current_height: u32, target_height: u32) {
@@ -2717,6 +2827,152 @@ mod tests {
             NetworkEvent::PeersUpdated { connected_count: 0, ref addresses, best_height: None }
             if addresses.is_empty()
         ));
+    }
+
+    // ---- WalletEvent enum tests ----
+
+    #[test]
+    fn test_wallet_event_variants() {
+        let events: Vec<WalletEvent> = vec![
+            WalletEvent::TransactionReceived {
+                wallet_id: "aabb".to_string(),
+                status: "mempool".to_string(),
+                account_index: 0,
+                txid: "deadbeef".to_string(),
+                amount_sats: 100_000,
+                addresses: vec!["XtestAddr1".to_string()],
+            },
+            WalletEvent::TransactionStatusChanged {
+                txid: "deadbeef".to_string(),
+                status: "block 100".to_string(),
+            },
+            WalletEvent::BalanceUpdated {
+                wallet_id: "aabb".to_string(),
+                spendable_sats: 1_000_000,
+                unconfirmed_sats: 50_000,
+                immature_sats: 0,
+                locked_sats: 0,
+            },
+        ];
+        let _cloned: Vec<WalletEvent> = events.to_vec();
+        assert_eq!(events.len(), 3);
+    }
+
+    #[test]
+    fn test_listener_receives_wallet_event() {
+        let listener = MockListener::new();
+        listener.on_wallet_event(WalletEvent::BalanceUpdated {
+            wallet_id: "aabb".to_string(),
+            spendable_sats: 1_000_000,
+            unconfirmed_sats: 0,
+            immature_sats: 0,
+            locked_sats: 0,
+        });
+        let events = listener.wallet_events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], WalletEvent::BalanceUpdated { .. }));
+    }
+
+    // ---- convert_wallet_event tests ----
+
+    /// `convert_wallet_event` maps `TransactionReceived` correctly.
+    #[test]
+    fn test_convert_wallet_event_transaction_received() {
+        use dashcore::hashes::Hash;
+        use dashcore::Txid;
+        use key_wallet::transaction_checking::TransactionContext;
+        use key_wallet_manager::WalletEvent as I;
+
+        let wallet_id = [0xabu8; 32];
+        let txid = Txid::all_zeros();
+        let event = I::TransactionReceived {
+            wallet_id,
+            status: TransactionContext::Mempool,
+            account_index: 2,
+            txid,
+            amount: 500_000,
+            addresses: vec![],
+        };
+
+        let bridge = convert_wallet_event(event);
+        match bridge {
+            WalletEvent::TransactionReceived {
+                wallet_id: wid,
+                status,
+                account_index,
+                txid: txid_str,
+                amount_sats,
+                addresses,
+            } => {
+                assert_eq!(wid, hex::encode([0xabu8; 32]));
+                assert_eq!(status, "mempool");
+                assert_eq!(account_index, 2);
+                assert_eq!(txid_str, Txid::all_zeros().to_string());
+                assert_eq!(amount_sats, 500_000);
+                assert!(addresses.is_empty());
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    /// `convert_wallet_event` maps `TransactionStatusChanged` correctly.
+    #[test]
+    fn test_convert_wallet_event_transaction_status_changed() {
+        use dashcore::hashes::Hash;
+        use dashcore::Txid;
+        use key_wallet::transaction_checking::TransactionContext;
+        use key_wallet_manager::WalletEvent as I;
+
+        let txid = Txid::all_zeros();
+        let event = I::TransactionStatusChanged {
+            txid,
+            status: TransactionContext::InstantSend,
+        };
+
+        let bridge = convert_wallet_event(event);
+        match bridge {
+            WalletEvent::TransactionStatusChanged {
+                txid: txid_str,
+                status,
+            } => {
+                assert_eq!(txid_str, Txid::all_zeros().to_string());
+                assert_eq!(status, "instant send");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    /// `convert_wallet_event` maps `BalanceUpdated` correctly.
+    #[test]
+    fn test_convert_wallet_event_balance_updated() {
+        use key_wallet_manager::WalletEvent as I;
+
+        let wallet_id = [0x01u8; 32];
+        let event = I::BalanceUpdated {
+            wallet_id,
+            spendable: 1_000_000,
+            unconfirmed: 250_000,
+            immature: 50_000,
+            locked: 10_000,
+        };
+
+        let bridge = convert_wallet_event(event);
+        match bridge {
+            WalletEvent::BalanceUpdated {
+                wallet_id: wid,
+                spendable_sats,
+                unconfirmed_sats,
+                immature_sats,
+                locked_sats,
+            } => {
+                assert_eq!(wid, hex::encode([0x01u8; 32]));
+                assert_eq!(spendable_sats, 1_000_000);
+                assert_eq!(unconfirmed_sats, 250_000);
+                assert_eq!(immature_sats, 50_000);
+                assert_eq!(locked_sats, 10_000);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
     }
 
     // ---- send_transaction error-path tests ----

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -558,6 +558,45 @@ pub struct TransactionInfo {
     pub is_incoming: bool,
 }
 
+// ============ Mempool record types ============
+
+/// UniFFI-compatible record for a single unconfirmed (mempool) transaction.
+///
+/// Maps from [`crate::types::UnconfirmedTransaction`].  The `Instant`-based
+/// `first_seen` field is converted to "seconds ago" at mapping time so that
+/// it is safe to cross the FFI boundary.
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct MempoolTransactionInfo {
+    /// Transaction ID as a hex string.
+    pub txid: String,
+    /// Fee paid by the transaction, in duffs (satoshis).
+    pub fee_sats: u64,
+    /// Serialised size of the transaction in bytes.
+    pub size: u32,
+    /// `true` if this transaction was locked via InstantSend.
+    pub is_instant_send: bool,
+    /// `true` if this transaction was sent from our wallet.
+    pub is_outgoing: bool,
+    /// Addresses involved in the transaction (Base58Check encoded).
+    pub addresses: Vec<String>,
+    /// Net amount change for our wallet in duffs — positive for incoming,
+    /// negative for outgoing.
+    pub net_amount_sats: i64,
+    /// Seconds elapsed since the transaction was first seen in the mempool.
+    pub first_seen_secs_ago: u64,
+}
+
+/// UniFFI-compatible aggregate pending-balance record from the mempool.
+///
+/// All amounts are in duffs (1 DASH = 100,000,000 duffs).
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct MempoolBalanceInfo {
+    /// Pending balance from regular (non-InstantSend) mempool transactions, in duffs.
+    pub pending_sats: u64,
+    /// Pending balance from InstantSend-locked mempool transactions, in duffs.
+    pub pending_instant_sats: u64,
+}
+
 // ============ Concrete type alias ============
 
 type ConcreteClient =
@@ -1091,6 +1130,54 @@ impl SpvClient {
         }
 
         vec![]
+    }
+}
+
+// ============ Mempool methods ============
+
+/// Maps an [`crate::types::UnconfirmedTransaction`] to the UniFFI-compatible
+/// [`MempoolTransactionInfo`] record.
+fn unconfirmed_tx_to_info(tx: &crate::types::UnconfirmedTransaction) -> MempoolTransactionInfo {
+    let first_seen_secs_ago = tokio::time::Instant::now().duration_since(tx.first_seen).as_secs();
+    MempoolTransactionInfo {
+        txid: tx.txid().to_string(),
+        fee_sats: tx.fee.to_sat(),
+        size: tx.size as u32,
+        is_instant_send: tx.is_instant_send,
+        is_outgoing: tx.is_outgoing,
+        addresses: tx.addresses.iter().map(|a| a.to_string()).collect(),
+        net_amount_sats: tx.net_amount,
+        first_seen_secs_ago,
+    }
+}
+
+#[uniffi::export]
+impl SpvClient {
+    /// Returns all transactions currently tracked in the mempool.
+    ///
+    /// Maps each [`crate::types::UnconfirmedTransaction`] to a
+    /// [`MempoolTransactionInfo`] record.  Returns an empty `Vec` when the
+    /// mempool is empty.
+    pub async fn get_mempool_transactions(&self) -> Vec<MempoolTransactionInfo> {
+        self.inner.get_all_mempool_transactions().await.iter().map(unconfirmed_tx_to_info).collect()
+    }
+
+    /// Returns the number of transactions currently tracked in the mempool.
+    pub async fn get_mempool_transaction_count(&self) -> u32 {
+        self.inner.get_mempool_transaction_count().await as u32
+    }
+
+    /// Returns the aggregate pending balance from the mempool.
+    ///
+    /// Reads `pending_balance` and `pending_instant_balance` directly from
+    /// the shared [`crate::types::MempoolState`].  Negative balances are
+    /// clamped to zero.
+    pub async fn get_mempool_balance(&self) -> MempoolBalanceInfo {
+        let balance = self.inner.get_aggregate_mempool_balance().await;
+        MempoolBalanceInfo {
+            pending_sats: balance.pending.to_sat(),
+            pending_instant_sats: balance.pending_instant.to_sat(),
+        }
     }
 }
 
@@ -3497,5 +3584,104 @@ mod tests {
             matches!(err, SpvClientError::Wallet { .. }),
             "expected Wallet error when restoring duplicate wallet, got: {err:?}"
         );
+    }
+
+    // ============ MempoolTransactionInfo / MempoolBalanceInfo tests ============
+
+    /// `unconfirmed_tx_to_info` maps all fields correctly.
+    #[test]
+    fn test_unconfirmed_tx_to_info_fields() {
+        use crate::types::UnconfirmedTransaction;
+        use dashcore::{Amount, Network, PublicKey};
+
+        // Build a minimal transaction for testing.
+        let tx = dashcore::Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+
+        // Construct a valid P2PKH address from a well-known compressed public key.
+        let pubkey = PublicKey::from_slice(&[
+            0x02, 0x79, 0xBE, 0x66, 0x7E, 0xF9, 0xDC, 0xBB, 0xAC, 0x55, 0xA0, 0x62, 0x95, 0xCE,
+            0x87, 0x0B, 0x07, 0x02, 0x9B, 0xFC, 0xDB, 0x2D, 0xCE, 0x28, 0xD9, 0x59, 0xF2, 0x81,
+            0x5B, 0x16, 0xF8, 0x17, 0x98,
+        ])
+        .expect("valid compressed pubkey");
+        let address = dashcore::Address::p2pkh(&pubkey, Network::Testnet);
+
+        let unconfirmed = UnconfirmedTransaction::new(
+            tx,
+            Amount::from_sat(500),
+            true,
+            false,
+            vec![address],
+            1_000,
+        );
+
+        let info = unconfirmed_tx_to_info(&unconfirmed);
+
+        assert_eq!(info.fee_sats, 500);
+        assert!(info.is_instant_send);
+        assert!(!info.is_outgoing);
+        assert_eq!(info.net_amount_sats, 1_000);
+        assert_eq!(info.addresses.len(), 1);
+        // first_seen_secs_ago should be very small (just created)
+        assert!(info.first_seen_secs_ago < 5, "first_seen_secs_ago should be near zero");
+    }
+
+    /// `MempoolBalanceInfo` fields are populated correctly.
+    #[test]
+    fn test_mempool_balance_info_fields() {
+        let info = MempoolBalanceInfo {
+            pending_sats: 1_000_000,
+            pending_instant_sats: 500_000,
+        };
+        assert_eq!(info.pending_sats, 1_000_000);
+        assert_eq!(info.pending_instant_sats, 500_000);
+    }
+
+    /// `get_mempool_transactions` returns an empty vec on a freshly constructed client.
+    #[tokio::test]
+    async fn test_get_mempool_transactions_empty() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let txs = client.get_mempool_transactions().await;
+        assert!(txs.is_empty(), "mempool should be empty on fresh client");
+    }
+
+    /// `get_mempool_transaction_count` returns 0 on a freshly constructed client.
+    #[tokio::test]
+    async fn test_get_mempool_transaction_count_zero() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert_eq!(client.get_mempool_transaction_count().await, 0);
+    }
+
+    /// `get_mempool_balance` returns zeros on a freshly constructed client.
+    #[tokio::test]
+    async fn test_get_mempool_balance_zero() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let balance = client.get_mempool_balance().await;
+        assert_eq!(balance.pending_sats, 0);
+        assert_eq!(balance.pending_instant_sats, 0);
     }
 }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -11,6 +11,8 @@ use std::sync::Arc;
 
 use dashcore::sml::llmq_entry_verification::LLMQEntryVerificationStatus;
 use dashcore::Network;
+use key_wallet::mnemonic::{Language, Mnemonic};
+use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::wallet::managed_wallet_info::{ManagedWalletInfo, TransactionRecord};
 use key_wallet_manager::wallet_manager::WalletManager;
@@ -388,6 +390,10 @@ pub enum SpvClientError {
     General {
         message: String,
     },
+    #[error("Wallet error: {message}")]
+    Wallet {
+        message: String,
+    },
 }
 
 impl From<SpvError> for SpvClientError {
@@ -439,6 +445,21 @@ pub struct FeeEstimate {
     pub fee_rate: String,
     /// Estimated transaction size in bytes.
     pub estimated_size: u32,
+}
+
+// ============ Wallet creation result ============
+
+/// Result of wallet creation, containing the generated mnemonic and wallet ID.
+///
+/// Returned by [`SpvClient::create_wallet`].  The `mnemonic` field should be
+/// presented to the user for secure backup; the `wallet_id` is a hex-encoded
+/// 32-byte identifier derived from the wallet's root public key.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct WalletCreationResult {
+    /// BIP39 mnemonic phrase (12 or 24 space-separated words).
+    pub mnemonic: String,
+    /// Hex-encoded 32-byte wallet identifier.
+    pub wallet_id: String,
 }
 
 // ============ Wallet record types ============
@@ -1292,6 +1313,93 @@ impl SpvClient {
             estimated_size: ESTIMATED_SIZE,
         }
     }
+}
+
+// ============ Wallet management methods ============
+
+#[uniffi::export]
+impl SpvClient {
+    /// Create a new HD wallet with a freshly generated BIP39 mnemonic.
+    ///
+    /// Generates a new mnemonic of the specified word count, derives a wallet
+    /// from it using the default account creation options, registers it with
+    /// the wallet manager, and returns the mnemonic phrase together with the
+    /// wallet's unique identifier.
+    ///
+    /// # Parameters
+    ///
+    /// * `word_count` – Number of mnemonic words; must be one of `12` or `24`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpvClientError::Wallet`] when:
+    /// * `word_count` is not a supported value (12 or 24).
+    /// * Entropy generation fails (platform RNG unavailable).
+    /// * A wallet with the same root key already exists in the manager.
+    pub async fn create_wallet(
+        &self,
+        word_count: u8,
+    ) -> Result<WalletCreationResult, SpvClientError> {
+        let mnemonic = Mnemonic::generate(word_count as usize, Language::English).map_err(|e| {
+            SpvClientError::Wallet {
+                message: e.to_string(),
+            }
+        })?;
+
+        let phrase = mnemonic.phrase();
+
+        let mut wallet_manager = self.inner.wallet().write().await;
+        let wallet_id = wallet_manager
+            .create_wallet_from_mnemonic(&phrase, "", 0, WalletAccountCreationOptions::Default)
+            .map_err(|e| SpvClientError::Wallet {
+                message: e.to_string(),
+            })?;
+
+        let wallet_id_hex = wallet_id.iter().map(|b| format!("{:02x}", b)).collect::<String>();
+
+        Ok(WalletCreationResult {
+            mnemonic: phrase,
+            wallet_id: wallet_id_hex,
+        })
+    }
+
+    /// Restore a wallet from an existing BIP39 mnemonic phrase.
+    ///
+    /// Parses and validates the mnemonic, derives the wallet using the default
+    /// account creation options, and registers it with the wallet manager.
+    /// This is the inverse of [`SpvClient::create_wallet`] and is used during
+    /// the onboarding flow to recover a previously created wallet.
+    ///
+    /// # Parameters
+    ///
+    /// * `mnemonic` – A space-separated BIP39 mnemonic phrase (12 or 24 words).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpvClientError::Wallet`] when:
+    /// * The mnemonic is not a valid BIP39 phrase.
+    /// * A wallet with the same root key already exists in the manager.
+    pub async fn restore_wallet(&self, mnemonic: String) -> Result<(), SpvClientError> {
+        let mut wallet_manager = self.inner.wallet().write().await;
+        wallet_manager
+            .create_wallet_from_mnemonic(&mnemonic, "", 0, WalletAccountCreationOptions::Default)
+            .map_err(|e| SpvClientError::Wallet {
+                message: e.to_string(),
+            })?;
+
+        Ok(())
+    }
+}
+
+/// Validate a BIP39 mnemonic phrase without creating a wallet.
+///
+/// Returns `true` if `mnemonic` is a well-formed English BIP39 phrase with a
+/// valid checksum, `false` otherwise.  This can be used to provide immediate
+/// feedback to the user during the restore flow before calling
+/// [`SpvClient::restore_wallet`].
+#[uniffi::export]
+pub fn validate_mnemonic(mnemonic: String) -> bool {
+    Mnemonic::validate(&mnemonic, Language::English)
 }
 
 // ============ Stub functions ============
@@ -2931,5 +3039,207 @@ mod tests {
         assert_eq!(low_upper.fee, 226, "LOW should map to 1 duff/byte");
         assert_eq!(medium_mixed.fee, 2260, "Medium should map to 10 duffs/byte");
         assert_eq!(high_upper.fee, 22600, "HIGH should map to 100 duffs/byte");
+    }
+
+    // ---- validate_mnemonic tests ----
+
+    #[test]
+    fn test_validate_mnemonic_valid_12_words() {
+        let valid = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        assert!(validate_mnemonic(valid.to_string()), "valid 12-word mnemonic should return true");
+    }
+
+    #[test]
+    fn test_validate_mnemonic_valid_24_words() {
+        let valid = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+        assert!(validate_mnemonic(valid.to_string()), "valid 24-word mnemonic should return true");
+    }
+
+    #[test]
+    fn test_validate_mnemonic_invalid() {
+        assert!(
+            !validate_mnemonic("not a valid mnemonic phrase at all".to_string()),
+            "invalid phrase should return false"
+        );
+    }
+
+    #[test]
+    fn test_validate_mnemonic_empty() {
+        assert!(!validate_mnemonic(String::new()), "empty string should return false");
+    }
+
+    #[test]
+    fn test_validate_mnemonic_wrong_checksum() {
+        // All 'abandon' words with wrong last word (changes checksum)
+        let bad_checksum =
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon";
+        assert!(
+            !validate_mnemonic(bad_checksum.to_string()),
+            "mnemonic with bad checksum should return false"
+        );
+    }
+
+    // ---- WalletCreationResult record tests ----
+
+    #[test]
+    fn test_wallet_creation_result_fields() {
+        let result = WalletCreationResult {
+            mnemonic: "test mnemonic".to_string(),
+            wallet_id: "abcdef1234567890".to_string(),
+        };
+        assert_eq!(result.mnemonic, "test mnemonic");
+        assert_eq!(result.wallet_id, "abcdef1234567890");
+    }
+
+    // ---- create_wallet tests ----
+
+    /// `create_wallet` with 12 words succeeds and returns valid mnemonic and wallet_id.
+    #[tokio::test]
+    async fn test_create_wallet_12_words() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let result = client.create_wallet(12).await.expect("create_wallet(12) should succeed");
+
+        // Mnemonic should have 12 words
+        assert_eq!(result.mnemonic.split_whitespace().count(), 12, "should have 12 words");
+        // wallet_id should be a 64-char hex string (32 bytes)
+        assert_eq!(result.wallet_id.len(), 64, "wallet_id should be 64 hex chars");
+        // The mnemonic should be valid
+        assert!(validate_mnemonic(result.mnemonic), "generated mnemonic must be valid");
+    }
+
+    /// `create_wallet` with 24 words succeeds and returns valid mnemonic and wallet_id.
+    #[tokio::test]
+    async fn test_create_wallet_24_words() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let result = client.create_wallet(24).await.expect("create_wallet(24) should succeed");
+
+        assert_eq!(result.mnemonic.split_whitespace().count(), 24, "should have 24 words");
+        assert_eq!(result.wallet_id.len(), 64, "wallet_id should be 64 hex chars");
+        assert!(validate_mnemonic(result.mnemonic), "generated mnemonic must be valid");
+    }
+
+    /// `create_wallet` with an invalid word count returns a `Wallet` error.
+    #[tokio::test]
+    async fn test_create_wallet_invalid_word_count() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let err = client
+            .create_wallet(13)
+            .await
+            .expect_err("create_wallet(13) should fail with unsupported word count");
+
+        assert!(
+            matches!(err, SpvClientError::Wallet { .. }),
+            "expected Wallet error for invalid word count, got: {err:?}"
+        );
+    }
+
+    // ---- restore_wallet tests ----
+
+    /// `restore_wallet` with a valid mnemonic succeeds.
+    #[tokio::test]
+    async fn test_restore_wallet_valid_mnemonic() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        client
+            .restore_wallet(mnemonic.to_string())
+            .await
+            .expect("restore_wallet with valid mnemonic should succeed");
+    }
+
+    /// `restore_wallet` with an invalid mnemonic returns a `Wallet` error.
+    #[tokio::test]
+    async fn test_restore_wallet_invalid_mnemonic() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let err = client
+            .restore_wallet("not a valid mnemonic".to_string())
+            .await
+            .expect_err("restore_wallet with invalid mnemonic should fail");
+
+        assert!(
+            matches!(err, SpvClientError::Wallet { .. }),
+            "expected Wallet error for invalid mnemonic, got: {err:?}"
+        );
+    }
+
+    /// `restore_wallet` called twice with the same mnemonic returns a `Wallet` error
+    /// (wallet already exists).
+    #[tokio::test]
+    async fn test_restore_wallet_duplicate_returns_error() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+        client.restore_wallet(mnemonic.to_string()).await.expect("first restore should succeed");
+
+        let err = client
+            .restore_wallet(mnemonic.to_string())
+            .await
+            .expect_err("second restore with same mnemonic should fail");
+
+        assert!(
+            matches!(err, SpvClientError::Wallet { .. }),
+            "expected Wallet error for duplicate wallet, got: {err:?}"
+        );
+    }
+
+    /// `create_wallet` followed by `restore_wallet` with its mnemonic returns a `Wallet`
+    /// error (wallet already exists).
+    #[tokio::test]
+    async fn test_create_then_restore_same_wallet_fails() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+
+        let result = client.create_wallet(12).await.expect("create_wallet should succeed");
+        let mnemonic = result.mnemonic.clone();
+
+        let err = client
+            .restore_wallet(mnemonic)
+            .await
+            .expect_err("restoring an already-created wallet should fail");
+
+        assert!(
+            matches!(err, SpvClientError::Wallet { .. }),
+            "expected Wallet error when restoring duplicate wallet, got: {err:?}"
+        );
     }
 }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -1,0 +1,78 @@
+//! Minimal UniFFI bridge module for dash-spv.
+//!
+//! This module validates three UniFFI call patterns:
+//! - Sync function
+//! - Async function
+//! - Callback interface
+//!
+//! Compiled only when the `uniffi` feature is enabled.
+
+use std::sync::Arc;
+
+/// A simple sync function that returns a greeting string.
+#[uniffi::export]
+pub fn hello() -> String {
+    "Hello from dash-spv!".to_string()
+}
+
+/// An async function that returns the library version.
+#[uniffi::export]
+pub async fn get_version() -> String {
+    crate::VERSION.to_string()
+}
+
+/// Callback interface for receiving SPV sync progress events.
+#[uniffi::export(with_foreign)]
+pub trait SpvEventListener: Send + Sync {
+    /// Called when sync progress changes.
+    fn on_sync_progress(&self, percentage: f64);
+}
+
+/// Starts a mock sync that reports progress via the listener callback.
+///
+/// Invokes `on_sync_progress` with 0.0 and 100.0 to simulate start and completion.
+#[uniffi::export]
+pub async fn start_mock_sync(listener: Arc<dyn SpvEventListener>) {
+    listener.on_sync_progress(0.0);
+    // Simulate minimal async work
+    tokio::task::yield_now().await;
+    listener.on_sync_progress(100.0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn test_hello() {
+        assert_eq!(hello(), "Hello from dash-spv!");
+    }
+
+    #[tokio::test]
+    async fn test_get_version() {
+        let version = get_version().await;
+        assert!(!version.is_empty(), "version should not be empty");
+        assert_eq!(version, crate::VERSION);
+    }
+
+    struct MockListener {
+        events: Mutex<Vec<f64>>,
+    }
+
+    impl SpvEventListener for MockListener {
+        fn on_sync_progress(&self, percentage: f64) {
+            self.events.lock().unwrap().push(percentage);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_start_mock_sync() {
+        let listener = Arc::new(MockListener {
+            events: Mutex::new(Vec::new()),
+        });
+        start_mock_sync(listener.clone()).await;
+        let events = listener.events.lock().unwrap();
+        assert_eq!(*events, vec![0.0, 100.0]);
+    }
+}

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -437,6 +437,23 @@ pub struct WalletBalance {
     pub immature: u64,
 }
 
+/// UniFFI-compatible address information record.
+///
+/// Describes a single HD-wallet address together with its BIP44/DIP9 derivation
+/// path and usage state.  Returned by [`SpvClient::get_addresses`] and used
+/// internally by [`SpvClient::get_receive_address`].
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct AddressInfo {
+    /// The Dash address (Base58Check encoded).
+    pub address: String,
+    /// Full BIP44/DIP9 derivation path, e.g. `"m/44'/5'/0'/0/0"`.
+    pub path: String,
+    /// `true` if this address has already received a transaction.
+    pub used: bool,
+    /// Child index within the address pool.
+    pub index: u32,
+}
+
 /// UniFFI-compatible transaction summary record.
 #[derive(uniffi::Record, Clone, Debug, PartialEq)]
 pub struct TransactionInfo {
@@ -864,6 +881,85 @@ impl SpvClient {
     /// be generated and call-sites can be wired up in advance.
     pub async fn get_transaction_count(&self) -> u32 {
         0
+    }
+}
+
+// ============ Address generation methods ============
+
+#[uniffi::export]
+impl SpvClient {
+    /// Returns the next unused receive address for account 0 of the first loaded wallet.
+    ///
+    /// Scans the external (receive) address pool of the first standard BIP44 account
+    /// (index 0) in the first registered wallet and returns the lowest-indexed address
+    /// that has not yet been used.
+    ///
+    /// Returns an empty string when no wallet has been loaded into the manager yet,
+    /// or when all pre-generated addresses are already used and no key material is
+    /// available to derive more.
+    pub async fn get_receive_address(&self) -> String {
+        let wallet = self.inner.wallet().read().await;
+        let wallet_infos = wallet.get_all_wallet_infos();
+
+        for info in wallet_infos.values() {
+            // Use account 0 from standard BIP44 accounts
+            if let Some(account) = info.accounts.standard_bip44_accounts.get(&0) {
+                if let key_wallet::managed_account::managed_account_type::ManagedAccountType::Standard {
+                    external_addresses,
+                    ..
+                } = &account.account_type
+                {
+                    // Return the first unused address
+                    for addr_info in external_addresses.addresses.values() {
+                        if !addr_info.used {
+                            return addr_info.address.to_string();
+                        }
+                    }
+                }
+            }
+        }
+
+        String::new()
+    }
+
+    /// Returns all known addresses for the given BIP44 account index.
+    ///
+    /// Iterates the external (receive) address pool of the standard BIP44 account
+    /// at `account` in the first registered wallet and maps each entry to an
+    /// [`AddressInfo`] record.
+    ///
+    /// Returns an empty `Vec` when no wallet is loaded, the requested account does
+    /// not exist, or the address pool contains no generated addresses yet.
+    ///
+    /// # Parameters
+    ///
+    /// * `account` – BIP44 account index (0-based).
+    pub async fn get_addresses(&self, account: u32) -> Vec<AddressInfo> {
+        let wallet = self.inner.wallet().read().await;
+        let wallet_infos = wallet.get_all_wallet_infos();
+
+        for info in wallet_infos.values() {
+            if let Some(managed_account) = info.accounts.standard_bip44_accounts.get(&account) {
+                if let key_wallet::managed_account::managed_account_type::ManagedAccountType::Standard {
+                    external_addresses,
+                    ..
+                } = &managed_account.account_type
+                {
+                    return external_addresses
+                        .addresses
+                        .values()
+                        .map(|addr_info| AddressInfo {
+                            address: addr_info.address.to_string(),
+                            path: addr_info.path.to_string(),
+                            used: addr_info.used,
+                            index: addr_info.index,
+                        })
+                        .collect();
+                }
+            }
+        }
+
+        vec![]
     }
 }
 
@@ -1853,6 +1949,92 @@ mod tests {
         assert!(
             matches!(err, SpvClientError::Network { .. }),
             "expected Network error when no peers connected, got: {err:?}"
+        );
+    }
+
+    // ---- AddressInfo record tests ----
+
+    #[test]
+    fn test_address_info_record_fields() {
+        let info = AddressInfo {
+            address: "XqEkVnMDPBcTkGputvMpkSTh27UiKmPDp9".to_string(),
+            path: "m/44'/5'/0'/0/0".to_string(),
+            used: false,
+            index: 0,
+        };
+        assert_eq!(info.address, "XqEkVnMDPBcTkGputvMpkSTh27UiKmPDp9");
+        assert_eq!(info.path, "m/44'/5'/0'/0/0");
+        assert!(!info.used);
+        assert_eq!(info.index, 0);
+    }
+
+    #[test]
+    fn test_address_info_used_flag() {
+        let unused = AddressInfo {
+            address: "Xaddr1".to_string(),
+            path: "m/44'/5'/0'/0/0".to_string(),
+            used: false,
+            index: 0,
+        };
+        let used = AddressInfo {
+            address: "Xaddr2".to_string(),
+            path: "m/44'/5'/0'/0/1".to_string(),
+            used: true,
+            index: 1,
+        };
+        assert!(!unused.used);
+        assert!(used.used);
+        assert_eq!(used.index, 1);
+    }
+
+    /// `get_receive_address` returns an empty string when no wallet is loaded.
+    #[tokio::test]
+    async fn test_get_receive_address_no_wallet() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let address = client.get_receive_address().await;
+        assert!(
+            address.is_empty(),
+            "get_receive_address should return empty string when no wallet is loaded"
+        );
+    }
+
+    /// `get_addresses` returns an empty vec when no wallet is loaded.
+    #[tokio::test]
+    async fn test_get_addresses_no_wallet() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let addresses = client.get_addresses(0).await;
+        assert!(
+            addresses.is_empty(),
+            "get_addresses should return empty vec when no wallet is loaded"
+        );
+    }
+
+    /// `get_addresses` with a non-existent account index returns an empty vec.
+    #[tokio::test]
+    async fn test_get_addresses_nonexistent_account() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let addresses = client.get_addresses(999).await;
+        assert!(
+            addresses.is_empty(),
+            "get_addresses with nonexistent account should return empty vec"
         );
     }
 }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -531,14 +531,18 @@ impl SpvClient {
         matches!(self.inner.sync_progress().await.state(), SyncState::Syncing)
     }
 
-    /// Returns the wallet balance.
+    /// Returns the wallet balance aggregated across all managed wallets.
     ///
-    /// TODO: delegate to `self.inner.wallet()` once wallet integration is complete.
+    /// Reads the wallet state under a shared lock and maps the internal
+    /// `WalletCoreBalance` breakdown to the UniFFI `WalletBalance` record.
+    /// All amounts are in duffs.
     pub async fn get_balance(&self) -> WalletBalance {
+        let wallet = self.inner.wallet().read().await;
+        let balance = wallet.get_aggregated_balance();
         WalletBalance {
-            confirmed: 0,
-            unconfirmed: 0,
-            immature: 0,
+            confirmed: balance.spendable(),
+            unconfirmed: balance.unconfirmed(),
+            immature: balance.immature(),
         }
     }
 
@@ -1093,6 +1097,44 @@ mod tests {
         };
         assert_eq!(
             balance,
+            WalletBalance {
+                confirmed: 0,
+                unconfirmed: 0,
+                immature: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_wallet_balance_mapping_from_wallet_core_balance() {
+        use key_wallet::WalletCoreBalance;
+        // Verify: confirmed=spendable, unconfirmed=unconfirmed, immature=immature.
+        // The `locked` field in WalletCoreBalance is intentionally excluded from
+        // WalletBalance (locked funds are not part of the spendable/pending/immature view).
+        let core = WalletCoreBalance::new(1_000_000, 250_000, 50_000, 999);
+        let mapped = WalletBalance {
+            confirmed: core.spendable(),
+            unconfirmed: core.unconfirmed(),
+            immature: core.immature(),
+        };
+        assert_eq!(mapped.confirmed, 1_000_000);
+        assert_eq!(mapped.unconfirmed, 250_000);
+        assert_eq!(mapped.immature, 50_000);
+    }
+
+    #[test]
+    fn test_get_aggregated_balance_empty_manager() {
+        use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
+        use key_wallet_manager::wallet_manager::WalletManager;
+        let manager = WalletManager::<ManagedWalletInfo>::new(dashcore::Network::Testnet);
+        let balance = manager.get_aggregated_balance();
+        let wallet_balance = WalletBalance {
+            confirmed: balance.spendable(),
+            unconfirmed: balance.unconfirmed(),
+            immature: balance.immature(),
+        };
+        assert_eq!(
+            wallet_balance,
             WalletBalance {
                 confirmed: 0,
                 unconfirmed: 0,

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -14,7 +14,7 @@ use dashcore::Network;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::wallet::managed_wallet_info::{ManagedWalletInfo, TransactionRecord};
 use key_wallet_manager::wallet_manager::WalletManager;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::client::{ClientConfig, DashSpvClient};
 use crate::error::SpvError;
@@ -487,6 +487,8 @@ type ConcreteClient =
 #[derive(uniffi::Object)]
 pub struct SpvClient {
     inner: ConcreteClient,
+    /// Handle to the background event-forwarding task, if a subscription is active.
+    subscription_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 #[uniffi::export]
@@ -510,6 +512,7 @@ impl SpvClient {
 
         Ok(Arc::new(Self {
             inner,
+            subscription_handle: Mutex::new(None),
         }))
     }
 
@@ -1002,6 +1005,225 @@ impl SpvClient {
         }
 
         vec![]
+    }
+}
+
+// ============ Event conversion helpers ============
+
+/// Convert an internal [`crate::sync::SyncEvent`] to the bridge [`SyncEvent`].
+///
+/// Returns `None` for internal events that have no bridge equivalent
+/// (e.g. `MempoolActivated`).
+fn convert_sync_event(event: crate::sync::SyncEvent) -> Option<SyncEvent> {
+    use crate::sync::SyncEvent as I;
+    match event {
+        I::SyncStart {
+            identifier,
+        } => Some(SyncEvent::SyncStart {
+            identifier: identifier.to_string(),
+        }),
+        I::BlockHeadersStored {
+            tip_height,
+        } => Some(SyncEvent::BlockHeadersStored {
+            tip_height,
+        }),
+        I::BlockHeaderSyncComplete {
+            tip_height,
+        } => Some(SyncEvent::BlockHeaderSyncComplete {
+            tip_height,
+        }),
+        I::FilterHeadersStored {
+            start_height,
+            end_height,
+            tip_height,
+        } => Some(SyncEvent::FilterHeadersStored {
+            start_height,
+            end_height,
+            tip_height,
+        }),
+        I::FilterHeadersSyncComplete {
+            tip_height,
+        } => Some(SyncEvent::FilterHeadersSyncComplete {
+            tip_height,
+        }),
+        I::FiltersStored {
+            start_height,
+            end_height,
+        } => Some(SyncEvent::FiltersStored {
+            start_height,
+            end_height,
+        }),
+        I::FiltersSyncComplete {
+            tip_height,
+        } => Some(SyncEvent::FiltersSyncComplete {
+            tip_height,
+        }),
+        I::BlocksNeeded {
+            blocks,
+        } => Some(SyncEvent::BlocksNeeded {
+            block_count: blocks.len() as u32,
+        }),
+        I::BlockProcessed {
+            block_hash,
+            height,
+            new_addresses,
+            ..
+        } => Some(SyncEvent::BlockProcessed {
+            block_hash: block_hash.to_string(),
+            height,
+            new_address_count: new_addresses.len() as u32,
+        }),
+        I::MasternodeStateUpdated {
+            height,
+        } => Some(SyncEvent::MasternodeStateUpdated {
+            height,
+        }),
+        I::ManagerError {
+            manager,
+            error,
+        } => Some(SyncEvent::ManagerError {
+            manager: manager.to_string(),
+            error,
+        }),
+        I::ChainLockReceived {
+            chain_lock,
+            validated,
+        } => Some(SyncEvent::ChainLockReceived {
+            block_height: chain_lock.block_height,
+            validated,
+        }),
+        I::InstantLockReceived {
+            instant_lock,
+            validated,
+        } => Some(SyncEvent::InstantLockReceived {
+            txid: instant_lock.txid.to_string(),
+            validated,
+        }),
+        // MempoolActivated has no bridge equivalent — silently drop it.
+        I::MempoolActivated {
+            ..
+        } => None,
+        I::SyncComplete {
+            header_tip,
+            cycle,
+        } => Some(SyncEvent::SyncComplete {
+            header_tip,
+            cycle,
+        }),
+    }
+}
+
+/// Convert an internal [`crate::network::NetworkEvent`] to the bridge [`NetworkEvent`].
+fn convert_network_event(event: crate::network::NetworkEvent) -> NetworkEvent {
+    use crate::network::NetworkEvent as I;
+    match event {
+        I::PeerConnected {
+            address,
+        } => NetworkEvent::PeerConnected {
+            address: address.to_string(),
+        },
+        I::PeerDisconnected {
+            address,
+        } => NetworkEvent::PeerDisconnected {
+            address: address.to_string(),
+        },
+        I::PeersUpdated {
+            connected_count,
+            addresses,
+            best_height,
+        } => NetworkEvent::PeersUpdated {
+            connected_count: connected_count as u64,
+            addresses: addresses.into_iter().map(|a| a.to_string()).collect(),
+            best_height,
+        },
+    }
+}
+
+// ============ Subscription methods ============
+
+#[uniffi::export]
+impl SpvClient {
+    /// Subscribe to SPV client events via the given listener.
+    ///
+    /// Spawns a single background tokio task that reads from the client's
+    /// internal broadcast channels and forwards sync events, network events,
+    /// and sync-progress updates to `listener`.
+    ///
+    /// Only one subscription is active at a time.  Calling `subscribe` again
+    /// cancels the previous task before starting a new one.
+    pub async fn subscribe(&self, listener: Arc<dyn SpvEventListener>) {
+        // Cancel any existing subscription first.
+        self.unsubscribe().await;
+
+        // Obtain broadcast/watch receivers from the inner client.
+        let mut sync_rx = self.inner.subscribe_sync_events().await;
+        let mut net_rx = self.inner.subscribe_network_events().await;
+        let mut progress_rx = self.inner.subscribe_progress().await;
+
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    result = sync_rx.recv() => {
+                        match result {
+                            Ok(event) => {
+                                if let Some(bridge_event) = convert_sync_event(event) {
+                                    listener.on_sync_event(bridge_event);
+                                }
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                                tracing::warn!(
+                                    skipped = n,
+                                    "SPV event subscriber lagged; some sync events were dropped"
+                                );
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                        }
+                    }
+                    result = net_rx.recv() => {
+                        match result {
+                            Ok(event) => {
+                                listener.on_network_event(convert_network_event(event));
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                                tracing::warn!(
+                                    skipped = n,
+                                    "SPV network-event subscriber lagged; some events were dropped"
+                                );
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                        }
+                    }
+                    result = progress_rx.changed() => {
+                        if result.is_err() {
+                            // Sender dropped — client is shutting down.
+                            break;
+                        }
+                        let (percentage, current_height, target_height) = {
+                            let progress = progress_rx.borrow_and_update();
+                            let pct = progress.percentage();
+                            let (cur, tgt) = progress
+                                .headers()
+                                .map(|h| (h.current_height(), h.target_height()))
+                                .unwrap_or((0, 0));
+                            (pct, cur, tgt)
+                        };
+                        listener.on_sync_progress(percentage, current_height, target_height);
+                    }
+                }
+            }
+        });
+
+        *self.subscription_handle.lock().await = Some(handle);
+    }
+
+    /// Cancel the active event subscription, if any.
+    ///
+    /// Aborts the background task that was spawned by [`subscribe`](Self::subscribe).
+    /// No-op when no subscription is active.
+    pub async fn unsubscribe(&self) {
+        if let Some(handle) = self.subscription_handle.lock().await.take() {
+            handle.abort();
+        }
     }
 }
 
@@ -2034,6 +2256,292 @@ mod tests {
         };
         let cloned = result.clone();
         assert_eq!(result, cloned);
+    }
+
+    // ---- subscribe / unsubscribe tests ----
+
+    /// `subscribe` stores a handle; `unsubscribe` clears it.
+    #[tokio::test]
+    async fn test_subscribe_and_unsubscribe() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+
+        // No subscription handle before subscribing.
+        assert!(
+            client.subscription_handle.lock().await.is_none(),
+            "no subscription handle before subscribe()"
+        );
+
+        let listener = Arc::new(MockListener::new());
+        client.subscribe(listener.clone()).await;
+
+        // A handle should be present after subscribing.
+        assert!(
+            client.subscription_handle.lock().await.is_some(),
+            "subscription handle should exist after subscribe()"
+        );
+
+        client.unsubscribe().await;
+
+        // Handle should be cleared after unsubscribe.
+        assert!(
+            client.subscription_handle.lock().await.is_none(),
+            "subscription handle should be gone after unsubscribe()"
+        );
+    }
+
+    /// Calling `subscribe` twice replaces the first subscription.
+    #[tokio::test]
+    async fn test_subscribe_replaces_previous_subscription() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+
+        let listener1 = Arc::new(MockListener::new());
+        client.subscribe(listener1).await;
+
+        let listener2 = Arc::new(MockListener::new());
+        client.subscribe(listener2).await;
+
+        // Only one handle should exist.
+        assert!(
+            client.subscription_handle.lock().await.is_some(),
+            "exactly one subscription handle should exist after two subscribe() calls"
+        );
+
+        client.unsubscribe().await;
+    }
+
+    /// `unsubscribe` is a no-op when no subscription is active.
+    #[tokio::test]
+    async fn test_unsubscribe_no_op_when_not_subscribed() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+
+        // Should not panic.
+        client.unsubscribe().await;
+        client.unsubscribe().await;
+    }
+
+    // ---- convert_sync_event tests ----
+
+    /// All internal SyncEvent variants produce the expected bridge variant.
+    #[test]
+    fn test_convert_sync_event_all_variants() {
+        use crate::sync::ManagerIdentifier;
+        use crate::sync::SyncEvent as I;
+        use std::collections::BTreeSet;
+
+        // SyncStart
+        let e = convert_sync_event(I::SyncStart {
+            identifier: ManagerIdentifier::BlockHeader,
+        });
+        assert!(
+            matches!(e, Some(SyncEvent::SyncStart { identifier }) if identifier == "BlockHeader")
+        );
+
+        // BlockHeadersStored
+        let e = convert_sync_event(I::BlockHeadersStored {
+            tip_height: 42,
+        });
+        assert!(matches!(
+            e,
+            Some(SyncEvent::BlockHeadersStored {
+                tip_height: 42
+            })
+        ));
+
+        // BlockHeaderSyncComplete
+        let e = convert_sync_event(I::BlockHeaderSyncComplete {
+            tip_height: 100,
+        });
+        assert!(matches!(
+            e,
+            Some(SyncEvent::BlockHeaderSyncComplete {
+                tip_height: 100
+            })
+        ));
+
+        // FilterHeadersStored
+        let e = convert_sync_event(I::FilterHeadersStored {
+            start_height: 0,
+            end_height: 99,
+            tip_height: 100,
+        });
+        assert!(matches!(
+            e,
+            Some(SyncEvent::FilterHeadersStored {
+                start_height: 0,
+                end_height: 99,
+                tip_height: 100
+            })
+        ));
+
+        // FilterHeadersSyncComplete
+        let e = convert_sync_event(I::FilterHeadersSyncComplete {
+            tip_height: 200,
+        });
+        assert!(matches!(
+            e,
+            Some(SyncEvent::FilterHeadersSyncComplete {
+                tip_height: 200
+            })
+        ));
+
+        // FiltersStored
+        let e = convert_sync_event(I::FiltersStored {
+            start_height: 10,
+            end_height: 20,
+        });
+        assert!(matches!(
+            e,
+            Some(SyncEvent::FiltersStored {
+                start_height: 10,
+                end_height: 20
+            })
+        ));
+
+        // FiltersSyncComplete
+        let e = convert_sync_event(I::FiltersSyncComplete {
+            tip_height: 300,
+        });
+        assert!(matches!(
+            e,
+            Some(SyncEvent::FiltersSyncComplete {
+                tip_height: 300
+            })
+        ));
+
+        // BlocksNeeded — 3 items in the set → block_count == 3
+        use dashcore_hashes::Hash as _;
+        use key_wallet_manager::wallet_manager::FilterMatchKey;
+        let mut blocks = BTreeSet::new();
+        blocks.insert(FilterMatchKey::new(100, dashcore::BlockHash::all_zeros()));
+        blocks.insert(FilterMatchKey::new(101, dashcore::BlockHash::all_zeros()));
+        blocks.insert(FilterMatchKey::new(102, dashcore::BlockHash::all_zeros()));
+        let e = convert_sync_event(I::BlocksNeeded {
+            blocks,
+        });
+        assert!(matches!(
+            e,
+            Some(SyncEvent::BlocksNeeded {
+                block_count: 3
+            })
+        ));
+
+        // MasternodeStateUpdated
+        let e = convert_sync_event(I::MasternodeStateUpdated {
+            height: 500,
+        });
+        assert!(matches!(
+            e,
+            Some(SyncEvent::MasternodeStateUpdated {
+                height: 500
+            })
+        ));
+
+        // ManagerError
+        let e = convert_sync_event(I::ManagerError {
+            manager: ManagerIdentifier::Filter,
+            error: "timeout".to_string(),
+        });
+        assert!(matches!(
+            e,
+            Some(SyncEvent::ManagerError { ref manager, ref error })
+            if manager == "Filter" && error == "timeout"
+        ));
+
+        // SyncComplete
+        let e = convert_sync_event(I::SyncComplete {
+            header_tip: 1000,
+            cycle: 1,
+        });
+        assert!(matches!(
+            e,
+            Some(SyncEvent::SyncComplete {
+                header_tip: 1000,
+                cycle: 1
+            })
+        ));
+
+        // MempoolActivated — should return None (no bridge equivalent)
+        let e = convert_sync_event(I::MempoolActivated {
+            peer: "127.0.0.1:9999".parse().unwrap(),
+        });
+        assert!(e.is_none(), "MempoolActivated should map to None");
+    }
+
+    // ---- convert_network_event tests ----
+
+    /// All internal NetworkEvent variants are converted correctly.
+    #[test]
+    fn test_convert_network_event_all_variants() {
+        use crate::network::NetworkEvent as I;
+
+        // PeerConnected
+        let addr: std::net::SocketAddr = "192.0.2.1:9999".parse().unwrap();
+        let e = convert_network_event(I::PeerConnected {
+            address: addr,
+        });
+        assert!(
+            matches!(e, NetworkEvent::PeerConnected { ref address } if address == "192.0.2.1:9999")
+        );
+
+        // PeerDisconnected
+        let addr: std::net::SocketAddr = "10.0.0.1:9999".parse().unwrap();
+        let e = convert_network_event(I::PeerDisconnected {
+            address: addr,
+        });
+        assert!(
+            matches!(e, NetworkEvent::PeerDisconnected { ref address } if address == "10.0.0.1:9999")
+        );
+
+        // PeersUpdated
+        let addrs: Vec<std::net::SocketAddr> =
+            vec!["1.2.3.4:9999".parse().unwrap(), "5.6.7.8:9999".parse().unwrap()];
+        let e = convert_network_event(I::PeersUpdated {
+            connected_count: 2,
+            addresses: addrs,
+            best_height: Some(500),
+        });
+        match e {
+            NetworkEvent::PeersUpdated {
+                connected_count,
+                addresses,
+                best_height,
+            } => {
+                assert_eq!(connected_count, 2);
+                assert_eq!(addresses.len(), 2);
+                assert_eq!(best_height, Some(500));
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+
+        // PeersUpdated with no best_height
+        let e = convert_network_event(I::PeersUpdated {
+            connected_count: 0,
+            addresses: vec![],
+            best_height: None,
+        });
+        assert!(matches!(
+            e,
+            NetworkEvent::PeersUpdated { connected_count: 0, ref addresses, best_height: None }
+            if addresses.is_empty()
+        ));
     }
 
     // ---- send_transaction error-path tests ----

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -11,7 +11,8 @@ use std::sync::Arc;
 
 use dashcore::sml::llmq_entry_verification::LLMQEntryVerificationStatus;
 use dashcore::Network;
-use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
+use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+use key_wallet::wallet::managed_wallet_info::{ManagedWalletInfo, TransactionRecord};
 use key_wallet_manager::wallet_manager::WalletManager;
 use tokio::sync::RwLock;
 
@@ -847,40 +848,81 @@ impl SpvClient {
 
 // ============ Transaction history methods ============
 
+/// Maps a [`TransactionRecord`] to the UniFFI-compatible [`TransactionInfo`] type.
+///
+/// `tip_height` is the current chain tip used to compute the confirmation count.
+fn transaction_record_to_info(record: &TransactionRecord, tip_height: u32) -> TransactionInfo {
+    TransactionInfo {
+        txid: record.txid.to_string(),
+        amount: record.net_amount,
+        fee: record.fee.unwrap_or(0),
+        confirmations: record.confirmations(tip_height),
+        timestamp: record.timestamp,
+        is_incoming: record.net_amount >= 0,
+    }
+}
+
 #[uniffi::export]
 impl SpvClient {
-    /// Returns a paginated list of transactions from the wallet's transaction history.
+    /// Returns a paginated list of transactions from the wallet's transaction history,
+    /// sorted by timestamp descending (newest first).
     ///
-    /// Transaction history sync is not yet implemented in the SPV client, so this
-    /// method always returns an empty `Vec`.  It is exported so foreign-language
-    /// bindings can be generated and call-sites can be wired up in advance.
+    /// Reads transaction records from all managed wallets and applies `offset` / `limit`
+    /// pagination.  When `limit` is `0` all remaining transactions after `offset` are
+    /// returned.
     ///
     /// # Parameters
     ///
-    /// * `limit`  – maximum number of transactions to return.
+    /// * `limit`  – maximum number of transactions to return (0 = unlimited).
     /// * `offset` – number of transactions to skip before returning results.
     pub async fn get_transactions(&self, limit: u32, offset: u32) -> Vec<TransactionInfo> {
-        let _ = (limit, offset);
-        vec![]
+        let tip_height = self.inner.tip_height().await;
+        let wallet = self.inner.wallet().read().await;
+
+        let mut records: Vec<&TransactionRecord> = wallet
+            .get_all_wallet_infos()
+            .values()
+            .flat_map(|info| info.transaction_history())
+            .collect();
+
+        // Newest first.
+        records.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+        let limit_usize = if limit == 0 {
+            usize::MAX
+        } else {
+            limit as usize
+        };
+        records
+            .into_iter()
+            .skip(offset as usize)
+            .take(limit_usize)
+            .map(|record| transaction_record_to_info(record, tip_height))
+            .collect()
     }
 
     /// Looks up a single transaction by its transaction ID.
     ///
-    /// Transaction history sync is not yet implemented in the SPV client, so this
-    /// method always returns `None`.  It is exported so foreign-language bindings
-    /// can be generated and call-sites can be wired up in advance.
+    /// Searches the transaction history of all managed wallets for a record whose
+    /// `txid` matches the provided hex string.  Returns `None` when no match is found.
     pub async fn get_transaction(&self, txid: String) -> Option<TransactionInfo> {
-        let _ = txid;
-        None
+        let tip_height = self.inner.tip_height().await;
+        let wallet = self.inner.wallet().read().await;
+
+        wallet
+            .get_all_wallet_infos()
+            .values()
+            .flat_map(|info| info.transaction_history())
+            .find(|record| record.txid.to_string() == txid)
+            .map(|record| transaction_record_to_info(record, tip_height))
     }
 
-    /// Returns the total number of transactions in the wallet's transaction history.
-    ///
-    /// Transaction history sync is not yet implemented in the SPV client, so this
-    /// method always returns `0`.  It is exported so foreign-language bindings can
-    /// be generated and call-sites can be wired up in advance.
+    /// Returns the total number of transactions across all managed wallets.
     pub async fn get_transaction_count(&self) -> u32 {
-        0
+        let wallet = self.inner.wallet().read().await;
+
+        wallet.get_all_wallet_infos().values().flat_map(|info| info.transaction_history()).count()
+            as u32
     }
 }
 
@@ -1785,9 +1827,9 @@ mod tests {
         );
     }
 
-    // ---- get_transactions / get_transaction / get_transaction_count stub tests ----
+    // ---- get_transactions / get_transaction / get_transaction_count tests ----
 
-    /// `get_transaction_count` always returns 0 (transaction history not yet implemented).
+    /// `get_transaction_count` returns 0 when no wallets are loaded.
     #[tokio::test]
     async fn test_get_transaction_count_returns_zero() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -1797,11 +1839,11 @@ mod tests {
         assert_eq!(
             client.get_transaction_count().await,
             0,
-            "get_transaction_count should return 0 (stub)"
+            "get_transaction_count should return 0 when no wallets are loaded"
         );
     }
 
-    /// `get_transactions` always returns an empty vec (transaction history not yet implemented).
+    /// `get_transactions` returns an empty vec when no wallets are loaded.
     #[tokio::test]
     async fn test_get_transactions_returns_empty() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -1810,11 +1852,11 @@ mod tests {
         let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
         assert!(
             client.get_transactions(10, 0).await.is_empty(),
-            "get_transactions should return empty vec (stub)"
+            "get_transactions should return empty vec when no wallets are loaded"
         );
     }
 
-    /// `get_transactions` with various limit/offset values always returns empty (stub).
+    /// `get_transactions` with various limit/offset values returns empty when no wallets are loaded.
     #[tokio::test]
     async fn test_get_transactions_with_limit_and_offset() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -1825,7 +1867,7 @@ mod tests {
         assert!(client.get_transactions(100, 50).await.is_empty());
     }
 
-    /// `get_transaction` always returns `None` (transaction history not yet implemented).
+    /// `get_transaction` returns `None` for an unknown txid.
     #[tokio::test]
     async fn test_get_transaction_returns_none() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -1834,8 +1876,142 @@ mod tests {
         let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
         assert!(
             client.get_transaction("abcd1234".to_string()).await.is_none(),
-            "get_transaction should return None (stub)"
+            "get_transaction should return None for unknown txid"
         );
+    }
+
+    // ---- get_transactions wiring tests ----
+
+    /// Helper that builds a minimal valid `dashcore::Transaction` with a unique lock_time
+    /// so that each call with a distinct `seed` produces a different txid.
+    fn make_test_tx(seed: u32) -> dashcore::Transaction {
+        dashcore::Transaction {
+            version: 1,
+            lock_time: seed,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        }
+    }
+
+    /// Wires up a wallet with two transaction records and asserts that
+    /// `get_transaction_count`, `get_transactions`, and `get_transaction` all
+    /// return the correct values.
+    #[tokio::test]
+    async fn test_get_transactions_returns_wallet_data() {
+        use key_wallet::wallet::initialization::WalletAccountCreationOptions;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest().without_filters().with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+
+        // Populate the wallet manager with a wallet and two transaction records.
+        {
+            let mut wallet_guard = client.inner.wallet().write().await;
+            let wallet_id = wallet_guard
+                .create_wallet_from_mnemonic(
+                    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+                    "",
+                    0,
+                    WalletAccountCreationOptions::default(),
+                )
+                .expect("wallet creation must succeed");
+
+            let tx1 = make_test_tx(1);
+            let tx2 = make_test_tx(2);
+            let txid1 = tx1.txid();
+            let txid2 = tx2.txid();
+
+            let record1 = TransactionRecord::new(tx1, 1_000_000, 50_000, false);
+            let record2 = TransactionRecord::new(tx2, 2_000_000, -30_000, true);
+
+            let info =
+                wallet_guard.get_wallet_info_mut(&wallet_id).expect("wallet info must exist");
+
+            // Insert records directly into the first available account's transaction map.
+            let account = info
+                .accounts_mut()
+                .all_accounts_mut()
+                .into_iter()
+                .next()
+                .expect("wallet must have at least one account");
+
+            account.transactions.insert(txid1, record1);
+            account.transactions.insert(txid2, record2);
+        }
+
+        // Count
+        assert_eq!(client.get_transaction_count().await, 2);
+
+        // Full list (limit 0 = unlimited)
+        let all = client.get_transactions(0, 0).await;
+        assert_eq!(all.len(), 2);
+
+        // Sorted newest-first: record2 has timestamp 2_000_000
+        assert_eq!(all[0].timestamp, 2_000_000);
+        assert_eq!(all[1].timestamp, 1_000_000);
+
+        // Direction flags
+        assert!(!all[0].is_incoming, "negative net_amount => outgoing");
+        assert!(all[1].is_incoming, "positive net_amount => incoming");
+
+        // Amounts
+        assert_eq!(all[0].amount, -30_000);
+        assert_eq!(all[1].amount, 50_000);
+
+        // Pagination: limit=1, offset=0 returns only the newest
+        let page = client.get_transactions(1, 0).await;
+        assert_eq!(page.len(), 1);
+        assert_eq!(page[0].timestamp, 2_000_000);
+
+        // Pagination: offset=1 skips the newest, returns the older one
+        let page2 = client.get_transactions(10, 1).await;
+        assert_eq!(page2.len(), 1);
+        assert_eq!(page2[0].timestamp, 1_000_000);
+
+        // get_transaction by txid – build txid string from known tx2 (amount -30_000)
+        let outgoing_txid = all[0].txid.clone();
+        let found = client.get_transaction(outgoing_txid.clone()).await;
+        assert!(found.is_some(), "should find transaction by txid");
+        assert_eq!(found.unwrap().amount, -30_000);
+
+        // get_transaction with unknown txid returns None
+        assert!(client
+            .get_transaction(
+                "0000000000000000000000000000000000000000000000000000000000000000".to_string()
+            )
+            .await
+            .is_none());
+    }
+
+    /// `transaction_record_to_info` correctly computes confirmations and maps fields.
+    #[test]
+    fn test_transaction_record_to_info_mapping() {
+        use dashcore::hashes::Hash;
+        use dashcore::BlockHash;
+
+        let tx = make_test_tx(10);
+        let txid = tx.txid();
+        let mut record = TransactionRecord::new(tx, 1_700_000_000, 100_000, false);
+        record.mark_confirmed(500, BlockHash::all_zeros());
+        record.set_fee(226);
+
+        // tip at height 505 → 505 - 500 + 1 = 6 confirmations
+        let info = transaction_record_to_info(&record, 505);
+        assert_eq!(info.txid, txid.to_string());
+        assert_eq!(info.amount, 100_000);
+        assert_eq!(info.fee, 226);
+        assert_eq!(info.confirmations, 6);
+        assert_eq!(info.timestamp, 1_700_000_000);
+        assert!(info.is_incoming);
+
+        // Unconfirmed tx → 0 confirmations
+        let tx2 = make_test_tx(11);
+        let record2 = TransactionRecord::new(tx2, 1_700_000_000, -50_000, true);
+        let info2 = transaction_record_to_info(&record2, 1000);
+        assert_eq!(info2.confirmations, 0);
+        assert!(!info2.is_incoming);
     }
 
     // ---- SendResult record tests ----

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -9,6 +9,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use dashcore::sml::llmq_entry_verification::LLMQEntryVerificationStatus;
 use dashcore::Network;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::wallet_manager::WalletManager;
@@ -674,6 +675,73 @@ impl SpvClient {
                     last_paid_height: 0,
                     registered_height: 0,
                 }
+            })
+            .collect()
+    }
+}
+
+/// UniFFI-compatible record representing a single quorum (LLMQ) entry.
+///
+/// Fields are mapped from the `QualifiedQuorumEntry` and its inner `QuorumEntry`.
+/// All hashes are represented as hex `String` values for cross-language convenience.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct QuorumInfo {
+    /// Quorum hash that identifies this quorum instance.
+    pub quorum_hash: String,
+    /// Quorum type string (e.g. `"1_50/60"`, `"100_Test"`).
+    pub quorum_type: String,
+    /// Number of members (signers slots) in this quorum.
+    pub members_count: u32,
+    /// `true` when the quorum signature has been successfully verified.
+    pub active: bool,
+}
+
+#[uniffi::export]
+impl SpvClient {
+    /// Looks up a single masternode by its ProRegTx hash.
+    ///
+    /// Scans the current masternode list for an entry whose `pro_tx_hash` matches
+    /// the provided string.  Returns `None` when masternodes are disabled, no list
+    /// has been received yet, or no entry with that hash exists.
+    pub async fn get_masternode(&self, pro_tx_hash: String) -> Option<MasternodeInfo> {
+        self.get_masternodes().await.into_iter().find(|mn| mn.pro_tx_hash == pro_tx_hash)
+    }
+
+    /// Returns all quorums from the current masternode list.
+    ///
+    /// Iterates the `quorums` map of the latest masternode list and maps each
+    /// [`dashcore::sml::quorum_entry::qualified_quorum_entry::QualifiedQuorumEntry`]
+    /// to a [`QuorumInfo`] record.  Returns an empty `Vec` when masternodes are
+    /// disabled, no list has been received yet, or no quorums are present.
+    ///
+    /// # Field mapping
+    ///
+    /// | Source field | `QuorumInfo` field |
+    /// |---|---|
+    /// | `quorum_entry.quorum_hash` | `quorum_hash` |
+    /// | `LLMQType` (map key) | `quorum_type` |
+    /// | `quorum_entry.signers.len()` | `members_count` |
+    /// | `verified == Verified` | `active` |
+    pub async fn get_active_quorums(&self) -> Vec<QuorumInfo> {
+        let Some(engine) = self.inner.masternode_engine().await else {
+            return vec![];
+        };
+        let guard = engine.read().await;
+        let Some(list) = guard.latest_masternode_list() else {
+            return vec![];
+        };
+        list.quorums
+            .iter()
+            .flat_map(|(llmq_type, quorums_by_hash)| {
+                quorums_by_hash.values().map(|entry| {
+                    let qe = &entry.quorum_entry;
+                    QuorumInfo {
+                        quorum_hash: qe.quorum_hash.to_string(),
+                        quorum_type: llmq_type.to_string(),
+                        members_count: qe.signers.len() as u32,
+                        active: entry.verified == LLMQEntryVerificationStatus::Verified,
+                    }
+                })
             })
             .collect()
     }
@@ -1383,6 +1451,92 @@ mod tests {
         let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
         assert!(
             client.get_masternodes().await.is_empty(),
+            "should return empty vec when engine has no list yet"
+        );
+    }
+
+    // ---- QuorumInfo record tests ----
+
+    #[test]
+    fn test_quorum_info_fields() {
+        let info = QuorumInfo {
+            quorum_hash: "deadbeef".to_string(),
+            quorum_type: "100_Test".to_string(),
+            members_count: 4,
+            active: true,
+        };
+        assert_eq!(info.quorum_hash, "deadbeef");
+        assert_eq!(info.quorum_type, "100_Test");
+        assert_eq!(info.members_count, 4);
+        assert!(info.active);
+    }
+
+    #[test]
+    fn test_quorum_info_inactive() {
+        let info = QuorumInfo {
+            quorum_hash: "aabbccdd".to_string(),
+            quorum_type: "1_50/60".to_string(),
+            members_count: 50,
+            active: false,
+        };
+        assert!(!info.active);
+        assert_eq!(info.members_count, 50);
+    }
+
+    /// `get_masternode` returns `None` when masternodes are disabled (no engine).
+    #[tokio::test]
+    async fn test_get_masternode_no_engine() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert!(
+            client.get_masternode("abc123".to_string()).await.is_none(),
+            "should return None when engine is None"
+        );
+    }
+
+    /// `get_masternode` returns `None` when masternodes are enabled but no list has been received.
+    #[tokio::test]
+    async fn test_get_masternode_empty_engine() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest().without_filters().with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert!(
+            client.get_masternode("abc123".to_string()).await.is_none(),
+            "should return None when engine has no list yet"
+        );
+    }
+
+    /// `get_active_quorums` returns an empty vec when masternodes are disabled (no engine).
+    #[tokio::test]
+    async fn test_get_active_quorums_no_engine() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert!(
+            client.get_active_quorums().await.is_empty(),
+            "should return empty vec when engine is None"
+        );
+    }
+
+    /// `get_active_quorums` returns an empty vec when masternodes are enabled but no list received.
+    #[tokio::test]
+    async fn test_get_active_quorums_empty_engine() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest().without_filters().with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert!(
+            client.get_active_quorums().await.is_empty(),
             "should return empty vec when engine has no list yet"
         );
     }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -183,6 +183,36 @@ pub enum NetworkEvent {
     },
 }
 
+// ============ Network info types ============
+
+/// UniFFI-compatible record describing a single connected peer.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct PeerInfo {
+    /// Socket address of the peer, e.g. `"192.0.2.1:9999"`.
+    pub address: String,
+    /// User-agent string reported by the peer.
+    pub user_agent: String,
+    /// Best block height reported by the peer.
+    pub best_height: u32,
+    /// Unix timestamp (seconds) of when the peer connected.
+    pub connected_since: u64,
+    /// Services bitmask advertised by the peer.
+    pub services: u64,
+}
+
+/// UniFFI-compatible record describing the current network state.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct NetworkInfo {
+    /// Network name (e.g. `"mainnet"`, `"testnet"`, `"regtest"`).
+    pub network: String,
+    /// Number of currently connected peers.
+    pub peer_count: u32,
+    /// Details for each connected peer.
+    ///
+    /// TODO: populate with real peer data from `PeerNetworkManager`.
+    pub peers: Vec<PeerInfo>,
+}
+
 /// Callback interface for receiving SPV client events on the foreign side.
 ///
 /// Implement this trait in React Native / Swift and register it via
@@ -378,6 +408,38 @@ impl From<SpvError> for SpvClientError {
     }
 }
 
+// ============ Wallet record types ============
+
+/// UniFFI-compatible wallet balance record.
+///
+/// All amounts are in duffs (1 DASH = 100,000,000 duffs).
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct WalletBalance {
+    /// Confirmed spendable balance, in duffs.
+    pub confirmed: u64,
+    /// Unconfirmed (pending) balance, in duffs.
+    pub unconfirmed: u64,
+    /// Immature coinbase balance not yet spendable, in duffs.
+    pub immature: u64,
+}
+
+/// UniFFI-compatible transaction summary record.
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct TransactionInfo {
+    /// Transaction ID as a hex string.
+    pub txid: String,
+    /// Net amount in duffs — positive for incoming, negative for outgoing.
+    pub amount: i64,
+    /// Fee paid in duffs.
+    pub fee: u64,
+    /// Number of confirmations (0 = unconfirmed).
+    pub confirmations: u32,
+    /// Unix timestamp of when the transaction was first seen.
+    pub timestamp: u64,
+    /// `true` if the transaction added funds to this wallet.
+    pub is_incoming: bool,
+}
+
 // ============ Concrete type alias ============
 
 type ConcreteClient =
@@ -467,6 +529,101 @@ impl SpvClient {
     /// Returns `true` when the client is actively downloading and processing blocks.
     pub async fn is_syncing(&self) -> bool {
         matches!(self.inner.sync_progress().await.state(), SyncState::Syncing)
+    }
+
+    /// Returns the wallet balance.
+    ///
+    /// TODO: delegate to `self.inner.wallet()` once wallet integration is complete.
+    pub async fn get_balance(&self) -> WalletBalance {
+        WalletBalance {
+            confirmed: 0,
+            unconfirmed: 0,
+            immature: 0,
+        }
+    }
+
+    /// Returns network and peer information.
+    ///
+    /// Currently returns a stub with the network name, peer count, and an empty
+    /// peer list.  Peer details will be wired up once `PeerNetworkManager`
+    /// exposes per-peer metadata.
+    ///
+    /// TODO: populate `peers` with real data from `PeerNetworkManager`.
+    pub async fn get_network_info(&self) -> NetworkInfo {
+        let network = self.inner.network().await;
+        let peer_count = self.inner.peer_count().await as u32;
+        NetworkInfo {
+            network: network.to_string(),
+            peer_count,
+            peers: vec![], // TODO: populate with real peer data
+        }
+    }
+}
+
+// ============ Masternode and Governance types ============
+
+/// UniFFI-compatible record representing a single masternode entry.
+///
+/// Fields are mapped from `MasternodeListEntry` internals. All hashes and
+/// addresses are represented as `String` values for cross-language convenience.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct MasternodeInfo {
+    /// ProRegTx hash that uniquely identifies this masternode.
+    pub pro_tx_hash: String,
+    /// Service address of the masternode (IP:port).
+    pub address: String,
+    /// Status of the masternode (e.g. "Enabled", "PoSeBanned").
+    pub status: String,
+    /// Proof-of-Service penalty score.
+    pub pose_penalty: u32,
+    /// Height at which this masternode was last paid.
+    pub last_paid_height: u32,
+    /// Block height at which the masternode was registered.
+    pub registered_height: u32,
+}
+
+/// UniFFI-compatible record representing a governance proposal.
+///
+/// These fields are stubs — governance sync is not yet implemented. The type
+/// is exported so foreign-language bindings can be generated in advance.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct GovernanceProposal {
+    /// Hash of the governance proposal object.
+    pub hash: String,
+    /// Human-readable name of the proposal.
+    pub name: String,
+    /// URL linking to the proposal details.
+    pub url: String,
+    /// Dash address that will receive the payment if the proposal passes.
+    pub payment_address: String,
+    /// Requested payment amount in duffs.
+    pub payment_amount: u64,
+    /// Number of "yes" votes cast for this proposal.
+    pub yes_count: u32,
+    /// Number of "no" votes cast against this proposal.
+    pub no_count: u32,
+    /// Number of "abstain" votes cast for this proposal.
+    pub abstain_count: u32,
+}
+
+#[uniffi::export]
+impl SpvClient {
+    /// Returns the number of masternodes in the current masternode list.
+    ///
+    /// TODO: wire up to `MasternodeListEngine` once the engine is accessible
+    /// from `DashSpvClient`.
+    pub async fn get_masternode_count(&self) -> u32 {
+        // TODO: return self.inner.masternode_list_engine()?.read().await.count()
+        0
+    }
+
+    /// Returns all masternodes from the current masternode list.
+    ///
+    /// TODO: wire up to `MasternodeListEngine` once the engine is accessible
+    /// from `DashSpvClient`.
+    pub async fn get_masternodes(&self) -> Vec<MasternodeInfo> {
+        // TODO: map MasternodeListEntry fields to MasternodeInfo
+        vec![]
     }
 }
 
@@ -869,5 +1026,239 @@ mod tests {
             "overall_percentage out of range: {}",
             info.overall_percentage
         );
+    }
+
+    // ---- WalletBalance record tests ----
+
+    #[test]
+    fn test_wallet_balance_fields() {
+        let balance = WalletBalance {
+            confirmed: 100_000_000,
+            unconfirmed: 50_000,
+            immature: 0,
+        };
+        assert_eq!(balance.confirmed, 100_000_000);
+        assert_eq!(balance.unconfirmed, 50_000);
+        assert_eq!(balance.immature, 0);
+    }
+
+    #[test]
+    fn test_wallet_balance_zero() {
+        let balance = WalletBalance {
+            confirmed: 0,
+            unconfirmed: 0,
+            immature: 0,
+        };
+        assert_eq!(
+            balance,
+            WalletBalance {
+                confirmed: 0,
+                unconfirmed: 0,
+                immature: 0
+            }
+        );
+    }
+
+    // ---- TransactionInfo record tests ----
+
+    #[test]
+    fn test_transaction_info_incoming() {
+        let tx = TransactionInfo {
+            txid: "abcd1234".to_string(),
+            amount: 500_000_000,
+            fee: 1_000,
+            confirmations: 6,
+            timestamp: 1_700_000_000,
+            is_incoming: true,
+        };
+        assert_eq!(tx.txid, "abcd1234");
+        assert_eq!(tx.amount, 500_000_000);
+        assert_eq!(tx.fee, 1_000);
+        assert_eq!(tx.confirmations, 6);
+        assert_eq!(tx.timestamp, 1_700_000_000);
+        assert!(tx.is_incoming);
+    }
+
+    #[test]
+    fn test_transaction_info_outgoing() {
+        let tx = TransactionInfo {
+            txid: "deadbeef".to_string(),
+            amount: -200_000_000,
+            fee: 2_000,
+            confirmations: 0,
+            timestamp: 1_700_001_000,
+            is_incoming: false,
+        };
+        assert!(tx.amount < 0);
+        assert!(!tx.is_incoming);
+        assert_eq!(tx.confirmations, 0);
+    }
+
+    // ---- SpvClient::get_balance stub test ----
+
+    #[tokio::test]
+    async fn test_get_balance_stub() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let balance = client.get_balance().await;
+        assert_eq!(
+            balance,
+            WalletBalance {
+                confirmed: 0,
+                unconfirmed: 0,
+                immature: 0
+            },
+            "stub get_balance should return all-zero balance"
+        );
+    }
+
+    // ---- PeerInfo / NetworkInfo record tests ----
+
+    #[test]
+    fn test_peer_info_record() {
+        let peer = PeerInfo {
+            address: "192.0.2.1:9999".to_string(),
+            user_agent: "/DashCore:0.18.0/".to_string(),
+            best_height: 1234,
+            connected_since: 1_700_000_000,
+            services: 0x40d,
+        };
+        assert_eq!(peer.address, "192.0.2.1:9999");
+        assert_eq!(peer.user_agent, "/DashCore:0.18.0/");
+        assert_eq!(peer.best_height, 1234);
+        assert_eq!(peer.connected_since, 1_700_000_000);
+        assert_eq!(peer.services, 0x40d);
+    }
+
+    #[test]
+    fn test_network_info_record_empty_peers() {
+        let info = NetworkInfo {
+            network: "mainnet".to_string(),
+            peer_count: 0,
+            peers: vec![],
+        };
+        assert_eq!(info.network, "mainnet");
+        assert_eq!(info.peer_count, 0);
+        assert!(info.peers.is_empty());
+    }
+
+    #[test]
+    fn test_network_info_record_with_peers() {
+        let peers = vec![
+            PeerInfo {
+                address: "10.0.0.1:9999".to_string(),
+                user_agent: "/DashCore:0.19.0/".to_string(),
+                best_height: 500,
+                connected_since: 1_600_000_000,
+                services: 1,
+            },
+            PeerInfo {
+                address: "10.0.0.2:9999".to_string(),
+                user_agent: "/DashCore:0.20.0/".to_string(),
+                best_height: 501,
+                connected_since: 1_600_000_001,
+                services: 5,
+            },
+        ];
+        let info = NetworkInfo {
+            network: "testnet".to_string(),
+            peer_count: 2,
+            peers: peers.clone(),
+        };
+        assert_eq!(info.network, "testnet");
+        assert_eq!(info.peer_count, 2);
+        assert_eq!(info.peers.len(), 2);
+        assert_eq!(info.peers[0].address, "10.0.0.1:9999");
+        assert_eq!(info.peers[1].best_height, 501);
+    }
+
+    /// Verify that `get_network_info` returns a stub with the correct network
+    /// name and zero peers before the client is started.
+    #[tokio::test]
+    async fn test_get_network_info_stub() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let info = client.get_network_info().await;
+
+        assert_eq!(info.network, "regtest", "network name should be 'regtest'");
+        assert_eq!(info.peer_count, 0, "peer count should be 0 before start");
+        assert!(info.peers.is_empty(), "peers should be empty in stub implementation");
+    }
+
+    // ---- MasternodeInfo / GovernanceProposal record tests ----
+
+    #[test]
+    fn test_masternode_info_fields() {
+        let info = MasternodeInfo {
+            pro_tx_hash: "abcd1234".to_string(),
+            address: "1.2.3.4:9999".to_string(),
+            status: "Enabled".to_string(),
+            pose_penalty: 0,
+            last_paid_height: 500,
+            registered_height: 100,
+        };
+        assert_eq!(info.pro_tx_hash, "abcd1234");
+        assert_eq!(info.address, "1.2.3.4:9999");
+        assert_eq!(info.status, "Enabled");
+        assert_eq!(info.pose_penalty, 0);
+        assert_eq!(info.last_paid_height, 500);
+        assert_eq!(info.registered_height, 100);
+    }
+
+    #[test]
+    fn test_governance_proposal_fields() {
+        let proposal = GovernanceProposal {
+            hash: "deadbeef".to_string(),
+            name: "Test Proposal".to_string(),
+            url: "https://example.com".to_string(),
+            payment_address: "XtestAddr".to_string(),
+            payment_amount: 100_000_000,
+            yes_count: 10,
+            no_count: 2,
+            abstain_count: 1,
+        };
+        assert_eq!(proposal.hash, "deadbeef");
+        assert_eq!(proposal.name, "Test Proposal");
+        assert_eq!(proposal.url, "https://example.com");
+        assert_eq!(proposal.payment_address, "XtestAddr");
+        assert_eq!(proposal.payment_amount, 100_000_000);
+        assert_eq!(proposal.yes_count, 10);
+        assert_eq!(proposal.no_count, 2);
+        assert_eq!(proposal.abstain_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_masternode_count_stub() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert_eq!(client.get_masternode_count().await, 0, "stub should return 0");
+    }
+
+    #[tokio::test]
+    async fn test_get_masternodes_stub() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let masternodes = client.get_masternodes().await;
+        assert!(masternodes.is_empty(), "stub should return empty vec");
     }
 }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -1,13 +1,9 @@
-//! Minimal UniFFI bridge module for dash-spv.
+//! UniFFI bridge module for dash-spv.
 //!
-//! This module validates three UniFFI call patterns:
-//! - Sync function
-//! - Async function
-//! - Callback interface
+//! Provides callback traits and UniFFI-compatible event record types for
+//! bridging the SPV client to foreign (e.g. React Native / Swift) code.
 //!
 //! Compiled only when the `uniffi` feature is enabled.
-
-use std::sync::Arc;
 
 use dashcore::Network;
 
@@ -17,40 +13,188 @@ uniffi::custom_type!(Network, String, {
     try_lift: |s| s.parse().map_err(|e: String| uniffi::deps::anyhow::anyhow!(e)),
 });
 
-/// A simple sync function that returns a greeting string.
+/// UniFFI-compatible representation of a sync event.
+///
+/// This is a flattened version of the internal [`crate::sync::SyncEvent`] that
+/// uses only types expressible across the UniFFI boundary.  Complex fields
+/// (e.g. `BlockHash`, `Address`, `ChainLock`) are represented as `String` or
+/// decomposed into primitive fields.
+#[derive(uniffi::Enum, Clone, Debug)]
+pub enum SyncEvent {
+    /// A sync manager has started a sync operation.
+    SyncStart {
+        /// Display name of the manager that started syncing.
+        identifier: String,
+    },
+
+    /// New block headers have been stored.
+    BlockHeadersStored {
+        /// New chain-tip height after storage.
+        tip_height: u32,
+    },
+
+    /// Block headers have reached the chain tip (initial header sync complete).
+    BlockHeaderSyncComplete {
+        /// Tip height when sync completed.
+        tip_height: u32,
+    },
+
+    /// New compact-filter headers have been stored.
+    FilterHeadersStored {
+        /// Lowest height stored in this batch.
+        start_height: u32,
+        /// Highest height stored in this batch.
+        end_height: u32,
+        /// New tip height after storage.
+        tip_height: u32,
+    },
+
+    /// Filter headers have reached the chain tip.
+    FilterHeadersSyncComplete {
+        /// Tip height when sync completed.
+        tip_height: u32,
+    },
+
+    /// Compact block filters have been stored and are ready for matching.
+    FiltersStored {
+        /// Lowest height stored.
+        start_height: u32,
+        /// Highest height stored.
+        end_height: u32,
+    },
+
+    /// Filter sync has reached the chain tip (all filters processed).
+    FiltersSyncComplete {
+        /// Tip height when sync completed.
+        tip_height: u32,
+    },
+
+    /// Filters matched the wallet; blocks need downloading.
+    BlocksNeeded {
+        /// Number of blocks that need to be downloaded.
+        block_count: u32,
+    },
+
+    /// A block was downloaded and processed through the wallet.
+    BlockProcessed {
+        /// Hex-encoded hash of the processed block.
+        block_hash: String,
+        /// Height of the processed block.
+        height: u32,
+        /// Number of new addresses derived from gap-limit maintenance.
+        new_address_count: u32,
+    },
+
+    /// Masternode state has been updated to a new height.
+    MasternodeStateUpdated {
+        /// New masternode-state height.
+        height: u32,
+    },
+
+    /// A sync manager encountered a recoverable error.
+    ManagerError {
+        /// Display name of the manager that encountered the error.
+        manager: String,
+        /// Human-readable error description.
+        error: String,
+    },
+
+    /// A ChainLock was received and processed.
+    ChainLockReceived {
+        /// Block height covered by this ChainLock.
+        block_height: u32,
+        /// Whether the BLS signature was successfully validated.
+        validated: bool,
+    },
+
+    /// An InstantSend lock was received and processed.
+    InstantLockReceived {
+        /// Hex-encoded transaction ID covered by this InstantLock.
+        txid: String,
+        /// Whether the BLS signature was successfully validated.
+        validated: bool,
+    },
+
+    /// All sync managers have reached the chain tip.
+    SyncComplete {
+        /// Final header tip height.
+        header_tip: u32,
+        /// Sync cycle (0 = initial sync, 1+ = incremental).
+        cycle: u32,
+    },
+}
+
+/// UniFFI-compatible representation of a network event.
+///
+/// This is a flattened version of the internal [`crate::network::NetworkEvent`]
+/// that uses only types expressible across the UniFFI boundary.  `SocketAddr`
+/// values are serialised as `"<ip>:<port>"` strings.
+#[derive(uniffi::Enum, Clone, Debug)]
+pub enum NetworkEvent {
+    /// A peer has connected.
+    PeerConnected {
+        /// Socket address of the connected peer, e.g. `"192.0.2.1:9999"`.
+        address: String,
+    },
+
+    /// A peer has disconnected.
+    PeerDisconnected {
+        /// Socket address of the disconnected peer.
+        address: String,
+    },
+
+    /// Summary of the peer pool emitted after every connect / disconnect.
+    PeersUpdated {
+        /// Number of currently connected peers.
+        connected_count: u64,
+        /// Socket addresses of all connected peers.
+        addresses: Vec<String>,
+        /// Best chain height reported by connected peers, if known.
+        best_height: Option<u32>,
+    },
+}
+
+/// Callback interface for receiving SPV client events on the foreign side.
+///
+/// Implement this trait in React Native / Swift and register it via
+/// `SpvClient::subscribe`.  The SPV client spawns a background tokio task that
+/// reads from its internal broadcast channels and calls these methods.
+///
+/// All methods are called from a background thread; implementations must be
+/// thread-safe (`Send + Sync`).
+#[uniffi::export(with_foreign)]
+pub trait SpvEventListener: Send + Sync {
+    /// Called whenever a sync event occurs (header stored, sync complete, etc.).
+    fn on_sync_event(&self, event: SyncEvent);
+
+    /// Called whenever a network event occurs (peer connected / disconnected).
+    fn on_network_event(&self, event: NetworkEvent);
+
+    /// Called when overall sync progress changes.
+    ///
+    /// * `percentage`     – completion ratio in `[0.0, 1.0]`
+    /// * `current_height` – current chain-tip height
+    /// * `target_height`  – estimated target height (best peer height)
+    fn on_sync_progress(&self, percentage: f64, current_height: u32, target_height: u32);
+}
+
+/// Returns a greeting string (sanity-check export).
 #[uniffi::export]
 pub fn hello() -> String {
     "Hello from dash-spv!".to_string()
 }
 
-/// An async function that returns the library version.
+/// Returns the library version string.
 #[uniffi::export]
 pub async fn get_version() -> String {
     crate::VERSION.to_string()
 }
 
-/// Callback interface for receiving SPV sync progress events.
-#[uniffi::export(with_foreign)]
-pub trait SpvEventListener: Send + Sync {
-    /// Called when sync progress changes.
-    fn on_sync_progress(&self, percentage: f64);
-}
-
-/// Starts a mock sync that reports progress via the listener callback.
-///
-/// Invokes `on_sync_progress` with 0.0 and 100.0 to simulate start and completion.
-#[uniffi::export]
-pub async fn start_mock_sync(listener: Arc<dyn SpvEventListener>) {
-    listener.on_sync_progress(0.0);
-    // Simulate minimal async work
-    tokio::task::yield_now().await;
-    listener.on_sync_progress(100.0);
-}
-
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
-    use std::sync::{Arc, Mutex};
 
     #[test]
     fn test_hello() {
@@ -65,22 +209,155 @@ mod tests {
     }
 
     struct MockListener {
-        events: Mutex<Vec<f64>>,
+        sync_events: Mutex<Vec<SyncEvent>>,
+        network_events: Mutex<Vec<NetworkEvent>>,
+        progress_events: Mutex<Vec<(f64, u32, u32)>>,
     }
 
-    impl SpvEventListener for MockListener {
-        fn on_sync_progress(&self, percentage: f64) {
-            self.events.lock().unwrap().push(percentage);
+    impl MockListener {
+        fn new() -> Self {
+            Self {
+                sync_events: Mutex::new(Vec::new()),
+                network_events: Mutex::new(Vec::new()),
+                progress_events: Mutex::new(Vec::new()),
+            }
         }
     }
 
-    #[tokio::test]
-    async fn test_start_mock_sync() {
-        let listener = Arc::new(MockListener {
-            events: Mutex::new(Vec::new()),
+    impl SpvEventListener for MockListener {
+        fn on_sync_event(&self, event: SyncEvent) {
+            self.sync_events.lock().unwrap().push(event);
+        }
+
+        fn on_network_event(&self, event: NetworkEvent) {
+            self.network_events.lock().unwrap().push(event);
+        }
+
+        fn on_sync_progress(&self, percentage: f64, current_height: u32, target_height: u32) {
+            self.progress_events.lock().unwrap().push((percentage, current_height, target_height));
+        }
+    }
+
+    #[test]
+    fn test_listener_receives_sync_event() {
+        let listener = MockListener::new();
+        listener.on_sync_event(SyncEvent::SyncComplete {
+            header_tip: 100,
+            cycle: 0,
         });
-        start_mock_sync(listener.clone()).await;
-        let events = listener.events.lock().unwrap();
-        assert_eq!(*events, vec![0.0, 100.0]);
+        let events = listener.sync_events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            SyncEvent::SyncComplete {
+                header_tip: 100,
+                cycle: 0
+            }
+        ));
+    }
+
+    #[test]
+    fn test_listener_receives_network_event() {
+        let listener = MockListener::new();
+        listener.on_network_event(NetworkEvent::PeerConnected {
+            address: "127.0.0.1:9999".to_string(),
+        });
+        let events = listener.network_events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], NetworkEvent::PeerConnected { .. }));
+    }
+
+    #[test]
+    fn test_listener_receives_progress() {
+        let listener = MockListener::new();
+        listener.on_sync_progress(0.5, 500, 1000);
+        let events = listener.progress_events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0], (0.5, 500, 1000));
+    }
+
+    #[test]
+    fn test_sync_event_variants() {
+        // Verify all variants can be constructed and cloned.
+        let events: Vec<SyncEvent> = vec![
+            SyncEvent::SyncStart {
+                identifier: "BlockHeader".to_string(),
+            },
+            SyncEvent::BlockHeadersStored {
+                tip_height: 1000,
+            },
+            SyncEvent::BlockHeaderSyncComplete {
+                tip_height: 1000,
+            },
+            SyncEvent::FilterHeadersStored {
+                start_height: 0,
+                end_height: 999,
+                tip_height: 1000,
+            },
+            SyncEvent::FilterHeadersSyncComplete {
+                tip_height: 1000,
+            },
+            SyncEvent::FiltersStored {
+                start_height: 0,
+                end_height: 999,
+            },
+            SyncEvent::FiltersSyncComplete {
+                tip_height: 1000,
+            },
+            SyncEvent::BlocksNeeded {
+                block_count: 5,
+            },
+            SyncEvent::BlockProcessed {
+                block_hash: "deadbeef".to_string(),
+                height: 500,
+                new_address_count: 2,
+            },
+            SyncEvent::MasternodeStateUpdated {
+                height: 1000,
+            },
+            SyncEvent::ManagerError {
+                manager: "Filter".to_string(),
+                error: "timeout".to_string(),
+            },
+            SyncEvent::ChainLockReceived {
+                block_height: 1000,
+                validated: true,
+            },
+            SyncEvent::InstantLockReceived {
+                txid: "abcd1234".to_string(),
+                validated: false,
+            },
+            SyncEvent::SyncComplete {
+                header_tip: 1000,
+                cycle: 0,
+            },
+        ];
+        // Clone succeeds for all variants.
+        let _cloned: Vec<SyncEvent> = events.to_vec();
+        assert_eq!(events.len(), 14);
+    }
+
+    #[test]
+    fn test_network_event_variants() {
+        let events: Vec<NetworkEvent> = vec![
+            NetworkEvent::PeerConnected {
+                address: "127.0.0.1:9999".to_string(),
+            },
+            NetworkEvent::PeerDisconnected {
+                address: "127.0.0.1:9999".to_string(),
+            },
+            NetworkEvent::PeersUpdated {
+                connected_count: 3,
+                addresses: vec!["127.0.0.1:9999".to_string()],
+                best_height: Some(1000),
+            },
+            NetworkEvent::PeersUpdated {
+                connected_count: 0,
+                addresses: vec![],
+                best_height: None,
+            },
+        ];
+        let _cloned: Vec<NetworkEvent> = events.to_vec();
+        assert_eq!(events.len(), 4);
     }
 }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -9,6 +9,14 @@
 
 use std::sync::Arc;
 
+use dashcore::Network;
+
+uniffi::custom_type!(Network, String, {
+    remote,
+    lower: |n| n.to_string(),
+    try_lift: |s| s.parse().map_err(|e: String| uniffi::deps::anyhow::anyhow!(e)),
+});
+
 /// A simple sync function that returns a greeting string.
 #[uniffi::export]
 pub fn hello() -> String {

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -208,8 +208,6 @@ pub struct NetworkInfo {
     /// Number of currently connected peers.
     pub peer_count: u32,
     /// Details for each connected peer.
-    ///
-    /// TODO: populate with real peer data from `PeerNetworkManager`.
     pub peers: Vec<PeerInfo>,
 }
 
@@ -548,18 +546,26 @@ impl SpvClient {
 
     /// Returns network and peer information.
     ///
-    /// Currently returns a stub with the network name, peer count, and an empty
-    /// peer list.  Peer details will be wired up once `PeerNetworkManager`
-    /// exposes per-peer metadata.
-    ///
-    /// TODO: populate `peers` with real data from `PeerNetworkManager`.
+    /// Queries `PeerNetworkManager` for a snapshot of all currently connected
+    /// peers and maps each entry to a [`PeerInfo`] record.
     pub async fn get_network_info(&self) -> NetworkInfo {
         let network = self.inner.network().await;
-        let peer_count = self.inner.peer_count().await as u32;
+        let snapshots = self.inner.peers_snapshot().await;
+        let peer_count = snapshots.len() as u32;
+        let peers = snapshots
+            .into_iter()
+            .map(|s| PeerInfo {
+                address: s.address.to_string(),
+                user_agent: s.user_agent,
+                best_height: s.best_height,
+                connected_since: s.connected_since,
+                services: s.services,
+            })
+            .collect();
         NetworkInfo {
             network: network.to_string(),
             peer_count,
-            peers: vec![], // TODO: populate with real peer data
+            peers,
         }
     }
 }
@@ -1261,10 +1267,10 @@ mod tests {
         assert_eq!(info.peers[1].best_height, 501);
     }
 
-    /// Verify that `get_network_info` returns a stub with the correct network
-    /// name and zero peers before the client is started.
+    /// Verify that `get_network_info` returns the correct network name and an
+    /// empty peer list when the client has not been started (no connections).
     #[tokio::test]
-    async fn test_get_network_info_stub() {
+    async fn test_get_network_info_no_peers_when_not_started() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let config = ClientConfig::regtest()
             .without_filters()
@@ -1276,7 +1282,8 @@ mod tests {
 
         assert_eq!(info.network, "regtest", "network name should be 'regtest'");
         assert_eq!(info.peer_count, 0, "peer count should be 0 before start");
-        assert!(info.peers.is_empty(), "peers should be empty in stub implementation");
+        assert!(info.peers.is_empty(), "peers list should be empty when no peers are connected");
+        assert_eq!(info.peer_count as usize, info.peers.len(), "peer_count must equal peers.len()");
     }
 
     // ---- MasternodeInfo / GovernanceProposal record tests ----

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -423,6 +423,24 @@ pub struct SendResult {
     pub status: String,
 }
 
+// ============ Fee estimation record ============
+
+/// UniFFI-compatible fee estimate record.
+///
+/// Returned by [`SpvClient::estimate_fee`] with a breakdown of the estimated
+/// transaction fee for a given amount and fee-rate level.
+///
+/// All amounts are in duffs (1 DASH = 100,000,000 duffs).
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct FeeEstimate {
+    /// Estimated fee in duffs.
+    pub fee: u64,
+    /// Fee rate level used: `"low"`, `"medium"`, or `"high"`.
+    pub fee_rate: String,
+    /// Estimated transaction size in bytes.
+    pub estimated_size: u32,
+}
+
 // ============ Wallet record types ============
 
 /// UniFFI-compatible wallet balance record.
@@ -1223,6 +1241,55 @@ impl SpvClient {
     pub async fn unsubscribe(&self) {
         if let Some(handle) = self.subscription_handle.lock().await.take() {
             handle.abort();
+        }
+    }
+}
+
+// ============ Fee estimation ============
+
+#[uniffi::export]
+impl SpvClient {
+    /// Estimate the fee for a transaction with the given amount and fee-rate level.
+    ///
+    /// # Fee rate levels
+    ///
+    /// | Level      | Rate (duffs/byte) |
+    /// |------------|-------------------|
+    /// | `"low"`    | 1                 |
+    /// | `"medium"` | 10                |
+    /// | `"high"`   | 100               |
+    ///
+    /// Any unrecognised fee-rate string defaults to the `"medium"` rate.
+    ///
+    /// # Size estimation
+    ///
+    /// A typical P2PKH transaction with one input and two outputs (payment +
+    /// change) is approximately 226 bytes:
+    ///
+    /// ```text
+    /// 1 input  × 148 bytes = 148
+    /// 2 outputs ×  34 bytes =  68
+    /// overhead              =  10
+    /// total                 = 226
+    /// ```
+    ///
+    /// The `amount` parameter is accepted for API compatibility but does not
+    /// affect the size estimate, which always assumes the standard 1-in/2-out
+    /// P2PKH layout.
+    pub fn estimate_fee(&self, _amount: u64, fee_rate: String) -> FeeEstimate {
+        /// Bytes for a standard 1-input 2-output P2PKH transaction.
+        const ESTIMATED_SIZE: u32 = 226;
+
+        let rate: u64 = match fee_rate.to_lowercase().as_str() {
+            "low" => 1,
+            "high" => 100,
+            _ => 10, // "medium" and any unknown level
+        };
+
+        FeeEstimate {
+            fee: u64::from(ESTIMATED_SIZE) * rate,
+            fee_rate,
+            estimated_size: ESTIMATED_SIZE,
         }
     }
 }
@@ -2720,5 +2787,149 @@ mod tests {
             addresses.is_empty(),
             "get_addresses with nonexistent account should return empty vec"
         );
+    }
+
+    // ---- FeeEstimate record tests ----
+
+    #[test]
+    fn test_fee_estimate_fields() {
+        let estimate = FeeEstimate {
+            fee: 226,
+            fee_rate: "low".to_string(),
+            estimated_size: 226,
+        };
+        assert_eq!(estimate.fee, 226);
+        assert_eq!(estimate.fee_rate, "low");
+        assert_eq!(estimate.estimated_size, 226);
+    }
+
+    #[test]
+    fn test_fee_estimate_clone_and_eq() {
+        let estimate = FeeEstimate {
+            fee: 2260,
+            fee_rate: "medium".to_string(),
+            estimated_size: 226,
+        };
+        let cloned = estimate.clone();
+        assert_eq!(estimate, cloned);
+    }
+
+    // ---- SpvClient::estimate_fee tests ----
+
+    #[tokio::test]
+    async fn test_estimate_fee_low_rate() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let estimate = client.estimate_fee(100_000_000, "low".to_string());
+
+        assert_eq!(estimate.estimated_size, 226, "standard P2PKH tx should be 226 bytes");
+        assert_eq!(estimate.fee_rate, "low");
+        assert_eq!(estimate.fee, 226, "low rate: 226 bytes × 1 duff/byte = 226 duffs");
+    }
+
+    #[tokio::test]
+    async fn test_estimate_fee_medium_rate() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let estimate = client.estimate_fee(50_000_000, "medium".to_string());
+
+        assert_eq!(estimate.estimated_size, 226);
+        assert_eq!(estimate.fee_rate, "medium");
+        assert_eq!(estimate.fee, 2260, "medium rate: 226 bytes × 10 duffs/byte = 2260 duffs");
+    }
+
+    #[tokio::test]
+    async fn test_estimate_fee_high_rate() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let estimate = client.estimate_fee(200_000_000, "high".to_string());
+
+        assert_eq!(estimate.estimated_size, 226);
+        assert_eq!(estimate.fee_rate, "high");
+        assert_eq!(estimate.fee, 22600, "high rate: 226 bytes × 100 duffs/byte = 22600 duffs");
+    }
+
+    #[tokio::test]
+    async fn test_estimate_fee_unknown_rate_defaults_to_medium() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let estimate = client.estimate_fee(0, "unknown_rate".to_string());
+
+        assert_eq!(estimate.estimated_size, 226);
+        assert_eq!(estimate.fee_rate, "unknown_rate");
+        assert_eq!(estimate.fee, 2260, "unknown rate should default to medium (10 duffs/byte)");
+    }
+
+    #[tokio::test]
+    async fn test_estimate_fee_amount_does_not_affect_result() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+
+        // Fee estimate should be the same regardless of amount
+        let estimate_small = client.estimate_fee(1_000, "medium".to_string());
+        let estimate_large = client.estimate_fee(100_000_000_000, "medium".to_string());
+
+        assert_eq!(estimate_small.fee, estimate_large.fee);
+        assert_eq!(estimate_small.estimated_size, estimate_large.estimated_size);
+    }
+
+    #[tokio::test]
+    async fn test_estimate_fee_zero_amount() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let estimate = client.estimate_fee(0, "low".to_string());
+
+        // Should still return a valid estimate even for amount=0
+        assert_eq!(estimate.estimated_size, 226);
+        assert_eq!(estimate.fee, 226);
+    }
+
+    #[tokio::test]
+    async fn test_estimate_fee_case_insensitive() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+
+        let low_upper = client.estimate_fee(0, "LOW".to_string());
+        let medium_mixed = client.estimate_fee(0, "Medium".to_string());
+        let high_upper = client.estimate_fee(0, "HIGH".to_string());
+
+        assert_eq!(low_upper.fee, 226, "LOW should map to 1 duff/byte");
+        assert_eq!(medium_mixed.fee, 2260, "Medium should map to 10 duffs/byte");
+        assert_eq!(high_upper.fee, 22600, "HIGH should map to 100 duffs/byte");
     }
 }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -747,6 +747,28 @@ impl SpvClient {
     }
 }
 
+#[uniffi::export]
+impl SpvClient {
+    /// Returns all governance proposals known to the SPV client.
+    ///
+    /// Governance sync is not yet implemented in the SPV client, so this method
+    /// always returns an empty `Vec`.  It is exported so foreign-language
+    /// bindings can be generated and call-sites can be wired up in advance.
+    pub async fn get_governance_proposals(&self) -> Vec<GovernanceProposal> {
+        vec![]
+    }
+
+    /// Looks up a single governance proposal by its hash.
+    ///
+    /// Governance sync is not yet implemented in the SPV client, so this method
+    /// always returns `None`.  It is exported so foreign-language bindings can
+    /// be generated and call-sites can be wired up in advance.
+    pub async fn get_governance_proposal(&self, hash: String) -> Option<GovernanceProposal> {
+        let _ = hash;
+        None
+    }
+}
+
 // ============ Stub functions ============
 
 /// Returns a greeting string (sanity-check export).
@@ -1538,6 +1560,34 @@ mod tests {
         assert!(
             client.get_active_quorums().await.is_empty(),
             "should return empty vec when engine has no list yet"
+        );
+    }
+
+    // ---- get_governance_proposals / get_governance_proposal stub tests ----
+
+    /// `get_governance_proposals` always returns an empty vec (governance not yet implemented).
+    #[tokio::test]
+    async fn test_get_governance_proposals_returns_empty() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest().without_filters().with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert!(
+            client.get_governance_proposals().await.is_empty(),
+            "get_governance_proposals should return empty vec (stub)"
+        );
+    }
+
+    /// `get_governance_proposal` always returns `None` (governance not yet implemented).
+    #[tokio::test]
+    async fn test_get_governance_proposal_returns_none() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest().without_filters().with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert!(
+            client.get_governance_proposal("deadbeef".to_string()).await.is_none(),
+            "get_governance_proposal should return None (stub)"
         );
     }
 }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -18,7 +18,7 @@ use crate::client::{ClientConfig, DashSpvClient};
 use crate::error::SpvError;
 use crate::network::PeerNetworkManager;
 use crate::storage::DiskStorageManager;
-use crate::sync::SyncState;
+use crate::sync::{ProgressPercentage, SyncProgress, SyncState};
 
 // ============ custom_type! mappings ============
 
@@ -207,6 +207,128 @@ pub trait SpvEventListener: Send + Sync {
     fn on_sync_progress(&self, percentage: f64, current_height: u32, target_height: u32);
 }
 
+// ============ Sync progress types ============
+
+/// Per-phase progress snapshot exposed over the UniFFI boundary.
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct PhaseProgress {
+    /// Current block height or item count for this phase.
+    pub current: u32,
+    /// Target block height or item count for this phase.
+    pub target: u32,
+    /// Completion ratio in `[0.0, 1.0]`.
+    pub percentage: f64,
+}
+
+impl PhaseProgress {
+    fn zero() -> Self {
+        Self {
+            current: 0,
+            target: 0,
+            percentage: 0.0,
+        }
+    }
+}
+
+/// Full sync progress snapshot for all phases, exposed over the UniFFI boundary.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct SyncProgressInfo {
+    /// Overall sync state: `"WaitForEvents"`, `"WaitingForConnections"`, `"Syncing"`, `"Synced"`, or `"Error"`.
+    pub state: String,
+    /// Whether all sync phases have completed successfully.
+    pub is_synced: bool,
+    /// Overall completion ratio in `[0.0, 1.0]`.
+    pub overall_percentage: f64,
+    /// Block header synchronization progress.
+    pub headers: PhaseProgress,
+    /// Compact filter-header synchronization progress.
+    pub filter_headers: PhaseProgress,
+    /// Compact filter synchronization progress.
+    pub filters: PhaseProgress,
+    /// Block download and wallet-processing progress.
+    pub blocks: PhaseProgress,
+    /// Masternode list synchronization progress.
+    pub masternodes: PhaseProgress,
+}
+
+impl From<&SyncProgress> for SyncProgressInfo {
+    fn from(p: &SyncProgress) -> Self {
+        let headers = p
+            .headers()
+            .map(|h| PhaseProgress {
+                current: h.current_height(),
+                target: h.target_height(),
+                percentage: h.percentage(),
+            })
+            .unwrap_or_else(|_| PhaseProgress::zero());
+
+        let filter_headers = p
+            .filter_headers()
+            .map(|fh| PhaseProgress {
+                current: fh.current_height(),
+                target: fh.target_height(),
+                percentage: fh.percentage(),
+            })
+            .unwrap_or_else(|_| PhaseProgress::zero());
+
+        let filters = p
+            .filters()
+            .map(|f| PhaseProgress {
+                current: f.current_height(),
+                target: f.target_height(),
+                percentage: f.percentage(),
+            })
+            .unwrap_or_else(|_| PhaseProgress::zero());
+
+        let blocks = p
+            .blocks()
+            .map(|b| {
+                let current = b.processed();
+                let target = b.requested();
+                let percentage = if target > 0 {
+                    (current as f64 / target as f64).min(1.0)
+                } else {
+                    0.0
+                };
+                PhaseProgress {
+                    current,
+                    target,
+                    percentage,
+                }
+            })
+            .unwrap_or_else(|_| PhaseProgress::zero());
+
+        let masternodes = p
+            .masternodes()
+            .map(|m| {
+                let current = m.current_height();
+                let target = m.target_height();
+                let percentage = if target > 0 {
+                    (current as f64 / target as f64).min(1.0)
+                } else {
+                    0.0
+                };
+                PhaseProgress {
+                    current,
+                    target,
+                    percentage,
+                }
+            })
+            .unwrap_or_else(|_| PhaseProgress::zero());
+
+        SyncProgressInfo {
+            state: format!("{:?}", p.state()),
+            is_synced: p.is_synced(),
+            overall_percentage: p.percentage(),
+            headers,
+            filter_headers,
+            filters,
+            blocks,
+            masternodes,
+        }
+    }
+}
+
 // ============ Error type ============
 
 /// Error type for the UniFFI SpvClient wrapper.
@@ -335,6 +457,11 @@ impl SpvClient {
     /// Returns the overall sync completion percentage in the range `[0.0, 1.0]`.
     pub async fn sync_progress(&self) -> f64 {
         self.inner.sync_progress().await.percentage()
+    }
+
+    /// Returns a detailed snapshot of sync progress for all phases.
+    pub async fn get_sync_progress(&self) -> SyncProgressInfo {
+        SyncProgressInfo::from(&self.inner.sync_progress().await)
     }
 
     /// Returns `true` when the client is actively downloading and processing blocks.
@@ -564,5 +691,183 @@ mod tests {
         );
 
         assert!(!client.is_syncing().await, "Client should not be syncing before start()");
+    }
+
+    // ============ PhaseProgress tests ============
+
+    #[test]
+    fn test_phase_progress_zero() {
+        let p = PhaseProgress::zero();
+        assert_eq!(p.current, 0);
+        assert_eq!(p.target, 0);
+        assert_eq!(p.percentage, 0.0);
+    }
+
+    #[test]
+    fn test_phase_progress_fields() {
+        let p = PhaseProgress {
+            current: 500,
+            target: 1000,
+            percentage: 0.5,
+        };
+        assert_eq!(p.current, 500);
+        assert_eq!(p.target, 1000);
+        assert_eq!(p.percentage, 0.5);
+    }
+
+    // ============ SyncProgressInfo mapping tests ============
+
+    #[test]
+    fn test_sync_progress_info_default_sync_progress() {
+        use crate::sync::SyncProgress;
+
+        let progress = SyncProgress::default();
+        let info = SyncProgressInfo::from(&progress);
+
+        assert_eq!(info.state, "WaitForEvents");
+        assert!(!info.is_synced);
+        assert_eq!(info.overall_percentage, 0.0);
+
+        // All phases should be zero when no managers have started.
+        assert_eq!(info.headers, PhaseProgress::zero());
+        assert_eq!(info.filter_headers, PhaseProgress::zero());
+        assert_eq!(info.filters, PhaseProgress::zero());
+        assert_eq!(info.blocks, PhaseProgress::zero());
+        assert_eq!(info.masternodes, PhaseProgress::zero());
+    }
+
+    #[test]
+    fn test_sync_progress_info_state_strings() {
+        use crate::sync::{BlockHeadersProgress, SyncProgress, SyncState};
+
+        // Build a SyncProgress with a headers entry in the Syncing state so the
+        // aggregate state is Syncing.
+        let mut headers = BlockHeadersProgress::default();
+        headers.set_state(SyncState::Syncing);
+        headers.update_target_height(1000);
+        headers.update_tip_height(500);
+
+        let mut progress = SyncProgress::default();
+        progress.update_headers(headers);
+
+        let info = SyncProgressInfo::from(&progress);
+        assert_eq!(info.state, "Syncing");
+        assert!(!info.is_synced);
+    }
+
+    #[test]
+    fn test_sync_progress_info_headers_phase() {
+        use crate::sync::{BlockHeadersProgress, SyncProgress, SyncState};
+
+        let mut headers = BlockHeadersProgress::default();
+        headers.set_state(SyncState::Syncing);
+        headers.update_target_height(1000);
+        headers.update_tip_height(750);
+
+        let mut progress = SyncProgress::default();
+        progress.update_headers(headers);
+
+        let info = SyncProgressInfo::from(&progress);
+        assert_eq!(info.headers.current, 750);
+        assert_eq!(info.headers.target, 1000);
+        assert!(
+            (info.headers.percentage - 0.75).abs() < 1e-9,
+            "expected 0.75, got {}",
+            info.headers.percentage
+        );
+    }
+
+    #[test]
+    fn test_sync_progress_info_blocks_phase() {
+        use crate::sync::{BlocksProgress, SyncProgress};
+
+        let mut blocks = BlocksProgress::default();
+        blocks.add_requested(100);
+        blocks.add_processed(60);
+
+        let mut progress = SyncProgress::default();
+        progress.update_blocks(blocks);
+
+        let info = SyncProgressInfo::from(&progress);
+        assert_eq!(info.blocks.current, 60);
+        assert_eq!(info.blocks.target, 100);
+        assert!(
+            (info.blocks.percentage - 0.6).abs() < 1e-9,
+            "expected 0.6, got {}",
+            info.blocks.percentage
+        );
+    }
+
+    #[test]
+    fn test_sync_progress_info_blocks_zero_requested() {
+        use crate::sync::{BlocksProgress, SyncProgress};
+
+        let blocks = BlocksProgress::default(); // requested = 0
+        let mut progress = SyncProgress::default();
+        progress.update_blocks(blocks);
+
+        let info = SyncProgressInfo::from(&progress);
+        assert_eq!(info.blocks.percentage, 0.0);
+    }
+
+    #[test]
+    fn test_sync_progress_info_masternodes_phase() {
+        use crate::sync::{MasternodesProgress, SyncProgress};
+
+        let mut masternodes = MasternodesProgress::default();
+        masternodes.update_target_height(2000);
+        masternodes.update_current_height(1000);
+
+        let mut progress = SyncProgress::default();
+        progress.update_masternodes(masternodes);
+
+        let info = SyncProgressInfo::from(&progress);
+        assert_eq!(info.masternodes.current, 1000);
+        assert_eq!(info.masternodes.target, 2000);
+        assert!(
+            (info.masternodes.percentage - 0.5).abs() < 1e-9,
+            "expected 0.5, got {}",
+            info.masternodes.percentage
+        );
+    }
+
+    #[test]
+    fn test_sync_progress_info_percentage_clamped() {
+        use crate::sync::{MasternodesProgress, SyncProgress};
+
+        // current > target should clamp to 1.0
+        let mut masternodes = MasternodesProgress::default();
+        masternodes.update_target_height(100);
+        masternodes.update_current_height(200);
+
+        let mut progress = SyncProgress::default();
+        progress.update_masternodes(masternodes);
+
+        let info = SyncProgressInfo::from(&progress);
+        assert_eq!(info.masternodes.percentage, 1.0);
+    }
+
+    /// Verify `get_sync_progress()` on a freshly-constructed client.
+    #[tokio::test]
+    async fn test_get_sync_progress_initial_state() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        let info = client.get_sync_progress().await;
+
+        // Before start() the client should not be fully synced.
+        assert!(!info.is_synced);
+        // The state must be one of the known variant strings.
+        let valid_states = ["WaitForEvents", "WaitingForConnections", "Syncing", "Synced", "Error"];
+        assert!(valid_states.contains(&info.state.as_str()), "unexpected state: {}", info.state);
+        assert!(
+            (0.0..=1.0).contains(&info.overall_percentage),
+            "overall_percentage out of range: {}",
+            info.overall_percentage
+        );
     }
 }

--- a/dash-spv/src/bridge/mod.rs
+++ b/dash-spv/src/bridge/mod.rs
@@ -769,6 +769,45 @@ impl SpvClient {
     }
 }
 
+// ============ Transaction history methods ============
+
+#[uniffi::export]
+impl SpvClient {
+    /// Returns a paginated list of transactions from the wallet's transaction history.
+    ///
+    /// Transaction history sync is not yet implemented in the SPV client, so this
+    /// method always returns an empty `Vec`.  It is exported so foreign-language
+    /// bindings can be generated and call-sites can be wired up in advance.
+    ///
+    /// # Parameters
+    ///
+    /// * `limit`  – maximum number of transactions to return.
+    /// * `offset` – number of transactions to skip before returning results.
+    pub async fn get_transactions(&self, limit: u32, offset: u32) -> Vec<TransactionInfo> {
+        let _ = (limit, offset);
+        vec![]
+    }
+
+    /// Looks up a single transaction by its transaction ID.
+    ///
+    /// Transaction history sync is not yet implemented in the SPV client, so this
+    /// method always returns `None`.  It is exported so foreign-language bindings
+    /// can be generated and call-sites can be wired up in advance.
+    pub async fn get_transaction(&self, txid: String) -> Option<TransactionInfo> {
+        let _ = txid;
+        None
+    }
+
+    /// Returns the total number of transactions in the wallet's transaction history.
+    ///
+    /// Transaction history sync is not yet implemented in the SPV client, so this
+    /// method always returns `0`.  It is exported so foreign-language bindings can
+    /// be generated and call-sites can be wired up in advance.
+    pub async fn get_transaction_count(&self) -> u32 {
+        0
+    }
+}
+
 // ============ Stub functions ============
 
 /// Returns a greeting string (sanity-check export).
@@ -1588,6 +1627,59 @@ mod tests {
         assert!(
             client.get_governance_proposal("deadbeef".to_string()).await.is_none(),
             "get_governance_proposal should return None (stub)"
+        );
+    }
+
+    // ---- get_transactions / get_transaction / get_transaction_count stub tests ----
+
+    /// `get_transaction_count` always returns 0 (transaction history not yet implemented).
+    #[tokio::test]
+    async fn test_get_transaction_count_returns_zero() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest().without_filters().with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert_eq!(
+            client.get_transaction_count().await,
+            0,
+            "get_transaction_count should return 0 (stub)"
+        );
+    }
+
+    /// `get_transactions` always returns an empty vec (transaction history not yet implemented).
+    #[tokio::test]
+    async fn test_get_transactions_returns_empty() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest().without_filters().with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert!(
+            client.get_transactions(10, 0).await.is_empty(),
+            "get_transactions should return empty vec (stub)"
+        );
+    }
+
+    /// `get_transactions` with various limit/offset values always returns empty (stub).
+    #[tokio::test]
+    async fn test_get_transactions_with_limit_and_offset() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest().without_filters().with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert!(client.get_transactions(0, 0).await.is_empty());
+        assert!(client.get_transactions(100, 50).await.is_empty());
+    }
+
+    /// `get_transaction` always returns `None` (transaction history not yet implemented).
+    #[tokio::test]
+    async fn test_get_transaction_returns_none() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config = ClientConfig::regtest().without_filters().with_storage_path(temp_dir.path());
+
+        let client = SpvClient::new(config).await.expect("SpvClient construction must succeed");
+        assert!(
+            client.get_transaction("abcd1234".to_string()).await.is_none(),
+            "get_transaction should return None (stub)"
         );
     }
 }

--- a/dash-spv/src/client/config.rs
+++ b/dash-spv/src/client/config.rs
@@ -11,6 +11,7 @@ use crate::types::ValidationMode;
 
 /// Strategy for handling mempool (unconfirmed) transactions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum MempoolStrategy {
     /// Fetch all announced transactions (high bandwidth, sees all transactions).
     FetchAll,
@@ -21,6 +22,7 @@ pub enum MempoolStrategy {
 /// Configuration for the Dash SPV client.
 #[derive(Debug, Clone)]
 #[repr(C)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ClientConfig {
     /// Network to connect to.
     pub network: Network,
@@ -62,7 +64,7 @@ pub struct ClientConfig {
     pub mempool_strategy: MempoolStrategy,
 
     /// Maximum number of unconfirmed transactions to track.
-    pub max_mempool_transactions: usize,
+    pub max_mempool_transactions: u64,
 
     /// Whether to fetch transactions from INV messages immediately.
     pub fetch_mempool_transactions: bool,
@@ -175,7 +177,7 @@ impl ClientConfig {
     }
 
     /// Set maximum number of mempool transactions to track.
-    pub fn with_max_mempool_transactions(mut self, max: usize) -> Self {
+    pub fn with_max_mempool_transactions(mut self, max: u64) -> Self {
         self.max_mempool_transactions = max;
         self
     }

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -23,7 +23,7 @@ use crate::storage::{
 };
 use crate::sync::{
     BlockHeadersManager, BlocksManager, ChainLockManager, FilterHeadersManager, FiltersManager,
-    InstantSendManager, Managers, MasternodesManager, SyncCoordinator,
+    InstantSendManager, Managers, MasternodesManager, MempoolManager, SyncCoordinator,
 };
 use crate::types::MempoolState;
 use dashcore::sml::masternode_list_engine::MasternodeListEngine;
@@ -122,10 +122,18 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
             managers.instantsend = Some(InstantSendManager::new(masternode_list_engine.clone()));
         }
 
-        let sync_coordinator = SyncCoordinator::new(managers).await;
-
-        // Create mempool state
+        // Create mempool state and build mempool manager if tracking is enabled
         let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
+        if config.enable_mempool_tracking {
+            managers.mempool = Some(MempoolManager::new(
+                wallet.clone(),
+                mempool_state.clone(),
+                config.mempool_strategy,
+                config.max_mempool_transactions,
+            ));
+        }
+
+        let sync_coordinator = SyncCoordinator::new(managers).await;
 
         // Wrap storage in Arc<Mutex>
         let storage = Arc::new(Mutex::new(storage));

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -151,7 +151,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
             if config.enable_mempool_tracking {
                 let filter = Arc::new(MempoolFilter::new(
                     config.mempool_strategy,
-                    config.max_mempool_transactions,
+                    config.max_mempool_transactions as usize,
                     client.mempool_state.clone(),
                     HashSet::new(), // TODO: populate from wallet's monitored addresses
                     config.network,
@@ -178,7 +178,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
     }
 
     /// Start the SPV client: spawn sync tasks and connect to the network.
-    pub(super) async fn start(&self) -> Result<()> {
+    pub async fn start(&self) -> Result<()> {
         {
             let running = self.running.read().await;
             if *running {

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -129,7 +129,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
                 wallet.clone(),
                 mempool_state.clone(),
                 config.mempool_strategy,
-                config.max_mempool_transactions,
+                config.max_mempool_transactions as usize,
             ));
         }
 

--- a/dash-spv/src/client/mempool.rs
+++ b/dash-spv/src/client/mempool.rs
@@ -125,7 +125,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         // For now, create empty filter until wallet integration is complete
         let filter = Arc::new(MempoolFilter::new(
             config.mempool_strategy,
-            config.max_mempool_transactions,
+            config.max_mempool_transactions as usize,
             self.mempool_state.clone(),
             HashSet::new(), // Will be populated from wallet's monitored addresses
             config.network,

--- a/dash-spv/src/client/mempool.rs
+++ b/dash-spv/src/client/mempool.rs
@@ -110,6 +110,30 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         mempool_state.transactions.len()
     }
 
+    /// Return a snapshot of all currently tracked mempool transactions.
+    ///
+    /// Clones the transactions from the shared mempool state so that callers
+    /// can iterate them without holding the lock.
+    pub async fn get_all_mempool_transactions(&self) -> Vec<crate::types::UnconfirmedTransaction> {
+        let mempool_state = self.mempool_state.read().await;
+        mempool_state.transactions.values().cloned().collect()
+    }
+
+    /// Return the aggregate pending balance from the mempool state.
+    ///
+    /// Sums regular and InstantSend pending balances.  Negative values (which
+    /// can arise if a transaction is removed after the balance was credited) are
+    /// clamped to zero.
+    pub async fn get_aggregate_mempool_balance(&self) -> crate::types::MempoolBalance {
+        let mempool_state = self.mempool_state.read().await;
+        let pending_sats = mempool_state.pending_balance.max(0) as u64;
+        let pending_instant_sats = mempool_state.pending_instant_balance.max(0) as u64;
+        crate::types::MempoolBalance {
+            pending: dashcore::Amount::from_sat(pending_sats),
+            pending_instant: dashcore::Amount::from_sat(pending_instant_sats),
+        }
+    }
+
     /// Record that we attempted to send a transaction (for UX/heuristics).
     pub async fn record_send(&self, txid: dashcore::Txid) -> Result<()> {
         let mut mempool_state = self.mempool_state.write().await;

--- a/dash-spv/src/client/mod.rs
+++ b/dash-spv/src/client/mod.rs
@@ -49,9 +49,18 @@ mod tests {
     use crate::client::config::MempoolStrategy;
     use crate::storage::DiskStorageManager;
     use crate::{test_utils::MockNetworkManager, types::UnconfirmedTransaction};
-    use dashcore::{Address, Amount, Transaction, TxOut};
+    use dashcore::sml::masternode_list::MasternodeList;
+    use dashcore::sml::masternode_list_entry::{
+        qualified_masternode_list_entry::QualifiedMasternodeListEntry, EntryMasternodeType,
+        MasternodeListEntry,
+    };
+    use dashcore::{Address, Amount, BlockHash, ProTxHash, Transaction, TxOut};
+    use dashcore_hashes::Hash;
     use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
     use key_wallet_manager::wallet_manager::WalletManager;
+    use std::collections::BTreeMap;
+    use std::net::SocketAddr;
+    use std::str::FromStr;
     use std::sync::Arc;
     use tempfile::TempDir;
     use tokio::sync::RwLock;
@@ -169,5 +178,104 @@ mod tests {
             Amount::from_sat(1_000_000_000),
             "InstantSend balance should be 10 Dash"
         );
+    }
+
+    // ============ masternode_engine() accessor tests ============
+
+    /// `masternode_engine()` returns `None` when masternodes are disabled.
+    #[tokio::test]
+    async fn test_masternode_engine_none_when_disabled() {
+        let config = ClientConfig::testnet()
+            .without_filters()
+            .without_masternodes()
+            .with_storage_path(TempDir::new().unwrap().path());
+
+        let network_manager = MockNetworkManager::new();
+        let storage = DiskStorageManager::new(&config).await.expect("storage");
+        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
+
+        let client = DashSpvClient::new(config, network_manager, storage, wallet)
+            .await
+            .expect("client construction must succeed");
+
+        assert!(
+            client.masternode_engine().await.is_none(),
+            "masternode_engine() should be None when masternodes are disabled"
+        );
+    }
+
+    /// `masternode_engine()` returns `Some` when masternodes are enabled.
+    #[tokio::test]
+    async fn test_masternode_engine_some_when_enabled() {
+        let config = ClientConfig::testnet()
+            .without_filters()
+            .with_storage_path(TempDir::new().unwrap().path());
+
+        let network_manager = MockNetworkManager::new();
+        let storage = DiskStorageManager::new(&config).await.expect("storage");
+        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
+
+        let client = DashSpvClient::new(config, network_manager, storage, wallet)
+            .await
+            .expect("client construction must succeed");
+
+        assert!(
+            client.masternode_engine().await.is_some(),
+            "masternode_engine() should be Some when masternodes are enabled"
+        );
+    }
+
+    /// Verifies that after manually inserting a masternode list into the engine
+    /// the count and entries are visible via the engine handle.
+    #[tokio::test]
+    async fn test_masternode_engine_populated_reflects_entries() {
+        let config = ClientConfig::testnet()
+            .without_filters()
+            .with_storage_path(TempDir::new().unwrap().path());
+        let network = config.network;
+
+        let network_manager = MockNetworkManager::new();
+        let storage = DiskStorageManager::new(&config).await.expect("storage");
+        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(network)));
+
+        let client = DashSpvClient::new(config, network_manager, storage, wallet)
+            .await
+            .expect("client construction must succeed");
+
+        let engine_arc = client.masternode_engine().await.expect("engine should be Some");
+
+        // Build a minimal MasternodeListEntry for testing.
+        let pro_reg_tx_hash = ProTxHash::all_zeros();
+        let entry = MasternodeListEntry {
+            version: 1,
+            pro_reg_tx_hash,
+            confirmed_hash: None,
+            service_address: SocketAddr::from_str("1.2.3.4:9999").unwrap(),
+            operator_public_key: dashcore::bls_sig_utils::BLSPublicKey::from([0u8; 48]),
+            key_id_voting: dashcore::PubkeyHash::all_zeros(),
+            is_valid: true,
+            mn_type: EntryMasternodeType::Regular,
+        };
+        let qualified: QualifiedMasternodeListEntry = entry.into();
+
+        // Insert the entry into a MasternodeList and load it into the engine.
+        let block_hash = BlockHash::all_zeros();
+        let masternodes = BTreeMap::from([(pro_reg_tx_hash, qualified)]);
+        let list = MasternodeList::build(masternodes, BTreeMap::new(), block_hash, 100).build();
+
+        {
+            let mut engine = engine_arc.write().await;
+            engine.masternode_lists.insert(100, list);
+        }
+
+        // Now read back via the accessor.
+        let engine_arc2 = client.masternode_engine().await.expect("engine should still be Some");
+        let engine = engine_arc2.read().await;
+        let latest = engine.latest_masternode_list().expect("list should be present");
+
+        assert_eq!(latest.masternodes.len(), 1, "should have 1 masternode");
+        let mn = latest.masternodes.values().next().unwrap();
+        assert!(mn.masternode_list_entry.is_valid, "masternode should be valid (Enabled)");
+        assert_eq!(mn.masternode_list_entry.service_address.to_string(), "1.2.3.4:9999");
     }
 }

--- a/dash-spv/src/client/mod.rs
+++ b/dash-spv/src/client/mod.rs
@@ -132,7 +132,7 @@ mod tests {
             let mut mempool_state = client.mempool_state.write().await;
             let tx_record = UnconfirmedTransaction {
                 transaction: tx.clone(),
-                first_seen: std::time::Instant::now(),
+                first_seen: tokio::time::Instant::now(),
                 fee: Amount::ZERO,
                 size: 0,
                 is_instant_send: false,

--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -27,6 +27,22 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         self.network.lock().await.peer_count()
     }
 
+    /// Return a snapshot of all currently connected peers.
+    ///
+    /// Delegates to [`crate::network::manager::PeerNetworkManager::get_peers_snapshot`]
+    /// via a downcast.  Returns an empty `Vec` when the underlying network
+    /// manager is not a `PeerNetworkManager`.
+    pub async fn peers_snapshot(&self) -> Vec<crate::network::manager::PeerSnapshot> {
+        let network_guard = self.network.lock().await;
+        if let Some(network) =
+            network_guard.as_any().downcast_ref::<crate::network::manager::PeerNetworkManager>()
+        {
+            network.get_peers_snapshot().await
+        } else {
+            vec![]
+        }
+    }
+
     /// Disconnect a specific peer.
     pub async fn disconnect_peer(&self, addr: &std::net::SocketAddr, reason: &str) -> Result<()> {
         // Cast network manager to PeerNetworkManager to access disconnect_peer

--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -52,6 +52,11 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         }
     }
 
+    /// Returns a clone of the masternode engine handle, or `None` if masternodes are disabled.
+    pub async fn masternode_engine(&self) -> Option<Arc<RwLock<MasternodeListEngine>>> {
+        self.masternode_engine.clone()
+    }
+
     /// Get a quorum entry by type and hash at a specific block height.
     /// Returns `SpvError::QuorumLookupError` if the quorum is not found.
     pub async fn get_quorum_at_height(

--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -29,6 +29,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
 
         let mut sync_coordinator_tick_interval = tokio::time::interval(SYNC_COORDINATOR_TICK_MS);
         let mut progress_updates = self.sync_coordinator.lock().await.subscribe_progress();
+        let mut wallet_events = self.wallet.read().await.subscribe_events();
 
         let error = loop {
             // Check if we should stop
@@ -51,6 +52,10 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
                             break None
                         }
                     }
+                }
+                Ok(event) = wallet_events.recv() => {
+                    tracing::info!("Wallet event: {}", event.description());
+                    None
                 }
                 _ = sync_coordinator_tick_interval.tick() => {
                     self.sync_coordinator.lock().await.tick().await.err().map(Into::into)

--- a/dash-spv/src/lib.rs
+++ b/dash-spv/src/lib.rs
@@ -56,6 +56,12 @@
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
+#[cfg(feature = "uniffi")]
+pub mod bridge;
+
 pub mod chain;
 pub mod client;
 pub mod error;

--- a/dash-spv/src/main.rs
+++ b/dash-spv/src/main.rs
@@ -264,6 +264,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         config = config.with_mempool_tracking(mempool_strategy);
     }
 
+    let mempool_strategy = *matches
+        .get_one::<MempoolStrategy>("mempool-strategy")
+        .expect("mempool-strategy has default value");
+    config = config.with_mempool_tracking(mempool_strategy);
+
     // Set start height if specified
     if let Some(start_height_str) = matches.get_one::<String>("start-height") {
         if start_height_str == "now" {

--- a/dash-spv/src/network/handshake.rs
+++ b/dash-spv/src/network/handshake.rs
@@ -10,7 +10,6 @@ use dashcore::network::message_network::VersionMessage;
 use dashcore::Network;
 // Hash trait not needed in current implementation
 
-use crate::client::config::MempoolStrategy;
 use crate::error::{NetworkError, NetworkResult};
 use crate::network::peer::Peer;
 use crate::network::Message;
@@ -40,17 +39,13 @@ pub struct HandshakeManager {
     version_received: bool,
     verack_received: bool,
     version_sent: bool,
-    mempool_strategy: MempoolStrategy,
+    relay: bool,
     user_agent: Option<String>,
 }
 
 impl HandshakeManager {
     /// Create a new handshake manager.
-    pub fn new(
-        network: Network,
-        mempool_strategy: MempoolStrategy,
-        user_agent: Option<String>,
-    ) -> Self {
+    pub fn new(network: Network, relay: bool, user_agent: Option<String>) -> Self {
         Self {
             _network: network,
             state: HandshakeState::Init,
@@ -60,7 +55,7 @@ impl HandshakeManager {
             version_received: false,
             verack_received: false,
             version_sent: false,
-            mempool_strategy,
+            relay,
             user_agent,
         }
     }
@@ -292,10 +287,7 @@ impl HandshakeManager {
             nonce: rand::random(),
             user_agent: ua,
             start_height: 0, // SPV client starts at 0
-            relay: match self.mempool_strategy {
-                MempoolStrategy::FetchAll => true, // Want all transactions for FetchAll strategy
-                _ => false,                        // Don't want relay for other strategies
-            },
+            relay: self.relay,
             mn_auth_challenge: [0; 32],   // Not a masternode
             masternode_connection: false, // Not connecting to masternode
         })

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -997,6 +997,9 @@ impl PeerNetworkManager {
         }
 
         let preferred_service = match &message {
+            NetworkMessage::FilterLoad(_)
+            | NetworkMessage::FilterClear
+            | NetworkMessage::MemPool => Some((ServiceFlags::BLOOM, true)),
             NetworkMessage::GetCFHeaders(_) | NetworkMessage::GetCFilters(_) => {
                 Some((ServiceFlags::COMPACT_FILTERS, true))
             }

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -57,8 +57,6 @@ pub struct PeerNetworkManager {
     tasks: Arc<Mutex<JoinSet<()>>>,
     /// Initial peer addresses
     initial_peers: Vec<SocketAddr>,
-    /// Current sync peer (sticky during sync operations)
-    current_sync_peer: Arc<Mutex<Option<SocketAddr>>>,
     /// Data directory for storage
     data_dir: PathBuf,
     /// Mempool strategy from config
@@ -113,7 +111,6 @@ impl PeerNetworkManager {
             shutdown_token: CancellationToken::new(),
             tasks: Arc::new(Mutex::new(JoinSet::new())),
             initial_peers: config.peers.clone(),
-            current_sync_peer: Arc::new(Mutex::new(None)),
             data_dir,
             mempool_strategy: config.mempool_strategy,
             user_agent: config.user_agent.clone(),
@@ -962,7 +959,7 @@ impl PeerNetworkManager {
         });
     }
 
-    /// Send a message to a single peer (using sticky peer selection for sync consistency)
+    /// Send a message to a single peer selected by message type requirements.
     async fn send_to_single_peer(&self, message: NetworkMessage) -> NetworkResult<()> {
         let peers = self.pool.get_all_peers().await;
 
@@ -970,104 +967,33 @@ impl PeerNetworkManager {
             return Err(NetworkError::ConnectionFailed("No connected peers".to_string()));
         }
 
-        // For filter-related messages, we need a peer that supports compact filters
-        let requires_compact_filters =
-            matches!(&message, NetworkMessage::GetCFHeaders(_) | NetworkMessage::GetCFilters(_));
-        let check_headers2 =
-            matches!(&message, NetworkMessage::GetHeaders(_) | NetworkMessage::GetHeaders2(_));
-
-        let selected_peer = if requires_compact_filters {
-            // Find a peer that supports compact filters
-            let mut filter_peer = None;
-            for (addr, peer) in &peers {
-                let peer_guard = peer.read().await;
-
-                if peer_guard.supports_compact_filters() {
-                    filter_peer = Some(*addr);
-                    break;
-                }
+        let preferred_service = match &message {
+            NetworkMessage::GetCFHeaders(_) | NetworkMessage::GetCFilters(_) => {
+                Some((ServiceFlags::COMPACT_FILTERS, true))
             }
-
-            match filter_peer {
-                Some(addr) => {
-                    log::debug!("Selected peer {} for compact filter request", addr);
-                    addr
-                }
-                None => {
-                    log::warn!("No peers support compact filters, cannot send {}", message.cmd());
-                    return Err(NetworkError::ProtocolError(
-                        "No peers support compact filters".to_string(),
-                    ));
-                }
+            NetworkMessage::GetHeaders(_) | NetworkMessage::GetHeaders2(_) => {
+                Some((ServiceFlags::NODE_HEADERS_COMPRESSED, false))
             }
-        } else if check_headers2 {
-            // Prefer a peer that advertises headers2 support
-            let mut current_sync_peer = self.current_sync_peer.lock().await;
-            let mut selected: Option<SocketAddr> = None;
-
-            if let Some(current_addr) = *current_sync_peer {
-                if let Some((_, peer)) = peers.iter().find(|(addr, _)| *addr == current_addr) {
-                    let peer_guard = peer.read().await;
-                    if peer_guard.supports_headers2() {
-                        selected = Some(current_addr);
-                    }
-                }
-            }
-
-            if selected.is_none() {
-                for (addr, peer) in &peers {
-                    let peer_guard = peer.read().await;
-                    if peer_guard.supports_headers2() {
-                        selected = Some(*addr);
-                        break;
-                    }
-                }
-            }
-
-            let chosen = selected.unwrap_or(peers[0].0);
-            if Some(chosen) != *current_sync_peer {
-                log::info!("Sync peer selected for Headers2: {}", chosen);
-                *current_sync_peer = Some(chosen);
-            }
-            drop(current_sync_peer);
-            chosen
-        } else {
-            // For non-filter messages, use the sticky sync peer
-            let mut current_sync_peer = self.current_sync_peer.lock().await;
-            let selected = if let Some(current_addr) = *current_sync_peer {
-                // Check if current sync peer is still connected
-                if peers.iter().any(|(addr, _)| *addr == current_addr) {
-                    // Keep using the same peer for sync consistency
-                    current_addr
-                } else {
-                    // Current sync peer disconnected, pick a new one
-                    let new_addr = peers[0].0;
-                    log::info!(
-                        "Sync peer switched from {} to {} (previous peer disconnected)",
-                        current_addr,
-                        new_addr
-                    );
-                    *current_sync_peer = Some(new_addr);
-                    new_addr
-                }
-            } else {
-                // No current sync peer, pick the first available
-                let new_addr = peers[0].0;
-                log::info!("Sync peer selected: {}", new_addr);
-                *current_sync_peer = Some(new_addr);
-                new_addr
-            };
-            drop(current_sync_peer);
-            selected
+            _ => None,
         };
 
-        // Find the peer for the selected address
-        let (addr, peer) = peers
-            .iter()
-            .find(|(a, _)| *a == selected_peer)
-            .ok_or_else(|| NetworkError::ConnectionFailed("Selected peer not found".to_string()))?;
+        let (addr, peer) = if let Some((flags, required)) = preferred_service {
+            match self.pool.peer_with_service(flags).await {
+                Some((address, peer)) => {
+                    log::debug!("Selected peer {} with {} for {}", address, flags, message.cmd());
+                    (address, peer)
+                }
+                None if required => {
+                    log::warn!("No peers support {}, cannot send {}", flags, message.cmd());
+                    return Err(NetworkError::ProtocolError(format!("No peers support {}", flags)));
+                }
+                None => self.next_peer(&peers),
+            }
+        } else {
+            self.next_peer(&peers)
+        };
 
-        self.send_message_to_peer(addr, peer, message).await
+        self.send_message_to_peer(&addr, &peer, message).await
     }
 
     /// Send a message distributed across connected peers using round-robin selection.
@@ -1086,33 +1012,17 @@ impl PeerNetworkManager {
         // Select eligible peers based on message type
         let (selected_peers, require_capability) = match &message {
             NetworkMessage::GetCFHeaders(_) | NetworkMessage::GetCFilters(_) => {
-                // Filter requests require compact filter support
-                let filter_peers: Vec<_> = {
-                    let mut result = Vec::new();
-                    for (addr, peer) in &peers {
-                        let peer_guard = peer.read().await;
-                        if peer_guard.supports_compact_filters() {
-                            result.push((*addr, peer.clone()));
-                        }
-                    }
-                    result
-                };
+                let filter_peers =
+                    self.pool.peers_with_service(ServiceFlags::COMPACT_FILTERS).await;
                 (filter_peers, true)
             }
             NetworkMessage::GetHeaders(_) | NetworkMessage::GetHeaders2(_) => {
-                // Prefer headers2 peers, fall back to all
-                let headers2_peers: Vec<_> = {
-                    let mut result = Vec::new();
-                    for (addr, peer) in &peers {
-                        let peer_guard = peer.read().await;
-                        if peer_guard.supports_headers2()
-                            && !self.headers2_disabled.lock().await.contains(addr)
-                        {
-                            result.push((*addr, peer.clone()));
-                        }
-                    }
-                    result
-                };
+                // Prefer headers2 peers (excluding disabled), fall back to all
+                let disabled = self.headers2_disabled.lock().await;
+                let mut headers2_peers =
+                    self.pool.peers_with_service(ServiceFlags::NODE_HEADERS_COMPRESSED).await;
+                headers2_peers.retain(|(addr, _)| !disabled.contains(addr));
+                drop(disabled);
                 if headers2_peers.is_empty() {
                     (peers.clone(), false)
                 } else {
@@ -1133,18 +1043,20 @@ impl PeerNetworkManager {
             };
         }
 
-        // Round-robin selection
-        let idx = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) % selected_peers.len();
-        let (addr, peer) = &selected_peers[idx];
+        let (addr, peer) = self.next_peer(&selected_peers);
 
-        log::debug!(
-            "Distributing {} request to peer {} (round-robin idx {})",
-            message.cmd(),
-            addr,
-            idx
-        );
+        log::debug!("Distributing {} request to peer {}", message.cmd(), addr);
 
-        self.send_message_to_peer(addr, peer, message).await
+        self.send_message_to_peer(&addr, &peer, message).await
+    }
+
+    /// Pick the next peer from `peers` using round-robin rotation.
+    fn next_peer(
+        &self,
+        peers: &[(SocketAddr, Arc<RwLock<Peer>>)],
+    ) -> (SocketAddr, Arc<RwLock<Peer>>) {
+        let idx = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) % peers.len();
+        (peers[idx].0, peers[idx].1.clone())
     }
 
     /// Send a message to the given peer.
@@ -1307,7 +1219,6 @@ impl Clone for PeerNetworkManager {
             shutdown_token: self.shutdown_token.clone(),
             tasks: self.tasks.clone(),
             initial_peers: self.initial_peers.clone(),
-            current_sync_peer: self.current_sync_peer.clone(),
             data_dir: self.data_dir.clone(),
             mempool_strategy: self.mempool_strategy,
             user_agent: self.user_agent.clone(),

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -230,7 +230,7 @@ impl PeerNetworkManager {
         let addrv2_handler = self.addrv2_handler.clone();
         let shutdown_token = self.shutdown_token.clone();
         let reputation_manager = self.reputation_manager.clone();
-        let relay = self.mempool_strategy != MempoolStrategy::BloomFilter;
+        let relay = false;
         let user_agent = self.user_agent.clone();
         let connected_peer_count = self.connected_peer_count.clone();
         let headers2_disabled = self.headers2_disabled.clone();

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -787,6 +787,36 @@ impl PeerNetworkManager {
                                     }
                                 });
                             }
+                            Some(NetworkRequest::SendMessageToPeer(msg, peer_address)) => {
+                                log::debug!("Request processor: sending {} to peer {}", msg.cmd(), peer_address);
+                                let this = this.clone();
+                                tokio::spawn(async move {
+                                    let fallback_msg = msg.clone();
+                                    let result = match this.pool.get_peer(&peer_address).await {
+                                        Some(peer) => match this.send_message_to_peer(&peer_address, &peer, msg).await {
+                                            Ok(()) => Ok(()),
+                                            Err(err) => {
+                                                log::warn!(
+                                                    "Target peer {} send failed ({}), falling back to distributed send",
+                                                    peer_address,
+                                                    err
+                                                );
+                                                this.send_distributed(fallback_msg).await
+                                            }
+                                        },
+                                        None => {
+                                            log::warn!(
+                                                "Target peer {} disconnected, falling back to distributed send",
+                                                peer_address
+                                            );
+                                            this.send_distributed(fallback_msg).await
+                                        }
+                                    };
+                                    if let Err(e) = result {
+                                        log::error!("Request processor: failed to send message to peer {}: {}", peer_address, e);
+                                    }
+                                });
+                            }
                             None => {
                                 log::info!("Request processor: channel closed");
                                 break;

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -230,7 +230,7 @@ impl PeerNetworkManager {
         let addrv2_handler = self.addrv2_handler.clone();
         let shutdown_token = self.shutdown_token.clone();
         let reputation_manager = self.reputation_manager.clone();
-        let mempool_strategy = self.mempool_strategy;
+        let relay = self.mempool_strategy != MempoolStrategy::BloomFilter;
         let user_agent = self.user_agent.clone();
         let connected_peer_count = self.connected_peer_count.clone();
         let headers2_disabled = self.headers2_disabled.clone();
@@ -260,8 +260,7 @@ impl PeerNetworkManager {
             match connect_result {
                 Ok(mut peer) => {
                     // Perform handshake
-                    let mut handshake_manager =
-                        HandshakeManager::new(network, mempool_strategy, user_agent);
+                    let mut handshake_manager = HandshakeManager::new(network, relay, user_agent);
                     match handshake_manager.perform_handshake(&mut peer).await {
                         Ok(_) => {
                             log::info!("Successfully connected to {}", addr);

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -37,6 +37,23 @@ use tokio_util::sync::CancellationToken;
 
 const DEFAULT_NETWORK_EVENT_CAPACITY: usize = 10000;
 
+/// Point-in-time snapshot of a single connected peer's state.
+///
+/// Returned by [`PeerNetworkManager::get_peers_snapshot`].
+#[derive(Debug, Clone)]
+pub struct PeerSnapshot {
+    /// Remote socket address of the peer.
+    pub address: SocketAddr,
+    /// User-agent string reported during the handshake (empty if not yet received).
+    pub user_agent: String,
+    /// Best block height reported by the peer (0 if not yet received).
+    pub best_height: u32,
+    /// Unix timestamp (seconds) of when the peer connected (0 if unknown).
+    pub connected_since: u64,
+    /// Raw services bitmask advertised by the peer (0 if not yet received).
+    pub services: u64,
+}
+
 /// Peer network manager
 pub struct PeerNetworkManager {
     /// Peer pool
@@ -1171,6 +1188,31 @@ impl PeerNetworkManager {
         .await;
 
         Ok(())
+    }
+
+    /// Return a point-in-time snapshot of all currently connected peers.
+    ///
+    /// Each entry captures the address, user-agent, best height, connection
+    /// timestamp, and services bitmask as they were at the moment of the call.
+    pub async fn get_peers_snapshot(&self) -> Vec<PeerSnapshot> {
+        let peers = self.pool.get_all_peers().await;
+        let mut result = Vec::with_capacity(peers.len());
+        for (addr, peer_lock) in peers {
+            let peer = peer_lock.read().await;
+            let connected_since = peer
+                .connected_since()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            result.push(PeerSnapshot {
+                address: addr,
+                user_agent: peer.user_agent().unwrap_or("").to_owned(),
+                best_height: peer.best_height().unwrap_or(0),
+                connected_since,
+                services: peer.services_bits().unwrap_or(0),
+            });
+        }
+        result
     }
 
     /// Get reputation information for all peers

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -24,6 +24,7 @@ use crate::error::NetworkResult;
 use crate::NetworkError;
 use dashcore::network::message::NetworkMessage;
 use dashcore::network::message_blockdata::{GetHeadersMessage, Inventory};
+use dashcore::network::message_bloom::FilterLoad;
 use dashcore::network::message_filter::{GetCFHeaders, GetCFilters};
 use dashcore::network::message_qrinfo::GetQRInfo;
 use dashcore::network::message_sml::GetMnListDiff;
@@ -149,7 +150,7 @@ impl RequestSender {
     /// Send a filterload message to the peer.
     pub fn send_filter_load(
         &self,
-        filter_load: dashcore::network::message_bloom::FilterLoad,
+        filter_load: FilterLoad,
     ) -> NetworkResult<()> {
         self.send_message(NetworkMessage::FilterLoad(filter_load))
     }

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -145,6 +145,24 @@ impl RequestSender {
             hashes.into_iter().map(Inventory::Block).collect(),
         ))
     }
+
+    /// Send a filterload message to the peer.
+    pub fn send_filter_load(
+        &self,
+        filter_load: dashcore::network::message_bloom::FilterLoad,
+    ) -> NetworkResult<()> {
+        self.send_message(NetworkMessage::FilterLoad(filter_load))
+    }
+
+    /// Send a filterclear message to the peer.
+    pub fn send_filter_clear(&self) -> NetworkResult<()> {
+        self.send_message(NetworkMessage::FilterClear)
+    }
+
+    /// Send a mempool message to request inventory of mempool transactions.
+    pub fn request_mempool(&self) -> NetworkResult<()> {
+        self.send_message(NetworkMessage::MemPool)
+    }
 }
 
 /// Network manager trait for abstracting network operations.

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -34,6 +34,7 @@ pub use manager::PeerNetworkManager;
 pub use message_dispatcher::{Message, MessageDispatcher};
 pub use message_type::MessageType;
 pub use peer::Peer;
+use std::net::SocketAddr;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 const FILTER_TYPE_DEFAULT: u8 = 0;
@@ -43,6 +44,8 @@ const FILTER_TYPE_DEFAULT: u8 = 0;
 pub enum NetworkRequest {
     /// Send a message to the network.
     SendMessage(NetworkMessage),
+    /// Send a message to a specific peer.
+    SendMessageToPeer(NetworkMessage, SocketAddr),
 }
 
 /// Handle for managers to queue outgoing network requests.
@@ -66,8 +69,24 @@ impl RequestSender {
             .map_err(|e| NetworkError::ProtocolError(e.to_string()))
     }
 
-    pub fn request_inventory(&self, inventory: Vec<Inventory>) -> NetworkResult<()> {
-        self.send_message(NetworkMessage::GetData(inventory))
+    /// Queue a message to be sent to a specific peer.
+    fn send_message_to_peer(
+        &self,
+        msg: NetworkMessage,
+        peer_address: SocketAddr,
+    ) -> NetworkResult<()> {
+        self.tx
+            .send(NetworkRequest::SendMessageToPeer(msg, peer_address))
+            .map_err(|e| NetworkError::ProtocolError(e.to_string()))
+    }
+
+    /// Request inventory from a specific peer.
+    pub fn request_inventory(
+        &self,
+        inventory: Vec<Inventory>,
+        peer_address: SocketAddr,
+    ) -> NetworkResult<()> {
+        self.send_message_to_peer(NetworkMessage::GetData(inventory), peer_address)
     }
 
     pub fn request_block_headers(&self, start_hash: BlockHash) -> NetworkResult<()> {

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -31,7 +31,7 @@ use dashcore::network::message_sml::GetMnListDiff;
 use dashcore::BlockHash;
 use dashcore_hashes::Hash;
 pub use handshake::{HandshakeManager, HandshakeState};
-pub use manager::PeerNetworkManager;
+pub use manager::{PeerNetworkManager, PeerSnapshot};
 pub use message_dispatcher::{Message, MessageDispatcher};
 pub use message_type::MessageType;
 pub use peer::Peer;

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -148,11 +148,7 @@ impl RequestSender {
     }
 
     /// Send a filterload message to a specific peer.
-    pub fn send_filter_load(
-        &self,
-        filter_load: FilterLoad,
-        peer: SocketAddr,
-    ) -> NetworkResult<()> {
+    pub fn send_filter_load(&self, filter_load: FilterLoad, peer: SocketAddr) -> NetworkResult<()> {
         self.send_message_to_peer(NetworkMessage::FilterLoad(filter_load), peer)
     }
 

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -147,22 +147,23 @@ impl RequestSender {
         ))
     }
 
-    /// Send a filterload message to the peer.
+    /// Send a filterload message to a specific peer.
     pub fn send_filter_load(
         &self,
         filter_load: FilterLoad,
+        peer: SocketAddr,
     ) -> NetworkResult<()> {
-        self.send_message(NetworkMessage::FilterLoad(filter_load))
+        self.send_message_to_peer(NetworkMessage::FilterLoad(filter_load), peer)
     }
 
-    /// Send a filterclear message to the peer.
-    pub fn send_filter_clear(&self) -> NetworkResult<()> {
-        self.send_message(NetworkMessage::FilterClear)
+    /// Send a filterclear message to a specific peer.
+    pub fn send_filter_clear(&self, peer: SocketAddr) -> NetworkResult<()> {
+        self.send_message_to_peer(NetworkMessage::FilterClear, peer)
     }
 
-    /// Send a mempool message to request inventory of mempool transactions.
-    pub fn request_mempool(&self) -> NetworkResult<()> {
-        self.send_message(NetworkMessage::MemPool)
+    /// Send a mempool message to request inventory from a specific peer.
+    pub fn request_mempool(&self, peer: SocketAddr) -> NetworkResult<()> {
+        self.send_message_to_peer(NetworkMessage::MemPool, peer)
     }
 }
 

--- a/dash-spv/src/network/peer.rs
+++ b/dash-spv/src/network/peer.rs
@@ -834,14 +834,23 @@ impl Peer {
 }
 
 #[cfg(test)]
+impl Peer {
+    pub(crate) fn set_services(&mut self, flags: ServiceFlags) {
+        self.services = Some(flags.as_u64());
+    }
+}
+
+#[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
     use std::time::{Duration, SystemTime};
 
     use super::Peer;
 
     #[test]
     fn remove_expired_pings() {
-        let mut peer = Peer::dummy();
+        let addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
+        let mut peer = Peer::dummy(addr);
         let now = SystemTime::now();
         let expired = now - Duration::from_secs(61);
 

--- a/dash-spv/src/network/peer.rs
+++ b/dash-spv/src/network/peer.rs
@@ -133,6 +133,21 @@ impl Peer {
         self.best_height
     }
 
+    /// Get the user-agent string reported by this peer during the handshake.
+    pub fn user_agent(&self) -> Option<&str> {
+        self.user_agent.as_deref()
+    }
+
+    /// Get the `SystemTime` at which this peer connected.
+    pub fn connected_since(&self) -> Option<std::time::SystemTime> {
+        self.connected_at
+    }
+
+    /// Get the raw services bitmask advertised by this peer.
+    pub fn services_bits(&self) -> Option<u64> {
+        self.services
+    }
+
     /// Check if peer supports compact filters (BIP 157/158).
     pub fn supports_compact_filters(&self) -> bool {
         self.has_service(ServiceFlags::COMPACT_FILTERS)

--- a/dash-spv/src/network/pool.rs
+++ b/dash-spv/src/network/pool.rs
@@ -3,6 +3,7 @@
 use crate::error::{NetworkError, SpvError as Error};
 use crate::network::constants::TARGET_PEERS;
 use crate::network::peer::Peer;
+use dashcore::network::constants::ServiceFlags;
 use dashcore::prelude::CoreBlockHeight;
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
@@ -145,6 +146,35 @@ impl PeerPool {
         }
     }
 
+    /// Find the first connected peer that advertises the given service flags.
+    pub(crate) async fn peer_with_service(
+        &self,
+        flags: ServiceFlags,
+    ) -> Option<(SocketAddr, Arc<RwLock<Peer>>)> {
+        let peers = self.peers.read().await;
+        for (addr, peer) in peers.iter() {
+            if peer.read().await.has_service(flags) {
+                return Some((*addr, Arc::clone(peer)));
+            }
+        }
+        None
+    }
+
+    /// Collect all connected peers that advertise the given service flags.
+    pub(crate) async fn peers_with_service(
+        &self,
+        flags: ServiceFlags,
+    ) -> Vec<(SocketAddr, Arc<RwLock<Peer>>)> {
+        let peers = self.peers.read().await;
+        let mut result = Vec::new();
+        for (addr, peer) in peers.iter() {
+            if peer.read().await.has_service(flags) {
+                result.push((*addr, peer.clone()));
+            }
+        }
+        result
+    }
+
     /// Check if we need more peers
     pub async fn needs_more_peers(&self) -> bool {
         self.peer_count().await < TARGET_PEERS
@@ -190,6 +220,15 @@ impl Default for PeerPool {
 }
 
 #[cfg(test)]
+impl PeerPool {
+    async fn insert_peer_with_services(&self, addr: SocketAddr, flags: ServiceFlags) {
+        let mut peer = Peer::dummy(addr);
+        peer.set_services(flags);
+        self.peers.write().await.insert(addr, Arc::new(RwLock::new(peer)));
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -207,5 +246,79 @@ mod tests {
         assert!(pool.mark_connecting(addr).await);
         assert!(!pool.mark_connecting(addr).await); // Already marked
         assert!(pool.is_connecting(&addr).await);
+    }
+
+    #[tokio::test]
+    async fn test_peer_with_service() {
+        let pool = PeerPool::new();
+        let flags = ServiceFlags::COMPACT_FILTERS;
+
+        // No match on empty pool
+        assert!(pool.peer_with_service(flags).await.is_none());
+
+        // No match when peers lack the requested flag
+        let addr1: SocketAddr = "127.0.0.1:1001".parse().unwrap();
+        pool.insert_peer_with_services(addr1, ServiceFlags::NETWORK).await;
+        assert!(pool.peer_with_service(flags).await.is_none());
+
+        // Returns the matching peer with correct address and services
+        let addr2: SocketAddr = "127.0.0.1:1002".parse().unwrap();
+        pool.insert_peer_with_services(addr2, ServiceFlags::NETWORK | flags).await;
+        let (found_addr, found_peer) = pool.peer_with_service(flags).await.unwrap();
+        assert_eq!(found_addr, addr2);
+        assert!(found_peer.read().await.has_service(flags));
+    }
+
+    #[tokio::test]
+    async fn test_peers_with_service() {
+        let pool = PeerPool::new();
+        let flags = ServiceFlags::COMPACT_FILTERS;
+
+        // Empty on empty pool
+        assert!(pool.peers_with_service(flags).await.is_empty());
+
+        // Empty when no peer has the flag
+        let addr1: SocketAddr = "127.0.0.1:1001".parse().unwrap();
+        pool.insert_peer_with_services(addr1, ServiceFlags::NETWORK).await;
+        assert!(pool.peers_with_service(flags).await.is_empty());
+
+        // Returns all matching peers, skips non-matching
+        let addr2: SocketAddr = "127.0.0.1:1002".parse().unwrap();
+        let addr3: SocketAddr = "127.0.0.1:1003".parse().unwrap();
+        pool.insert_peer_with_services(addr2, flags).await;
+        pool.insert_peer_with_services(addr3, ServiceFlags::NETWORK | flags).await;
+
+        let results: HashMap<SocketAddr, _> =
+            pool.peers_with_service(flags).await.into_iter().collect();
+        assert_eq!(results.len(), 2);
+        assert!(results[&addr2].read().await.has_service(flags));
+        assert!(results[&addr3].read().await.has_service(flags));
+    }
+
+    #[tokio::test]
+    async fn test_service_lookup_with_combined_flags() {
+        let pool = PeerPool::new();
+        let combined = ServiceFlags::COMPACT_FILTERS | ServiceFlags::NODE_HEADERS_COMPRESSED;
+
+        // Peer with only one of the two flags does not match combined query
+        let addr1: SocketAddr = "127.0.0.1:1001".parse().unwrap();
+        pool.insert_peer_with_services(addr1, ServiceFlags::COMPACT_FILTERS).await;
+        assert!(pool.peer_with_service(combined).await.is_none());
+        assert!(pool.peers_with_service(combined).await.is_empty());
+
+        // Peer with both flags matches
+        let addr2: SocketAddr = "127.0.0.1:1002".parse().unwrap();
+        pool.insert_peer_with_services(addr2, combined | ServiceFlags::NETWORK).await;
+        let (found, _) = pool.peer_with_service(combined).await.unwrap();
+        assert_eq!(found, addr2);
+
+        let all = pool.peers_with_service(combined).await;
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].0, addr2);
+
+        // Single-flag queries still match both peers appropriately
+        assert!(pool.peer_with_service(ServiceFlags::COMPACT_FILTERS).await.is_some());
+        let cf_peers = pool.peers_with_service(ServiceFlags::COMPACT_FILTERS).await;
+        assert_eq!(cf_peers.len(), 2);
     }
 }

--- a/dash-spv/src/sync/blocks/manager.rs
+++ b/dash-spv/src/sync/blocks/manager.rs
@@ -39,6 +39,8 @@ pub struct BlocksManager<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterf
     pub(super) pipeline: BlocksPipeline,
     /// Whether FiltersSyncComplete has been received.
     pub(super) filters_sync_complete: bool,
+    /// Best known chainlock height for context-aware block processing.
+    pub(super) best_chainlock_height: Option<u32>,
 }
 
 impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H, B, W> {
@@ -60,6 +62,7 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
             wallet,
             pipeline: BlocksPipeline::new(),
             filters_sync_complete: false,
+            best_chainlock_height: None,
         }
     }
 
@@ -84,7 +87,7 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
 
             // Process block through wallet
             let mut wallet = self.wallet.write().await;
-            let result = wallet.process_block(&block, height).await;
+            let result = wallet.process_block(&block, height, self.best_chainlock_height).await;
             drop(wallet);
 
             let total_relevant = result.relevant_tx_count();
@@ -99,6 +102,8 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
                     result.new_addresses.len()
                 );
             }
+
+            let confirmed_txids: Vec<_> = result.relevant_txids().cloned().collect();
 
             // Collect new addresses for gap limit rescanning
             let new_addresses: Vec<_> = result.new_addresses.into_iter().collect();
@@ -122,6 +127,7 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
                 block_hash: hash,
                 height,
                 new_addresses,
+                confirmed_txids,
             });
         }
 
@@ -222,5 +228,50 @@ mod tests {
         // Should queue the block
         assert_eq!(manager.state(), SyncState::Syncing);
         assert!(events.is_empty());
+    }
+
+    use dashcore::ephemerealdata::chain_lock::ChainLock;
+    use dashcore::hashes::Hash;
+
+    fn make_chainlock(height: u32) -> ChainLock {
+        ChainLock {
+            block_height: height,
+            block_hash: dashcore::BlockHash::all_zeros(),
+            signature: [0u8; 96].into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_chainlock_received_updates_height() {
+        let mut manager = create_test_manager().await;
+        let network = MockNetworkManager::new();
+        let requests = network.request_sender();
+
+        assert!(manager.best_chainlock_height.is_none());
+
+        let event = SyncEvent::ChainLockReceived {
+            chain_lock: make_chainlock(500),
+            validated: true,
+        };
+
+        manager.handle_sync_event(&event, &requests).await.unwrap();
+        assert_eq!(manager.best_chainlock_height, Some(500));
+    }
+
+    #[tokio::test]
+    async fn test_chainlock_lower_height_ignored() {
+        let mut manager = create_test_manager().await;
+        let network = MockNetworkManager::new();
+        let requests = network.request_sender();
+
+        manager.best_chainlock_height = Some(500);
+
+        let event = SyncEvent::ChainLockReceived {
+            chain_lock: make_chainlock(300),
+            validated: true,
+        };
+
+        manager.handle_sync_event(&event, &requests).await.unwrap();
+        assert_eq!(manager.best_chainlock_height, Some(500));
     }
 }

--- a/dash-spv/src/sync/blocks/manager.rs
+++ b/dash-spv/src/sync/blocks/manager.rs
@@ -165,12 +165,12 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> std::fmt::Debug
 mod tests {
     use super::*;
     use crate::network::{MessageType, NetworkManager};
-    use dashcore::BlockHash;
     use crate::storage::{
         DiskStorageManager, PersistentBlockHeaderStorage, PersistentBlockStorage, StorageManager,
     };
     use crate::sync::{ManagerIdentifier, SyncEvent, SyncManagerProgress};
     use crate::test_utils::MockNetworkManager;
+    use dashcore::BlockHash;
     use key_wallet_manager::test_utils::MockWallet;
     use key_wallet_manager::wallet_manager::FilterMatchKey;
     use std::collections::BTreeSet;

--- a/dash-spv/src/sync/blocks/manager.rs
+++ b/dash-spv/src/sync/blocks/manager.rs
@@ -165,6 +165,7 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> std::fmt::Debug
 mod tests {
     use super::*;
     use crate::network::{MessageType, NetworkManager};
+    use dashcore::BlockHash;
     use crate::storage::{
         DiskStorageManager, PersistentBlockHeaderStorage, PersistentBlockStorage, StorageManager,
     };
@@ -236,7 +237,7 @@ mod tests {
     fn make_chainlock(height: u32) -> ChainLock {
         ChainLock {
             block_height: height,
-            block_hash: dashcore::BlockHash::all_zeros(),
+            block_hash: BlockHash::all_zeros(),
             signature: [0u8; 96].into(),
         }
     }

--- a/dash-spv/src/sync/blocks/sync_manager.rs
+++ b/dash-spv/src/sync/blocks/sync_manager.rs
@@ -159,6 +159,18 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface + 'static> SyncM
             return self.process_buffered_blocks().await;
         }
 
+        // Track chainlock height for context-aware block processing
+        if let SyncEvent::ChainLockReceived {
+            chain_lock,
+            ..
+        } = event
+        {
+            let new_height = chain_lock.block_height;
+            if self.best_chainlock_height.map_or(true, |h| new_height > h) {
+                self.best_chainlock_height = Some(new_height);
+            }
+        }
+
         // React to FiltersSyncComplete - filters are done, no more BlocksNeeded events coming
         if let SyncEvent::FiltersSyncComplete {
             ..

--- a/dash-spv/src/sync/chainlock/sync_manager.rs
+++ b/dash-spv/src/sync/chainlock/sync_manager.rs
@@ -58,7 +58,8 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for ChainLockManager
                         "Received {} ChainLock announcements, requesting via getdata",
                         chainlocks_to_request.len()
                     );
-                    requests.request_inventory(chainlocks_to_request.clone())?;
+                    requests
+                        .request_inventory(chainlocks_to_request.clone(), msg.peer_address())?;
 
                     for item in &chainlocks_to_request {
                         if let Inventory::ChainLock(hash) = item {

--- a/dash-spv/src/sync/events.rs
+++ b/dash-spv/src/sync/events.rs
@@ -4,6 +4,7 @@ use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::{Address, BlockHash, Txid};
 use key_wallet_manager::wallet_manager::FilterMatchKey;
 use std::collections::BTreeSet;
+use std::net::SocketAddr;
 
 /// Events that managers can emit and subscribe to.
 ///
@@ -145,6 +146,15 @@ pub enum SyncEvent {
         validated: bool,
     },
 
+    /// Mempool relay activated on a peer.
+    ///
+    /// Emitted by: `MempoolManager`
+    /// Consumed by: External listeners
+    MempoolActivated {
+        /// The peer that mempool relay was activated on.
+        peer: SocketAddr,
+    },
+
     /// Sync has reached the chain tip (all managers idle).
     ///
     /// Emitted on every not-synced to synced transition. Cycle 0 is the
@@ -241,6 +251,11 @@ impl SyncEvent {
                 validated,
             } => {
                 format!("InstantLockReceived(txid={}, validated={})", instant_lock.txid, validated)
+            }
+            SyncEvent::MempoolActivated {
+                peer,
+            } => {
+                format!("MempoolActivated(peer={})", peer)
             }
             SyncEvent::SyncComplete {
                 header_tip,

--- a/dash-spv/src/sync/events.rs
+++ b/dash-spv/src/sync/events.rs
@@ -1,7 +1,7 @@
 use crate::sync::ManagerIdentifier;
 use dashcore::ephemerealdata::chain_lock::ChainLock;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
-use dashcore::{Address, BlockHash};
+use dashcore::{Address, BlockHash, Txid};
 use key_wallet_manager::wallet_manager::FilterMatchKey;
 use std::collections::BTreeSet;
 
@@ -90,7 +90,8 @@ pub enum SyncEvent {
     /// Block downloaded and processed through wallet.
     ///
     /// Emitted by: `BlocksManager`
-    /// Consumed by: `FiltersManager` (for gap limit rescanning)
+    /// Consumed by: `FiltersManager` (for gap limit rescanning),
+    ///              `MempoolManager` (to remove confirmed txs)
     BlockProcessed {
         /// Hash of the processed block
         block_hash: BlockHash,
@@ -98,6 +99,8 @@ pub enum SyncEvent {
         height: u32,
         /// New addresses discovered from wallet gap limit maintenance
         new_addresses: Vec<Address>,
+        /// Transaction IDs confirmed in this block that are relevant to the wallet
+        confirmed_txids: Vec<Txid>,
     },
 
     /// Masternode state updated to a new height.

--- a/dash-spv/src/sync/filters/pipeline.rs
+++ b/dash-spv/src/sync/filters/pipeline.rs
@@ -785,7 +785,9 @@ mod tests {
 
         // Verify message was sent
         let request = rx.try_recv().unwrap();
-        let NetworkRequest::SendMessage(msg) = request;
+        let NetworkRequest::SendMessage(msg) = request else {
+            panic!("Expected SendMessage variant");
+        };
         if let NetworkMessage::GetCFilters(gcf) = msg {
             assert_eq!(gcf.start_height, 0);
             assert_eq!(gcf.filter_type, 0);

--- a/dash-spv/src/sync/identifier.rs
+++ b/dash-spv/src/sync/identifier.rs
@@ -10,6 +10,7 @@ pub enum ManagerIdentifier {
     Masternode,
     ChainLock,
     InstantSend,
+    Mempool,
 }
 
 impl Display for ManagerIdentifier {
@@ -22,6 +23,7 @@ impl Display for ManagerIdentifier {
             ManagerIdentifier::Masternode => write!(f, "Masternode"),
             ManagerIdentifier::ChainLock => write!(f, "ChainLock"),
             ManagerIdentifier::InstantSend => write!(f, "InstantSend"),
+            ManagerIdentifier::Mempool => write!(f, "Mempool"),
         }
     }
 }
@@ -39,5 +41,6 @@ mod tests {
         assert_eq!(ManagerIdentifier::Masternode.to_string(), "Masternode");
         assert_eq!(ManagerIdentifier::ChainLock.to_string(), "ChainLock");
         assert_eq!(ManagerIdentifier::InstantSend.to_string(), "InstantSend");
+        assert_eq!(ManagerIdentifier::Mempool.to_string(), "Mempool");
     }
 }

--- a/dash-spv/src/sync/instantsend/sync_manager.rs
+++ b/dash-spv/src/sync/instantsend/sync_manager.rs
@@ -49,7 +49,7 @@ impl SyncManager for InstantSendManager {
                         "Received {} InstantSendLock announcements, requesting via getdata",
                         islocks_to_request.len()
                     );
-                    requests.request_inventory(islocks_to_request)?;
+                    requests.request_inventory(islocks_to_request, msg.peer_address())?;
                 }
                 Ok(vec![])
             }

--- a/dash-spv/src/sync/mempool/bloom.rs
+++ b/dash-spv/src/sync/mempool/bloom.rs
@@ -1,0 +1,174 @@
+//! Bloom filter builder for wallet addresses and outpoints.
+//!
+//! Builds BIP37 bloom filters from wallet data for peer-side transaction filtering.
+
+use dashcore::bloom::{BloomError, BloomFilter};
+use dashcore::consensus::Encodable;
+use dashcore::network::message_bloom::{BloomFlags, FilterLoad};
+use dashcore::{Address, OutPoint};
+
+/// Extract the raw hash payload bytes from an address for bloom filter insertion.
+fn address_payload_bytes(addr: &Address) -> Option<Vec<u8>> {
+    match addr.payload() {
+        dashcore::address::Payload::PubkeyHash(hash) => Some(<[u8; 20]>::from(*hash).to_vec()),
+        dashcore::address::Payload::ScriptHash(hash) => Some(<[u8; 20]>::from(*hash).to_vec()),
+        dashcore::address::Payload::WitnessProgram(prog) => {
+            Some(prog.program().as_bytes().to_vec())
+        }
+        _ => {
+            tracing::warn!("skipping unknown address type for bloom filter: {:?}", addr);
+            None
+        }
+    }
+}
+
+/// Build a bloom filter from wallet addresses and outpoints.
+///
+/// Addresses are inserted as their raw hash payload bytes (20-byte hash160
+/// for P2PKH/P2SH). This matches what Dash Core's `CheckScript` extracts as
+/// data pushes from scriptPubKeys.
+///
+/// Outpoints are inserted as consensus-serialized bytes (`txid || vout_le`)
+/// to detect transactions spending our UTXOs.
+pub(super) fn build_wallet_bloom_filter(
+    addresses: &[Address],
+    outpoints: &[OutPoint],
+    false_positive_rate: f64,
+    tweak: u32,
+) -> Result<FilterLoad, BloomError> {
+    let element_count = addresses.len() + outpoints.len();
+    if element_count == 0 {
+        let filter = BloomFilter::new(1, false_positive_rate, tweak, BloomFlags::All)?;
+        return Ok(FilterLoad::from_bloom_filter(&filter));
+    }
+
+    let mut filter =
+        BloomFilter::new(element_count as u32, false_positive_rate, tweak, BloomFlags::All)?;
+
+    for addr in addresses {
+        if let Some(payload) = address_payload_bytes(addr) {
+            filter.insert(&payload);
+        }
+    }
+
+    for outpoint in outpoints {
+        let mut buf = Vec::new();
+        outpoint.consensus_encode(&mut buf).expect("outpoint serialization to vec cannot fail");
+        filter.insert(&buf);
+    }
+
+    Ok(FilterLoad::from_bloom_filter(&filter))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dashcore::hashes::Hash;
+    use dashcore::{Network, Txid};
+
+    #[test]
+    fn test_build_filter_from_addresses() {
+        let addr = Address::dummy(Network::Testnet, 0);
+        let filter_load =
+            build_wallet_bloom_filter(std::slice::from_ref(&addr), &[], 0.0005, 0).unwrap();
+
+        let filter = filter_load.to_bloom_filter().unwrap();
+        assert!(filter.contains(&address_payload_bytes(&addr).unwrap()));
+    }
+
+    #[test]
+    fn test_build_filter_from_outpoints() {
+        let outpoint = OutPoint {
+            txid: Txid::from_byte_array([1u8; 32]),
+            vout: 0,
+        };
+        let filter_load = build_wallet_bloom_filter(&[], &[outpoint], 0.0005, 0).unwrap();
+
+        let filter = filter_load.to_bloom_filter().unwrap();
+        let mut buf = Vec::new();
+        outpoint.consensus_encode(&mut buf).unwrap();
+        assert!(filter.contains(&buf));
+    }
+
+    #[test]
+    fn test_build_filter_mixed() {
+        let addr = Address::dummy(Network::Testnet, 0);
+        let outpoint = OutPoint {
+            txid: Txid::from_byte_array([2u8; 32]),
+            vout: 1,
+        };
+
+        let filter_load =
+            build_wallet_bloom_filter(std::slice::from_ref(&addr), &[outpoint], 0.0005, 42)
+                .unwrap();
+        let filter = filter_load.to_bloom_filter().unwrap();
+
+        assert!(filter.contains(&address_payload_bytes(&addr).unwrap()));
+
+        let mut buf = Vec::new();
+        outpoint.consensus_encode(&mut buf).unwrap();
+        assert!(filter.contains(&buf));
+
+        assert!(!filter.contains(&[0xff; 20]));
+    }
+
+    #[test]
+    fn test_build_filter_empty_inputs() {
+        let filter_load = build_wallet_bloom_filter(&[], &[], 0.0005, 0).unwrap();
+        let filter = filter_load.to_bloom_filter().unwrap();
+        assert!(!filter.contains(&[1, 2, 3]));
+    }
+
+    #[test]
+    fn test_build_filter_flags() {
+        let addr = Address::dummy(Network::Testnet, 0);
+        let filter_load = build_wallet_bloom_filter(&[addr], &[], 0.0005, 0).unwrap();
+        assert_eq!(filter_load.flags, BloomFlags::All);
+    }
+
+    #[test]
+    fn test_build_filter_tweak() {
+        let addr = Address::dummy(Network::Testnet, 0);
+        let filter_load = build_wallet_bloom_filter(&[addr], &[], 0.0005, 12345).unwrap();
+        assert_eq!(filter_load.tweak, 12345);
+    }
+
+    #[test]
+    fn test_unmatched_address_not_in_filter() {
+        let addr1 = Address::dummy(Network::Testnet, 0);
+        let addr2 = Address::dummy(Network::Testnet, 1);
+
+        let filter_load = build_wallet_bloom_filter(&[addr1], &[], 0.0005, 0).unwrap();
+        let filter = filter_load.to_bloom_filter().unwrap();
+
+        assert!(!filter.contains(&address_payload_bytes(&addr2).unwrap()));
+    }
+
+    #[test]
+    fn test_build_filter_rejects_invalid_fp_rates() {
+        let addr = Address::dummy(Network::Testnet, 0);
+        let addrs = std::slice::from_ref(&addr);
+
+        assert!(build_wallet_bloom_filter(addrs, &[], 0.0, 0).is_err());
+        assert!(build_wallet_bloom_filter(addrs, &[], -0.5, 0).is_err());
+        assert!(build_wallet_bloom_filter(addrs, &[], 1.0, 0).is_err());
+        assert!(build_wallet_bloom_filter(addrs, &[], 1.5, 0).is_err());
+    }
+
+    #[test]
+    fn test_build_filter_with_extreme_fp_rates() {
+        let addr = Address::dummy(Network::Testnet, 0);
+        let addrs = std::slice::from_ref(&addr);
+        let payload = address_payload_bytes(&addr).unwrap();
+
+        // Very small rate: produces a larger filter but still works
+        let filter =
+            build_wallet_bloom_filter(addrs, &[], 0.000001, 0).unwrap().to_bloom_filter().unwrap();
+        assert!(filter.contains(&payload));
+
+        // Large rate near upper bound: produces a tiny filter but still works
+        let filter =
+            build_wallet_bloom_filter(addrs, &[], 0.999, 0).unwrap().to_bloom_filter().unwrap();
+        assert!(filter.contains(&payload));
+    }
+}

--- a/dash-spv/src/sync/mempool/bloom.rs
+++ b/dash-spv/src/sync/mempool/bloom.rs
@@ -13,9 +13,7 @@ fn address_payload_bytes(addr: &Address) -> Option<Vec<u8>> {
     match addr.payload() {
         Payload::PubkeyHash(hash) => Some(<[u8; 20]>::from(*hash).to_vec()),
         Payload::ScriptHash(hash) => Some(<[u8; 20]>::from(*hash).to_vec()),
-        Payload::WitnessProgram(prog) => {
-            Some(prog.program().as_bytes().to_vec())
-        }
+        Payload::WitnessProgram(prog) => Some(prog.program().as_bytes().to_vec()),
         _ => {
             tracing::warn!("skipping unknown address type for bloom filter: {:?}", addr);
             None
@@ -102,8 +100,7 @@ mod tests {
         };
 
         let filter_load =
-            build_wallet_bloom_filter(slice::from_ref(&addr), &[outpoint], 0.0005, 42)
-                .unwrap();
+            build_wallet_bloom_filter(slice::from_ref(&addr), &[outpoint], 0.0005, 42).unwrap();
         let filter = filter_load.to_bloom_filter().unwrap();
 
         assert!(filter.contains(&address_payload_bytes(&addr).unwrap()));

--- a/dash-spv/src/sync/mempool/bloom.rs
+++ b/dash-spv/src/sync/mempool/bloom.rs
@@ -2,6 +2,7 @@
 //!
 //! Builds BIP37 bloom filters from wallet data for peer-side transaction filtering.
 
+use dashcore::address::Payload;
 use dashcore::bloom::{BloomError, BloomFilter};
 use dashcore::consensus::Encodable;
 use dashcore::network::message_bloom::{BloomFlags, FilterLoad};
@@ -10,9 +11,9 @@ use dashcore::{Address, OutPoint};
 /// Extract the raw hash payload bytes from an address for bloom filter insertion.
 fn address_payload_bytes(addr: &Address) -> Option<Vec<u8>> {
     match addr.payload() {
-        dashcore::address::Payload::PubkeyHash(hash) => Some(<[u8; 20]>::from(*hash).to_vec()),
-        dashcore::address::Payload::ScriptHash(hash) => Some(<[u8; 20]>::from(*hash).to_vec()),
-        dashcore::address::Payload::WitnessProgram(prog) => {
+        Payload::PubkeyHash(hash) => Some(<[u8; 20]>::from(*hash).to_vec()),
+        Payload::ScriptHash(hash) => Some(<[u8; 20]>::from(*hash).to_vec()),
+        Payload::WitnessProgram(prog) => {
             Some(prog.program().as_bytes().to_vec())
         }
         _ => {
@@ -62,6 +63,8 @@ pub(super) fn build_wallet_bloom_filter(
 
 #[cfg(test)]
 mod tests {
+    use std::slice;
+
     use super::*;
     use dashcore::hashes::Hash;
     use dashcore::{Network, Txid};
@@ -70,7 +73,7 @@ mod tests {
     fn test_build_filter_from_addresses() {
         let addr = Address::dummy(Network::Testnet, 0);
         let filter_load =
-            build_wallet_bloom_filter(std::slice::from_ref(&addr), &[], 0.0005, 0).unwrap();
+            build_wallet_bloom_filter(slice::from_ref(&addr), &[], 0.0005, 0).unwrap();
 
         let filter = filter_load.to_bloom_filter().unwrap();
         assert!(filter.contains(&address_payload_bytes(&addr).unwrap()));
@@ -99,7 +102,7 @@ mod tests {
         };
 
         let filter_load =
-            build_wallet_bloom_filter(std::slice::from_ref(&addr), &[outpoint], 0.0005, 42)
+            build_wallet_bloom_filter(slice::from_ref(&addr), &[outpoint], 0.0005, 42)
                 .unwrap();
         let filter = filter_load.to_bloom_filter().unwrap();
 
@@ -147,7 +150,7 @@ mod tests {
     #[test]
     fn test_build_filter_rejects_invalid_fp_rates() {
         let addr = Address::dummy(Network::Testnet, 0);
-        let addrs = std::slice::from_ref(&addr);
+        let addrs = slice::from_ref(&addr);
 
         assert!(build_wallet_bloom_filter(addrs, &[], 0.0, 0).is_err());
         assert!(build_wallet_bloom_filter(addrs, &[], -0.5, 0).is_err());
@@ -158,7 +161,7 @@ mod tests {
     #[test]
     fn test_build_filter_with_extreme_fp_rates() {
         let addr = Address::dummy(Network::Testnet, 0);
-        let addrs = std::slice::from_ref(&addr);
+        let addrs = slice::from_ref(&addr);
         let payload = address_payload_bytes(&addr).unwrap();
 
         // Very small rate: produces a larger filter but still works

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -1,0 +1,1595 @@
+//! Mempool manager for monitoring unconfirmed transactions.
+//!
+//! Activates after initial sync is complete and uses either BIP37 bloom
+//! filters or local address matching to identify wallet-relevant
+//! transactions from the mempool.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashcore::network::message_blockdata::Inventory;
+use dashcore::Txid;
+use rand::seq::IteratorRandom;
+use tokio::sync::RwLock;
+
+use super::bloom::build_wallet_bloom_filter;
+use crate::client::config::MempoolStrategy;
+use crate::error::{SyncError, SyncResult};
+use crate::network::RequestSender;
+use crate::sync::mempool::MempoolProgress;
+use crate::sync::SyncEvent;
+use crate::types::{MempoolState, UnconfirmedTransaction};
+use key_wallet_manager::wallet_interface::WalletInterface;
+
+/// Timeout for pruning expired mempool transactions (24 hours).
+const MEMPOOL_TX_EXPIRY: Duration = Duration::from_secs(24 * 3600);
+
+/// Timeout for pending getdata requests that never received a response.
+const PENDING_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Maximum number of in-flight getdata requests.
+const MAX_IN_FLIGHT: usize = 100;
+
+/// Bloom filter false positive rate for BIP37 mempool filtering.
+// TODO: expose via config, e.g. as a privacy level enum (low/medium/high) instead of a raw f64
+const BLOOM_FALSE_POSITIVE_RATE: f64 = 0.0005;
+
+/// Timeout for activation retry. If no inventory is received within this
+/// duration after activation, the mempool manager re-attempts activation.
+const ACTIVATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Mempool manager that monitors unconfirmed transactions from the P2P network.
+pub struct MempoolManager<W: WalletInterface> {
+    pub(super) progress: MempoolProgress,
+    pub(super) wallet: Arc<RwLock<W>>,
+    pub(super) mempool_state: Arc<RwLock<MempoolState>>,
+    strategy: MempoolStrategy,
+    max_transactions: usize,
+    /// Txids we have requested via getdata but not yet received, with request time.
+    pending_requests: HashMap<Txid, Instant>,
+    /// Txids waiting to be sent via getdata, grouped by the peer that announced them.
+    queued: HashMap<SocketAddr, VecDeque<Txid>>,
+    /// Whether a bloom filter is currently loaded on the peer.
+    filter_loaded: bool,
+    /// Address count when current filter was built (for staleness detection).
+    filter_address_count: usize,
+    /// Outpoint count when current filter was built (for staleness detection).
+    filter_outpoint_count: usize,
+    /// Whether the bloom filter needs rebuilding (set when new addresses are generated).
+    needs_filter_rebuild: bool,
+    /// Timestamp when activation was last attempted. Used to detect activation
+    /// failures: if no inventory response arrives within the timeout, activation
+    /// is retried. Cleared when the first inventory message is received.
+    activated_at: Option<Instant>,
+    /// IS lock txids that arrived before their corresponding transaction.
+    pending_is_locks: HashSet<Txid>,
+}
+
+impl<W: WalletInterface> MempoolManager<W> {
+    /// Creates a new mempool manager with the given wallet, shared mempool state,
+    /// bloom filter strategy, and transaction capacity limit.
+    pub(crate) fn new(
+        wallet: Arc<RwLock<W>>,
+        mempool_state: Arc<RwLock<MempoolState>>,
+        strategy: MempoolStrategy,
+        max_transactions: usize,
+    ) -> Self {
+        Self {
+            progress: MempoolProgress::default(),
+            wallet,
+            mempool_state,
+            strategy,
+            max_transactions,
+            pending_requests: HashMap::new(),
+            queued: HashMap::new(),
+            filter_loaded: false,
+            filter_address_count: 0,
+            filter_outpoint_count: 0,
+            needs_filter_rebuild: false,
+            activated_at: None,
+            pending_is_locks: HashSet::new(),
+        }
+    }
+
+    /// Activate mempool monitoring after sync is complete.
+    ///
+    /// For BloomFilter strategy: builds and sends a bloom filter, then sends `mempool`.
+    /// For FetchAll strategy: just sends `mempool`.
+    ///
+    /// Sets `activated_at` so that `needs_activation_retry()` can detect
+    /// activation failures if no inventory response arrives within the timeout.
+    pub(super) async fn activate(&mut self, requests: &RequestSender) -> SyncResult<()> {
+        tracing::info!("Activating mempool manager (strategy: {:?})", self.strategy);
+
+        if self.strategy == MempoolStrategy::BloomFilter {
+            self.load_bloom_filter(requests).await?;
+        }
+
+        // Request current mempool inventory
+        requests.request_mempool()?;
+
+        self.activated_at = Some(Instant::now());
+        Ok(())
+    }
+
+    /// Whether activation needs to be retried. Returns true if activation was
+    /// attempted but no inventory response arrived within the timeout.
+    pub(super) fn needs_activation_retry(&self) -> bool {
+        self.activated_at.is_some_and(|t| t.elapsed() >= ACTIVATION_TIMEOUT)
+    }
+
+    /// Build and send a bloom filter to the peer.
+    async fn load_bloom_filter(&mut self, requests: &RequestSender) -> SyncResult<()> {
+        let wallet = self.wallet.read().await;
+        let addresses = wallet.monitored_addresses();
+        let outpoints = wallet.watched_outpoints();
+        drop(wallet);
+
+        if addresses.is_empty() && outpoints.is_empty() {
+            tracing::debug!("No addresses or outpoints to build bloom filter from");
+            return Ok(());
+        }
+
+        match build_wallet_bloom_filter(
+            &addresses,
+            &outpoints,
+            BLOOM_FALSE_POSITIVE_RATE,
+            rand::random(),
+        ) {
+            Ok(filter_load) => {
+                tracing::info!(
+                    "Built bloom filter with {} addresses and {} outpoints (fp_rate={}, size={}B)",
+                    addresses.len(),
+                    outpoints.len(),
+                    BLOOM_FALSE_POSITIVE_RATE,
+                    filter_load.filter.len()
+                );
+
+                requests.send_filter_load(filter_load)?;
+
+                self.filter_loaded = true;
+                self.filter_address_count = addresses.len();
+                self.filter_outpoint_count = outpoints.len();
+            }
+            Err(e) => {
+                return Err(SyncError::InvalidState(format!(
+                    "bloom filter construction failed: {}",
+                    e
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Rebuild the bloom filter (e.g., after new addresses are generated).
+    pub(super) async fn rebuild_filter(&mut self, requests: &RequestSender) -> SyncResult<()> {
+        if self.strategy != MempoolStrategy::BloomFilter {
+            return Ok(());
+        }
+
+        // Clear the old filter first
+        if self.filter_loaded {
+            if let Err(e) = requests.send_filter_clear() {
+                tracing::warn!("Failed to send filter clear: {}", e);
+            }
+            self.filter_loaded = false;
+        }
+
+        // Build and load a new filter
+        self.load_bloom_filter(requests).await?;
+
+        // Re-request mempool with updated filter
+        requests.request_mempool()?;
+
+        Ok(())
+    }
+
+    /// Handle incoming inventory announcements.
+    ///
+    /// Filters for new transaction txids and enqueues them. The actual getdata
+    /// requests are sent by `send_queued()`, respecting the in-flight limit.
+    pub(super) fn handle_inv(
+        &mut self,
+        inv: &[Inventory],
+        peer: SocketAddr,
+        requests: &RequestSender,
+    ) -> SyncResult<Vec<SyncEvent>> {
+        // Inventory received, activation confirmed
+        self.activated_at = None;
+
+        let mempool_full = self
+            .mempool_state
+            .try_read()
+            .is_ok_and(|state| state.transactions.len() >= self.max_transactions);
+        if mempool_full {
+            return Ok(vec![]);
+        }
+
+        let total_queued: usize = self.queued.values().map(|q| q.len()).sum();
+        let mut enqueued = 0;
+        for item in inv {
+            let Inventory::Transaction(txid) = item else {
+                continue;
+            };
+            if self.pending_requests.contains_key(txid)
+                || self.is_queued(txid)
+                || self
+                    .mempool_state
+                    .try_read()
+                    .is_ok_and(|state| state.transactions.contains_key(txid))
+            {
+                continue;
+            }
+            if self.pending_requests.len() + total_queued + enqueued >= self.max_transactions {
+                break;
+            }
+            self.queued.entry(peer).or_default().push_back(*txid);
+            enqueued += 1;
+        }
+
+        if enqueued > 0 {
+            tracing::debug!("Enqueued {} mempool txids for download", enqueued);
+            self.send_queued(requests)?;
+        }
+
+        Ok(vec![])
+    }
+
+    /// Drain per-peer queues and send getdata for up to `MAX_IN_FLIGHT` items.
+    ///
+    /// Deduplicates at send time against `pending_requests` and `mempool_state`
+    /// in case a transaction was received between enqueue and send.
+    pub(super) fn send_queued(&mut self, requests: &RequestSender) -> SyncResult<()> {
+        let mut available = MAX_IN_FLIGHT.saturating_sub(self.pending_requests.len());
+        if available == 0 || self.queued.is_empty() {
+            return Ok(());
+        }
+
+        let now = Instant::now();
+        let mut per_peer: HashMap<SocketAddr, Vec<Inventory>> = HashMap::new();
+
+        let peers: Vec<SocketAddr> = self.queued.keys().copied().collect();
+        for peer in peers {
+            if available == 0 {
+                break;
+            }
+            let Some(queue) = self.queued.get_mut(&peer) else {
+                continue;
+            };
+            while available > 0 {
+                let Some(txid) = queue.pop_front() else {
+                    break;
+                };
+                if self.pending_requests.contains_key(&txid)
+                    || self
+                        .mempool_state
+                        .try_read()
+                        .is_ok_and(|state| state.transactions.contains_key(&txid))
+                {
+                    continue;
+                }
+                self.pending_requests.insert(txid, now);
+                per_peer.entry(peer).or_default().push(Inventory::Transaction(txid));
+                available -= 1;
+            }
+        }
+
+        // Remove empty queues
+        self.queued.retain(|_, q| !q.is_empty());
+
+        let total_queued: usize = self.queued.values().map(|q| q.len()).sum();
+        for (peer, inventory) in per_peer {
+            if inventory.is_empty() {
+                continue;
+            }
+            tracing::debug!(
+                "Requesting {} mempool transactions via getdata from {} ({} still queued)",
+                inventory.len(),
+                peer,
+                total_queued,
+            );
+            requests.request_inventory(inventory, peer)?;
+        }
+        Ok(())
+    }
+
+    /// Handle a received transaction.
+    pub(super) async fn handle_tx(
+        &mut self,
+        tx: dashcore::Transaction,
+    ) -> SyncResult<Vec<SyncEvent>> {
+        let txid = tx.txid();
+        self.pending_requests.remove(&txid);
+        self.progress.add_received(1);
+
+        // Check for a pre-arrived IS lock before wallet processing consumes it
+        let is_locked = self.pending_is_locks.remove(&txid);
+
+        let result = {
+            let mut wallet = self.wallet.write().await;
+            wallet.process_mempool_transaction(&tx, is_locked).await
+        };
+
+        if !result.is_relevant {
+            return Ok(vec![]);
+        }
+
+        self.progress.add_relevant(1);
+        tracing::info!("Wallet-relevant mempool transaction: {}", txid);
+
+        // Build and store the unconfirmed transaction.
+        // The wallet already confirmed relevance, so we store unconditionally.
+        let unconfirmed_tx = UnconfirmedTransaction::new(
+            tx,
+            dashcore::Amount::ZERO,
+            is_locked,
+            result.is_outgoing,
+            result.addresses,
+            result.net_amount,
+        );
+        {
+            let mut state = self.mempool_state.write().await;
+            state.add_transaction(unconfirmed_tx);
+            self.progress.set_tracked(state.transactions.len() as u32);
+        }
+
+        // Flag filter rebuild if new addresses were generated
+        if !result.new_addresses.is_empty() {
+            tracing::info!(
+                "Wallet generated {} new addresses from mempool tx, filter rebuild needed",
+                result.new_addresses.len()
+            );
+            self.needs_filter_rebuild = true;
+        }
+
+        Ok(vec![])
+    }
+
+    /// Remove confirmed transactions from mempool state and notify the wallet.
+    pub(super) async fn remove_confirmed(&mut self, txids: &[Txid]) {
+        let mut removed = Vec::new();
+        {
+            let mut state = self.mempool_state.write().await;
+            for txid in txids {
+                if state.remove_transaction(txid).is_some() {
+                    removed.push(*txid);
+                }
+            }
+            if !removed.is_empty() {
+                self.progress.add_removed(removed.len() as u32);
+                self.progress.set_tracked(state.transactions.len() as u32);
+                tracing::debug!("Removed {} confirmed transactions from mempool", removed.len());
+            }
+        }
+    }
+
+    /// Mark a mempool transaction as InstantSend-locked and notify the wallet.
+    ///
+    /// If the transaction hasn't arrived yet, remembers the txid so the lock
+    /// can be applied when the transaction is later received via `handle_tx`.
+    pub(super) async fn mark_instant_send(&mut self, txid: &Txid) {
+        let mut state = self.mempool_state.write().await;
+        let marked = if let Some(tx) = state.transactions.get_mut(txid) {
+            tx.is_instant_send = true;
+            tracing::debug!("Marked mempool tx {} as InstantSend-locked", txid);
+            true
+        } else {
+            self.pending_is_locks.insert(*txid);
+            tracing::debug!("IS lock arrived before tx {}, remembering for later", txid);
+            false
+        };
+        drop(state);
+        if marked {
+            let mut wallet = self.wallet.write().await;
+            wallet.process_instant_send_lock(*txid);
+        }
+    }
+
+    /// Forward a chainlock notification to the wallet for retroactive status updates.
+    pub(super) async fn forward_chainlock(&mut self, height: u32) {
+        let mut wallet = self.wallet.write().await;
+        wallet.process_chainlock(height);
+    }
+
+    /// Prune expired transactions and their pending IS locks from mempool state.
+    pub(super) async fn prune_expired(&mut self) {
+        let mut state = self.mempool_state.write().await;
+        let pruned = state.prune_expired(MEMPOOL_TX_EXPIRY);
+        if !pruned.is_empty() {
+            self.progress.add_removed(pruned.len() as u32);
+            self.progress.set_tracked(state.transactions.len() as u32);
+            tracing::debug!("Pruned {} expired mempool transactions", pruned.len());
+            for txid in &pruned {
+                self.pending_is_locks.remove(txid);
+            }
+        }
+    }
+
+    fn is_queued(&self, txid: &Txid) -> bool {
+        self.queued.values().any(|q| q.contains(txid))
+    }
+
+    /// Register a newly connected peer so it can receive getdata requests.
+    pub(super) fn handle_peer_connected(&mut self, peer: SocketAddr) {
+        self.queued.entry(peer).or_default();
+    }
+
+    /// Remove a disconnected peer's queue, redistributing its txids to another peer.
+    pub(super) fn handle_peer_disconnected(&mut self, peer: SocketAddr) {
+        if let Some(orphaned) = self.queued.remove(&peer) {
+            if orphaned.is_empty() {
+                return;
+            }
+            if let Some(queue) = self.queued.values_mut().choose(&mut rand::thread_rng()) {
+                queue.extend(orphaned);
+            }
+        }
+    }
+
+    /// Clear pending requests, queued txids, pending IS locks, and reset filter state on disconnect.
+    pub(super) fn clear_pending(&mut self) {
+        self.pending_requests.clear();
+        self.queued.clear();
+        self.pending_is_locks.clear();
+        self.filter_loaded = false;
+    }
+
+    /// Remove pending requests that have timed out without receiving a response.
+    /// Timed-out txids are re-queued to any connected peer for retry.
+    pub(super) fn prune_pending_requests(&mut self) {
+        let mut timed_out = Vec::new();
+        self.pending_requests.retain(|txid, requested_at| {
+            if requested_at.elapsed() >= PENDING_REQUEST_TIMEOUT {
+                timed_out.push(*txid);
+                false
+            } else {
+                true
+            }
+        });
+        if timed_out.is_empty() {
+            return;
+        }
+        tracing::debug!("Pruned {} timed-out pending requests, re-queuing", timed_out.len());
+        if let Some(queue) = self.queued.values_mut().choose(&mut rand::thread_rng()) {
+            queue.extend(timed_out);
+        }
+    }
+
+    /// Check if the bloom filter needs rebuilding due to new wallet addresses.
+    pub(super) async fn check_filter_staleness(&mut self, requests: &RequestSender) {
+        if self.strategy != MempoolStrategy::BloomFilter || !self.filter_loaded {
+            return;
+        }
+
+        let needs_rebuild = if self.needs_filter_rebuild {
+            true
+        } else {
+            let wallet = self.wallet.read().await;
+            wallet.monitored_addresses().len() != self.filter_address_count
+                || wallet.watched_outpoints().len() != self.filter_outpoint_count
+        };
+
+        if needs_rebuild {
+            tracing::info!("Bloom filter stale, rebuilding");
+            self.needs_filter_rebuild = false;
+            let _ = self.rebuild_filter(requests).await;
+        }
+    }
+}
+
+impl<W: WalletInterface> std::fmt::Debug for MempoolManager<W> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MempoolManager")
+            .field("progress", &self.progress)
+            .field("strategy", &self.strategy)
+            .field("pending_requests", &self.pending_requests.len())
+            .field("queued", &self.queued.values().map(|q| q.len()).sum::<usize>())
+            .field("filter_loaded", &self.filter_loaded)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::NetworkRequest;
+    use dashcore::hashes::Hash;
+    use dashcore::network::message::NetworkMessage;
+    use dashcore::{Address, Network, OutPoint, ScriptBuf, Transaction};
+    use key_wallet::transaction_checking::TransactionContext;
+    use key_wallet_manager::test_utils::MockWallet;
+
+    use crate::test_utils::test_socket_address;
+    use tokio::sync::mpsc;
+
+    fn create_test_manager(
+    ) -> (MempoolManager<MockWallet>, RequestSender, mpsc::UnboundedReceiver<NetworkRequest>) {
+        let wallet = Arc::new(RwLock::new(MockWallet::new()));
+        let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
+        let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let requests = RequestSender::new(tx);
+
+        let manager = MempoolManager::new(wallet, mempool_state, MempoolStrategy::FetchAll, 1000);
+
+        (manager, requests, rx)
+    }
+
+    fn create_bloom_manager(
+    ) -> (MempoolManager<MockWallet>, RequestSender, mpsc::UnboundedReceiver<NetworkRequest>) {
+        let wallet = Arc::new(RwLock::new(MockWallet::new()));
+        let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
+        let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let requests = RequestSender::new(tx);
+
+        let manager =
+            MempoolManager::new(wallet, mempool_state, MempoolStrategy::BloomFilter, 1000);
+
+        (manager, requests, rx)
+    }
+
+    #[tokio::test]
+    async fn test_activation_fetch_all() {
+        let (mut manager, requests, _rx) = create_test_manager();
+        manager.activate(&requests).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_activation_bloom_filter() {
+        let (mut manager, requests, _rx) = create_bloom_manager();
+        manager.activate(&requests).await.unwrap();
+        // No addresses in mock wallet, so filter should not be loaded
+        assert!(!manager.filter_loaded);
+    }
+
+    #[tokio::test]
+    async fn test_handle_inv_deduplication() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        let txid = Txid::from_byte_array([1u8; 32]);
+        let inv = vec![Inventory::Transaction(txid)];
+
+        // First call should add to pending
+        let events = manager.handle_inv(&inv, test_socket_address(1), &requests).unwrap();
+        assert!(events.is_empty());
+        assert!(manager.pending_requests.contains_key(&txid));
+
+        // Second call with same txid should be filtered out
+        let events = manager.handle_inv(&inv, test_socket_address(1), &requests).unwrap();
+        assert!(events.is_empty());
+        assert_eq!(manager.pending_requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_handle_inv_capacity_limit() {
+        let wallet = Arc::new(RwLock::new(MockWallet::new()));
+        let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
+        let (tx, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let requests = RequestSender::new(tx);
+
+        let mut manager = MempoolManager::new(
+            wallet,
+            mempool_state.clone(),
+            MempoolStrategy::FetchAll,
+            2, // Very small capacity
+        );
+
+        // Fill mempool to capacity
+        {
+            let mut state = mempool_state.write().await;
+            for i in 0..2u32 {
+                let tx = Transaction {
+                    version: 1,
+                    lock_time: i,
+                    input: vec![],
+                    output: vec![],
+                    special_transaction_payload: None,
+                };
+                state.add_transaction(UnconfirmedTransaction::new(
+                    tx,
+                    dashcore::Amount::from_sat(0),
+                    false,
+                    false,
+                    Vec::new(),
+                    0,
+                ));
+            }
+        }
+
+        // New transactions should be filtered out
+        let new_txid = Txid::from_byte_array([99u8; 32]);
+        let inv = vec![Inventory::Transaction(new_txid)];
+        let events = manager.handle_inv(&inv, test_socket_address(1), &requests).unwrap();
+        assert!(events.is_empty());
+        assert!(!manager.pending_requests.contains_key(&new_txid));
+    }
+
+    #[tokio::test]
+    async fn test_handle_inv_pending_requests_limit() {
+        let wallet = Arc::new(RwLock::new(MockWallet::new()));
+        let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
+        let (tx, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let requests = RequestSender::new(tx);
+
+        let mut manager = MempoolManager::new(wallet, mempool_state, MempoolStrategy::FetchAll, 2);
+
+        // Fill pending requests to capacity
+        let inv1: Vec<Inventory> =
+            (0..2).map(|i| Inventory::Transaction(Txid::from_byte_array([i; 32]))).collect();
+        manager.handle_inv(&inv1, test_socket_address(1), &requests).unwrap();
+        assert_eq!(manager.pending_requests.len(), 2);
+
+        // Additional requests should be rejected when pending is at capacity
+        let extra_txid = Txid::from_byte_array([99; 32]);
+        let inv2 = vec![Inventory::Transaction(extra_txid)];
+        manager.handle_inv(&inv2, test_socket_address(1), &requests).unwrap();
+        assert!(!manager.pending_requests.contains_key(&extra_txid));
+    }
+
+    #[test]
+    fn test_prune_pending_requests_timeout() {
+        let wallet = Arc::new(RwLock::new(MockWallet::new()));
+        let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
+        let (tx, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let _requests = RequestSender::new(tx);
+
+        let mut manager =
+            MempoolManager::new(wallet, mempool_state, MempoolStrategy::FetchAll, 1000);
+
+        let fresh_txid = Txid::from_byte_array([1; 32]);
+        let stale_txid = Txid::from_byte_array([2; 32]);
+
+        manager.pending_requests.insert(fresh_txid, Instant::now());
+        manager
+            .pending_requests
+            .insert(stale_txid, Instant::now() - PENDING_REQUEST_TIMEOUT - Duration::from_secs(1));
+
+        manager.prune_pending_requests();
+
+        assert!(manager.pending_requests.contains_key(&fresh_txid));
+        assert!(!manager.pending_requests.contains_key(&stale_txid));
+    }
+
+    #[tokio::test]
+    async fn test_handle_tx_irrelevant() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+
+        let events = manager.handle_tx(tx).await.unwrap();
+        // MockWallet returns is_relevant=false by default
+        assert!(events.is_empty());
+        assert_eq!(manager.progress.received(), 1);
+
+        // Irrelevant tx should not be stored in mempool state
+        let state = manager.mempool_state.read().await;
+        assert!(!state.transactions.contains_key(&txid));
+        assert_eq!(manager.progress.relevant(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_remove_confirmed() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        // Add a transaction to mempool state
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+        {
+            let mut state = manager.mempool_state.write().await;
+            state.add_transaction(UnconfirmedTransaction::new(
+                tx,
+                dashcore::Amount::from_sat(0),
+                false,
+                false,
+                Vec::new(),
+                0,
+            ));
+        }
+
+        manager.remove_confirmed(&[txid]).await;
+
+        let state = manager.mempool_state.read().await;
+        assert!(!state.transactions.contains_key(&txid));
+        assert_eq!(manager.progress.removed(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mark_instant_send() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+        {
+            let mut state = manager.mempool_state.write().await;
+            state.add_transaction(UnconfirmedTransaction::new(
+                tx,
+                dashcore::Amount::from_sat(0),
+                false,
+                false,
+                Vec::new(),
+                0,
+            ));
+        }
+
+        manager.mark_instant_send(&txid).await;
+
+        let state = manager.mempool_state.read().await;
+        assert!(state.transactions.get(&txid).unwrap().is_instant_send);
+    }
+
+    #[tokio::test]
+    async fn test_handle_inv_non_transaction_filtered() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        let inv = vec![
+            Inventory::Block(dashcore::BlockHash::all_zeros()),
+            Inventory::Transaction(Txid::from_byte_array([1u8; 32])),
+        ];
+
+        let events = manager.handle_inv(&inv, test_socket_address(1), &requests).unwrap();
+        assert!(events.is_empty());
+        // Only the transaction should be tracked, not the block
+        assert_eq!(manager.pending_requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_prune_expired() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        // Add a transaction to mempool state
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        {
+            let mut state = manager.mempool_state.write().await;
+            state.add_transaction(UnconfirmedTransaction::new(
+                tx,
+                dashcore::Amount::from_sat(0),
+                false,
+                false,
+                Vec::new(),
+                0,
+            ));
+        }
+
+        // Prune should not remove fresh transactions
+        manager.prune_expired().await;
+        let state = manager.mempool_state.read().await;
+        assert_eq!(state.transactions.len(), 1);
+    }
+
+    /// Create a manager with BloomFilter strategy where the wallet reports
+    /// mempool transactions as relevant. BloomFilter strategy skips local
+    /// address pre-filtering, relying on the wallet for definitive checks.
+    fn create_relevant_manager(
+    ) -> (MempoolManager<MockWallet>, RequestSender, Arc<RwLock<MockWallet>>) {
+        let mut mock = MockWallet::new();
+        mock.set_mempool_relevant(true);
+        let wallet = Arc::new(RwLock::new(mock));
+        let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
+        let (tx, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let requests = RequestSender::new(tx);
+
+        let manager =
+            MempoolManager::new(wallet.clone(), mempool_state, MempoolStrategy::BloomFilter, 1000);
+
+        (manager, requests, wallet)
+    }
+
+    #[tokio::test]
+    async fn test_handle_tx_relevant_emits_event() {
+        let (mut manager, _requests, _wallet) = create_relevant_manager();
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+
+        let events = manager.handle_tx(tx).await.unwrap();
+        assert!(events.is_empty());
+
+        // Verify transaction was stored in mempool state
+        let state = manager.mempool_state.read().await;
+        assert!(state.transactions.contains_key(&txid));
+        assert_eq!(manager.progress.received(), 1);
+        assert_eq!(manager.progress.relevant(), 1);
+        assert_eq!(manager.progress.tracked(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_handle_tx_clears_pending_request() {
+        let (mut manager, _requests, _wallet) = create_relevant_manager();
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+
+        // Simulate that we requested this transaction
+        manager.pending_requests.insert(txid, Instant::now());
+        assert!(manager.pending_requests.contains_key(&txid));
+
+        manager.handle_tx(tx).await.unwrap();
+        // Pending request should be cleared regardless of relevance
+        assert!(!manager.pending_requests.contains_key(&txid));
+
+        // Since the manager uses BloomFilter strategy (relevant mock), tx should be stored
+        let state = manager.mempool_state.read().await;
+        assert!(state.transactions.contains_key(&txid));
+    }
+
+    fn create_bloom_manager_with_addresses(
+        addresses: Vec<Address>,
+    ) -> (
+        MempoolManager<MockWallet>,
+        RequestSender,
+        tokio::sync::mpsc::UnboundedReceiver<NetworkRequest>,
+    ) {
+        let mut mock = MockWallet::new();
+        mock.set_addresses(addresses);
+        let wallet = Arc::new(RwLock::new(mock));
+        let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
+        let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let requests = RequestSender::new(tx);
+
+        let manager =
+            MempoolManager::new(wallet, mempool_state, MempoolStrategy::BloomFilter, 1000);
+
+        (manager, requests, rx)
+    }
+
+    /// Create a test P2PKH address from a byte pattern.
+    fn test_address(byte: u8) -> Address {
+        // Build OP_DUP OP_HASH160 <20-byte-hash> OP_EQUALVERIFY OP_CHECKSIG
+        let mut script_bytes = vec![0x76, 0xa9, 0x14]; // OP_DUP OP_HASH160 PUSH20
+        script_bytes.extend_from_slice(&[byte; 20]);
+        script_bytes.push(0x88); // OP_EQUALVERIFY
+        script_bytes.push(0xac); // OP_CHECKSIG
+        let script = ScriptBuf::from(script_bytes);
+        Address::from_script(&script, Network::Testnet).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_bloom_filter_loaded_with_addresses() {
+        let addr = test_address(0xab);
+
+        let (mut manager, requests, _rx) = create_bloom_manager_with_addresses(vec![addr]);
+        manager.activate(&requests).await.unwrap();
+
+        assert!(manager.filter_loaded);
+        assert_eq!(manager.filter_address_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_check_filter_staleness_no_change() {
+        let addr = test_address(0xab);
+
+        let (mut manager, requests, _rx) = create_bloom_manager_with_addresses(vec![addr]);
+        manager.activate(&requests).await.unwrap();
+        assert!(manager.filter_loaded);
+
+        // Address count hasn't changed, so staleness check should be a no-op
+        manager.check_filter_staleness(&requests).await;
+        assert!(manager.filter_loaded);
+        assert_eq!(manager.filter_address_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_check_filter_staleness_detects_change() {
+        let addr1 = test_address(0xab);
+
+        let (mut manager, requests, _rx) = create_bloom_manager_with_addresses(vec![addr1.clone()]);
+        manager.activate(&requests).await.unwrap();
+        assert_eq!(manager.filter_address_count, 1);
+
+        // Simulate wallet generating a new address
+        let addr2 = test_address(0xcd);
+        {
+            let mut wallet = manager.wallet.write().await;
+            wallet.set_addresses(vec![addr1, addr2]);
+        }
+
+        // Staleness check should detect the change and rebuild
+        manager.check_filter_staleness(&requests).await;
+        assert!(manager.filter_loaded);
+        assert_eq!(manager.filter_address_count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_check_filter_staleness_detects_outpoint_change() {
+        let addr = test_address(0xab);
+
+        let (mut manager, requests, mut rx) = create_bloom_manager_with_addresses(vec![addr]);
+        manager.activate(&requests).await.unwrap();
+        assert_eq!(manager.filter_outpoint_count, 0);
+
+        // Drain messages from activation
+        while rx.try_recv().is_ok() {}
+
+        // Add outpoints without changing addresses
+        let outpoint = OutPoint::new(Txid::from_byte_array([0x01; 32]), 0);
+        {
+            let mut wallet = manager.wallet.write().await;
+            wallet.set_outpoints(vec![outpoint]);
+        }
+
+        // Staleness check should detect the outpoint change and rebuild
+        manager.check_filter_staleness(&requests).await;
+        assert!(manager.filter_loaded);
+        assert_eq!(manager.filter_outpoint_count, 1);
+
+        // Verify a FilterLoad message was sent
+        let mut found_filter_load = false;
+        while let Ok(msg) = rx.try_recv() {
+            if matches!(msg, NetworkRequest::SendMessage(NetworkMessage::FilterLoad(_))) {
+                found_filter_load = true;
+            }
+        }
+        assert!(found_filter_load, "expected FilterLoad message after outpoint change");
+    }
+
+    #[tokio::test]
+    async fn test_rebuild_filter_fetch_all_noop() {
+        let (mut manager, requests, _rx) = create_test_manager();
+        // Rebuild on FetchAll strategy should be a no-op
+        manager.rebuild_filter(&requests).await.unwrap();
+        assert!(!manager.filter_loaded);
+    }
+
+    #[tokio::test]
+    async fn test_remove_confirmed_nonexistent() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+        let txid = Txid::from_byte_array([99; 32]);
+        // Removing a non-existent txid should not panic or change counters
+        manager.remove_confirmed(&[txid]).await;
+        assert_eq!(manager.progress.removed(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_mark_instant_send_emits_status_change() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 42,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+        {
+            let mut state = manager.mempool_state.write().await;
+            state.add_transaction(UnconfirmedTransaction::new(
+                tx,
+                dashcore::Amount::from_sat(0),
+                false,
+                false,
+                Vec::new(),
+                0,
+            ));
+        }
+
+        manager.mark_instant_send(&txid).await;
+
+        // Verify mempool state also reflects IS flag
+        let state = manager.mempool_state.read().await;
+        assert!(state.transactions.get(&txid).unwrap().is_instant_send);
+        drop(state);
+
+        let wallet = manager.wallet.read().await;
+        let status_changes = wallet.status_changes();
+        let changes = status_changes.lock().await;
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].0, txid);
+        assert_eq!(changes[0].1, TransactionContext::InstantSend);
+    }
+
+    #[tokio::test]
+    async fn test_mark_instant_send_stores_pending_for_unknown() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        let unknown_txid = Txid::from_byte_array([0xbb; 32]);
+        manager.mark_instant_send(&unknown_txid).await;
+
+        // No immediate wallet notification
+        let wallet = manager.wallet.read().await;
+        let status_changes = wallet.status_changes();
+        let changes = status_changes.lock().await;
+        assert!(changes.is_empty());
+
+        // But the txid is remembered for when the transaction arrives
+        assert!(manager.pending_is_locks.contains(&unknown_txid));
+    }
+
+    #[tokio::test]
+    async fn test_remove_confirmed_only_cleans_mempool_state() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 99,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+        {
+            let mut state = manager.mempool_state.write().await;
+            state.add_transaction(UnconfirmedTransaction::new(
+                tx,
+                dashcore::Amount::from_sat(0),
+                false,
+                false,
+                Vec::new(),
+                0,
+            ));
+        }
+
+        manager.remove_confirmed(&[txid]).await;
+
+        // Mempool state should be cleaned up
+        let state = manager.mempool_state.read().await;
+        assert!(!state.transactions.contains_key(&txid));
+        drop(state);
+
+        // No wallet notification — block processing handles the confirmed transition
+        let wallet = manager.wallet.read().await;
+        let status_changes = wallet.status_changes();
+        let changes = status_changes.lock().await;
+        assert!(changes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_remove_confirmed_no_emit_for_unknown() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        let unknown_txid = Txid::from_byte_array([0xcc; 32]);
+        manager.remove_confirmed(&[unknown_txid]).await;
+
+        // Mempool state should remain empty
+        let state = manager.mempool_state.read().await;
+        assert!(state.transactions.is_empty());
+        assert_eq!(manager.progress.removed(), 0);
+        drop(state);
+
+        let wallet = manager.wallet.read().await;
+        let status_changes = wallet.status_changes();
+        let changes = status_changes.lock().await;
+        assert!(changes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_in_flight_limit() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        // Send 200 INVs — only MAX_IN_FLIGHT should go to pending, rest queued
+        let inv: Vec<Inventory> = (0..200u16)
+            .map(|i| {
+                let mut bytes = [0u8; 32];
+                bytes[0..2].copy_from_slice(&i.to_le_bytes());
+                Inventory::Transaction(Txid::from_byte_array(bytes))
+            })
+            .collect();
+
+        manager.handle_inv(&inv, test_socket_address(1), &requests).unwrap();
+        assert_eq!(manager.pending_requests.len(), MAX_IN_FLIGHT);
+        assert_eq!(manager.queued.values().map(|q| q.len()).sum::<usize>(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_send_queued_drains_after_response() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        // Fill with 150 INVs
+        let inv: Vec<Inventory> = (0..150u16)
+            .map(|i| {
+                let mut bytes = [0u8; 32];
+                bytes[0..2].copy_from_slice(&i.to_le_bytes());
+                Inventory::Transaction(Txid::from_byte_array(bytes))
+            })
+            .collect();
+
+        manager.handle_inv(&inv, test_socket_address(1), &requests).unwrap();
+        assert_eq!(manager.pending_requests.len(), MAX_IN_FLIGHT);
+        assert_eq!(manager.queued.values().map(|q| q.len()).sum::<usize>(), 50);
+
+        // Simulate receiving 10 responses (freeing 10 slots)
+        let pending_txids: Vec<Txid> = manager.pending_requests.keys().take(10).copied().collect();
+        for txid in &pending_txids {
+            manager.pending_requests.remove(txid);
+        }
+        assert_eq!(manager.pending_requests.len(), 90);
+
+        // send_queued should fill the freed slots
+        manager.send_queued(&requests).unwrap();
+        assert_eq!(manager.pending_requests.len(), MAX_IN_FLIGHT);
+        assert_eq!(manager.queued.values().map(|q| q.len()).sum::<usize>(), 40);
+    }
+
+    #[tokio::test]
+    async fn test_send_queued_skips_already_received() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        // Create a real transaction and get its actual txid
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0xaa,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+
+        // Enqueue the txid
+        manager.queued.entry(test_socket_address(1)).or_default().push_back(txid);
+
+        // Simulate the transaction arriving in mempool_state before send
+        {
+            let mut state = manager.mempool_state.write().await;
+            state.add_transaction(UnconfirmedTransaction::new(
+                tx,
+                dashcore::Amount::from_sat(0),
+                false,
+                false,
+                Vec::new(),
+                0,
+            ));
+        }
+
+        manager.send_queued(&requests).unwrap();
+        // Txid should have been skipped, not added to pending
+        assert!(manager.pending_requests.is_empty());
+        assert!(manager.queued.is_empty() || manager.queued.values().all(|q| q.is_empty()));
+    }
+
+    #[test]
+    fn test_clear_pending_clears_queue() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        manager.pending_requests.insert(Txid::from_byte_array([1; 32]), Instant::now());
+        manager
+            .queued
+            .entry(test_socket_address(1))
+            .or_default()
+            .push_back(Txid::from_byte_array([2; 32]));
+        manager.pending_is_locks.insert(Txid::from_byte_array([3; 32]));
+
+        manager.clear_pending();
+
+        assert!(manager.pending_requests.is_empty());
+        assert!(manager.queued.is_empty());
+        assert!(manager.pending_is_locks.is_empty());
+    }
+
+    #[test]
+    fn test_send_queued_noop_at_capacity() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        // Fill pending to MAX_IN_FLIGHT
+        for i in 0..MAX_IN_FLIGHT as u16 {
+            let mut bytes = [0u8; 32];
+            bytes[0..2].copy_from_slice(&i.to_le_bytes());
+            manager.pending_requests.insert(Txid::from_byte_array(bytes), Instant::now());
+        }
+
+        // Add something to the queue
+        manager
+            .queued
+            .entry(test_socket_address(1))
+            .or_default()
+            .push_back(Txid::from_byte_array([0xff; 32]));
+
+        manager.send_queued(&requests).unwrap();
+        // Queue should remain unchanged (one peer with one txid)
+        assert_eq!(manager.queued.values().map(|q| q.len()).sum::<usize>(), 1);
+        assert_eq!(manager.pending_requests.len(), MAX_IN_FLIGHT);
+    }
+
+    #[tokio::test]
+    async fn test_forward_chainlock() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        manager.forward_chainlock(500).await;
+        manager.forward_chainlock(600).await;
+
+        let wallet = manager.wallet.read().await;
+        let notifications = wallet.chainlock_notifications();
+        let heights = notifications.lock().await;
+        assert_eq!(*heights, vec![500, 600]);
+    }
+
+    #[tokio::test]
+    async fn test_instant_send_before_transaction() {
+        let (mut manager, _requests, _wallet) = create_relevant_manager();
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 77,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+
+        // IS lock arrives before the transaction
+        manager.mark_instant_send(&txid).await;
+        assert!(manager.pending_is_locks.contains(&txid));
+
+        // Transaction arrives
+        manager.handle_tx(tx).await.unwrap();
+
+        // Pending IS lock consumed
+        assert!(manager.pending_is_locks.is_empty());
+
+        // Transaction stored with IS flag set
+        let state = manager.mempool_state.read().await;
+        assert!(state.transactions.get(&txid).unwrap().is_instant_send);
+    }
+
+    #[tokio::test]
+    async fn test_instant_send_before_irrelevant_transaction() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 88,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+
+        // IS lock arrives before the transaction
+        manager.mark_instant_send(&txid).await;
+        assert!(manager.pending_is_locks.contains(&txid));
+
+        // Transaction arrives but wallet says it's not relevant
+        manager.handle_tx(tx).await.unwrap();
+
+        // Pending IS lock cleaned up (no leak)
+        assert!(manager.pending_is_locks.is_empty());
+
+        // Irrelevant tx should not be stored in mempool state
+        let state = manager.mempool_state.read().await;
+        assert!(!state.transactions.contains_key(&txid));
+    }
+
+    #[tokio::test]
+    async fn test_prune_expired_preserves_unrelated_is_locks() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        // A pending IS lock for a tx that hasn't arrived yet should survive pruning
+        let pending_txid = Txid::from_byte_array([0xcc; 32]);
+        manager.pending_is_locks.insert(pending_txid);
+        manager.prune_expired().await;
+        assert!(
+            manager.pending_is_locks.contains(&pending_txid),
+            "pending IS lock for non-expired tx should be preserved"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prune_expired_removes_is_lock_for_expired_tx() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+
+        // Add the tx with a timestamp far in the past so it expires
+        {
+            let mut state = manager.mempool_state.write().await;
+            let mut utx = UnconfirmedTransaction::new(
+                tx,
+                dashcore::Amount::from_sat(0),
+                false,
+                false,
+                Vec::new(),
+                0,
+            );
+            utx.first_seen = Instant::now() - MEMPOOL_TX_EXPIRY - Duration::from_secs(1);
+            state.add_transaction(utx);
+        }
+
+        // Also store a pending IS lock for this txid and an unrelated one
+        let unrelated_txid = Txid::from_byte_array([0xdd; 32]);
+        manager.pending_is_locks.insert(txid);
+        manager.pending_is_locks.insert(unrelated_txid);
+
+        manager.prune_expired().await;
+
+        // The expired tx's IS lock should be removed
+        assert!(
+            !manager.pending_is_locks.contains(&txid),
+            "IS lock for expired tx should be removed"
+        );
+        // The unrelated IS lock should be preserved
+        assert!(
+            manager.pending_is_locks.contains(&unrelated_txid),
+            "IS lock for non-expired tx should be preserved"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_inv_dedup_against_queue() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        // Fill pending to capacity so items go to queue
+        for i in 0..MAX_IN_FLIGHT as u16 {
+            let mut bytes = [0u8; 32];
+            bytes[0..2].copy_from_slice(&i.to_le_bytes());
+            manager.pending_requests.insert(Txid::from_byte_array(bytes), Instant::now());
+        }
+
+        let txid = Txid::from_byte_array([0xff; 32]);
+        let inv = vec![Inventory::Transaction(txid)];
+
+        // First call enqueues
+        manager.handle_inv(&inv, test_socket_address(1), &requests).unwrap();
+        assert_eq!(manager.queued.values().map(|q| q.len()).sum::<usize>(), 1);
+
+        // Second call with same txid should be deduped
+        manager.handle_inv(&inv, test_socket_address(1), &requests).unwrap();
+        assert_eq!(manager.queued.values().map(|q| q.len()).sum::<usize>(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_activation_retry_on_timeout() {
+        let (mut manager, requests, _rx) = create_test_manager();
+        manager.activate(&requests).await.unwrap();
+
+        // Right after activation, retry should not be needed
+        assert!(!manager.needs_activation_retry());
+        assert!(manager.activated_at.is_some());
+
+        // Simulate timeout by backdating the activation timestamp
+        manager.activated_at = Some(Instant::now() - ACTIVATION_TIMEOUT);
+        assert!(manager.needs_activation_retry());
+    }
+
+    #[tokio::test]
+    async fn test_activation_retry_cleared_by_inv() {
+        let (mut manager, requests, _rx) = create_test_manager();
+        manager.activate(&requests).await.unwrap();
+        assert!(manager.activated_at.is_some());
+
+        // Receiving inventory confirms activation
+        let txid = Txid::from_byte_array([1u8; 32]);
+        let inv = vec![Inventory::Transaction(txid)];
+        manager.handle_inv(&inv, test_socket_address(1), &requests).unwrap();
+
+        assert!(manager.activated_at.is_none());
+        assert!(!manager.needs_activation_retry());
+    }
+
+    #[tokio::test]
+    async fn test_bloom_filter_load_failure_propagates() {
+        let addr = test_address(0xab);
+        let mut mock = MockWallet::new();
+        mock.set_addresses(vec![addr]);
+        let wallet = Arc::new(RwLock::new(mock));
+        let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
+        let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let requests = RequestSender::new(tx);
+
+        let mut manager =
+            MempoolManager::new(wallet, mempool_state, MempoolStrategy::BloomFilter, 1000);
+
+        // Drop receiver so send_filter_load fails
+        drop(rx);
+
+        // activate() should propagate the error
+        let result = manager.activate(&requests).await;
+        assert!(result.is_err());
+        assert!(!manager.filter_loaded);
+    }
+
+    #[tokio::test]
+    async fn test_handle_tx_relevant_populates_wallet_effect_fields() {
+        let (mut manager, _requests, wallet) = create_relevant_manager();
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+
+        // Set effect data on the mock wallet before handle_tx
+        {
+            let w = wallet.read().await;
+            w.set_effect(txid, 50000, vec!["yWdXnYxGbouNoo8yMvcbZmZ3Gdp6BpySxL".into()]).await;
+        }
+
+        manager.handle_tx(tx).await.unwrap();
+
+        let state = manager.mempool_state.read().await;
+        let stored = state.transactions.get(&txid).unwrap();
+        assert_eq!(stored.net_amount, 50000);
+        assert!(!stored.is_outgoing);
+        assert!(!stored.is_instant_send);
+        assert_eq!(stored.addresses.len(), 1);
+        assert_eq!(stored.addresses[0].to_string(), "yWdXnYxGbouNoo8yMvcbZmZ3Gdp6BpySxL");
+    }
+
+    #[tokio::test]
+    async fn test_handle_tx_outgoing_transaction() {
+        let (mut manager, _requests, wallet) = create_relevant_manager();
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 123,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+
+        {
+            let w = wallet.read().await;
+            w.set_effect(txid, -30000, vec![]).await;
+        }
+
+        manager.handle_tx(tx).await.unwrap();
+
+        let state = manager.mempool_state.read().await;
+        let stored = state.transactions.get(&txid).unwrap();
+        assert_eq!(stored.net_amount, -30000);
+        assert!(stored.is_outgoing);
+        assert!(!stored.is_instant_send);
+        assert!(stored.addresses.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_handle_tx_flags_filter_rebuild_on_new_addresses() {
+        let new_addr = test_address(0xef);
+
+        let mut mock = MockWallet::new();
+        mock.set_mempool_relevant(true);
+        mock.set_mempool_new_addresses(vec![new_addr.clone()]);
+        let wallet = Arc::new(RwLock::new(mock));
+        let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
+        let (tx_chan, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let _requests = RequestSender::new(tx_chan);
+
+        let mut manager =
+            MempoolManager::new(wallet, mempool_state, MempoolStrategy::BloomFilter, 1000);
+
+        let tx = Transaction {
+            version: 1,
+            lock_time: 456,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+
+        assert!(!manager.needs_filter_rebuild);
+        let txid = tx.txid();
+        manager.handle_tx(tx).await.unwrap();
+        assert!(manager.needs_filter_rebuild);
+
+        // Relevant tx should be stored in mempool state
+        let state = manager.mempool_state.read().await;
+        assert!(state.transactions.contains_key(&txid));
+    }
+
+    #[test]
+    fn test_peer_connected_creates_queue() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+        let peer = test_socket_address(1);
+
+        assert!(!manager.queued.contains_key(&peer));
+        manager.handle_peer_connected(peer);
+        assert!(manager.queued.contains_key(&peer));
+        assert!(manager.queued[&peer].is_empty());
+    }
+
+    #[test]
+    fn test_peer_disconnected_redistributes_queue() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+        let peer1 = test_socket_address(1);
+        let peer2 = test_socket_address(2);
+
+        manager.handle_peer_connected(peer1);
+        manager.handle_peer_connected(peer2);
+
+        // Queue some txids on peer1
+        let txid1 = Txid::from_byte_array([1; 32]);
+        let txid2 = Txid::from_byte_array([2; 32]);
+        manager.queued.get_mut(&peer1).unwrap().push_back(txid1);
+        manager.queued.get_mut(&peer1).unwrap().push_back(txid2);
+
+        manager.handle_peer_disconnected(peer1);
+
+        assert!(!manager.queued.contains_key(&peer1));
+        // Txids should have moved to peer2
+        let peer2_queue = &manager.queued[&peer2];
+        assert!(peer2_queue.contains(&txid1));
+        assert!(peer2_queue.contains(&txid2));
+    }
+
+    #[test]
+    fn test_peer_disconnected_no_peers_drops_queue() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+        let peer = test_socket_address(1);
+
+        manager.handle_peer_connected(peer);
+        manager.queued.get_mut(&peer).unwrap().push_back(Txid::from_byte_array([1; 32]));
+
+        manager.handle_peer_disconnected(peer);
+
+        assert!(manager.queued.is_empty());
+    }
+
+    #[test]
+    fn test_prune_pending_requeues_to_connected_peer() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+        let peer = test_socket_address(1);
+        manager.handle_peer_connected(peer);
+
+        let txid = Txid::from_byte_array([1; 32]);
+        manager
+            .pending_requests
+            .insert(txid, Instant::now() - PENDING_REQUEST_TIMEOUT - Duration::from_secs(1));
+
+        manager.prune_pending_requests();
+
+        assert!(!manager.pending_requests.contains_key(&txid));
+        assert!(manager.queued[&peer].contains(&txid));
+    }
+
+    #[test]
+    fn test_prune_pending_drops_when_no_peers() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        let txid = Txid::from_byte_array([1; 32]);
+        manager
+            .pending_requests
+            .insert(txid, Instant::now() - PENDING_REQUEST_TIMEOUT - Duration::from_secs(1));
+
+        manager.prune_pending_requests();
+
+        assert!(!manager.pending_requests.contains_key(&txid));
+        assert!(manager.queued.is_empty());
+    }
+}

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -20,7 +20,7 @@ use crate::client::config::MempoolStrategy;
 use crate::error::{SyncError, SyncResult};
 use crate::network::RequestSender;
 use crate::sync::mempool::MempoolProgress;
-use crate::sync::SyncEvent;
+use crate::sync::{SyncEvent, SyncState};
 use crate::types::{MempoolState, UnconfirmedTransaction};
 use key_wallet_manager::wallet_interface::WalletInterface;
 
@@ -205,6 +205,11 @@ impl<W: WalletInterface> MempoolManager<W> {
         peer: SocketAddr,
         requests: &RequestSender,
     ) -> SyncResult<Vec<SyncEvent>> {
+        // Ignore inventory announcements until sync is complete and we've activated
+        if self.progress.state() != SyncState::Synced {
+            return Ok(vec![]);
+        }
+
         // Inventory received, activation confirmed
         self.activated_at = None;
 
@@ -520,7 +525,9 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
-        let manager = MempoolManager::new(wallet, mempool_state, MempoolStrategy::FetchAll, 1000);
+        let mut manager =
+            MempoolManager::new(wallet, mempool_state, MempoolStrategy::FetchAll, 1000);
+        manager.progress.set_state(SyncState::Synced);
 
         (manager, requests, rx)
     }
@@ -540,8 +547,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_activation_fetch_all() {
-        let (mut manager, requests, _rx) = create_test_manager();
+        let (mut manager, requests, mut rx) = create_test_manager();
         manager.activate(&requests).await.unwrap();
+
+        // FetchAll activation sends mempool then filterclear
+        let msg1 = rx.recv().await.unwrap();
+        assert!(matches!(msg1, NetworkRequest::SendMessage(NetworkMessage::MemPool)));
+        let msg2 = rx.recv().await.unwrap();
+        assert!(matches!(msg2, NetworkRequest::SendMessage(NetworkMessage::FilterClear)));
     }
 
     #[tokio::test]
@@ -550,6 +563,26 @@ mod tests {
         manager.activate(&requests).await.unwrap();
         // No addresses in mock wallet, so filter should not be loaded
         assert!(!manager.filter_loaded);
+    }
+
+    #[tokio::test]
+    async fn test_handle_inv_ignored_before_sync() {
+        let wallet = Arc::new(RwLock::new(MockWallet::new()));
+        let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
+        let (tx, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let requests = RequestSender::new(tx);
+
+        // Manager starts in WaitForEvents, not Synced
+        let mut manager =
+            MempoolManager::new(wallet, mempool_state, MempoolStrategy::FetchAll, 1000);
+
+        let txid = Txid::from_byte_array([1u8; 32]);
+        let inv = vec![Inventory::Transaction(txid)];
+        manager.handle_inv(&inv, test_socket_address(1), &requests).unwrap();
+
+        // Should be ignored — nothing queued or pending
+        assert!(manager.pending_requests.is_empty());
+        assert!(manager.queued.is_empty());
     }
 
     #[tokio::test]
@@ -622,6 +655,7 @@ mod tests {
         let requests = RequestSender::new(tx);
 
         let mut manager = MempoolManager::new(wallet, mempool_state, MempoolStrategy::FetchAll, 2);
+        manager.progress.set_state(SyncState::Synced);
 
         // Fill pending requests to capacity
         let inv1: Vec<Inventory> =

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -325,10 +325,7 @@ impl<W: WalletInterface> MempoolManager<W> {
     }
 
     /// Handle a received transaction.
-    pub(super) async fn handle_tx(
-        &mut self,
-        tx: Transaction,
-    ) -> SyncResult<Vec<SyncEvent>> {
+    pub(super) async fn handle_tx(&mut self, tx: Transaction) -> SyncResult<Vec<SyncEvent>> {
         let txid = tx.txid();
         self.pending_requests.remove(&txid);
         self.progress.add_received(1);
@@ -437,8 +434,7 @@ impl<W: WalletInterface> MempoolManager<W> {
 
         // Prune pending IS locks whose transaction never arrived
         let before = self.pending_is_locks.len();
-        self.pending_is_locks
-            .retain(|_, inserted_at| inserted_at.elapsed() < MEMPOOL_TX_EXPIRY);
+        self.pending_is_locks.retain(|_, inserted_at| inserted_at.elapsed() < MEMPOOL_TX_EXPIRY);
         let expired = before - self.pending_is_locks.len();
         if expired > 0 {
             tracing::debug!("Pruned {} expired pending IS locks", expired);
@@ -477,9 +473,7 @@ impl<W: WalletInterface> MempoolManager<W> {
             // Non-mempool peer, remove its queue and redistribute txids
             if let Some(orphaned) = self.queued.remove(&peer) {
                 if !orphaned.is_empty() {
-                    if let Some(queue) =
-                        self.queued.values_mut().choose(&mut rand::thread_rng())
-                    {
+                    if let Some(queue) = self.queued.values_mut().choose(&mut rand::thread_rng()) {
                         queue.extend(orphaned);
                     }
                 }
@@ -600,9 +594,13 @@ mod tests {
 
         // FetchAll activation sends mempool then filterclear to the chosen peer
         let msg1 = rx.recv().await.unwrap();
-        assert!(matches!(msg1, NetworkRequest::SendMessageToPeer(NetworkMessage::MemPool, p) if p == peer));
+        assert!(
+            matches!(msg1, NetworkRequest::SendMessageToPeer(NetworkMessage::MemPool, p) if p == peer)
+        );
         let msg2 = rx.recv().await.unwrap();
-        assert!(matches!(msg2, NetworkRequest::SendMessageToPeer(NetworkMessage::FilterClear, p) if p == peer));
+        assert!(
+            matches!(msg2, NetworkRequest::SendMessageToPeer(NetworkMessage::FilterClear, p) if p == peer)
+        );
         assert_eq!(manager.mempool_peer, Some(peer));
     }
 
@@ -944,11 +942,7 @@ mod tests {
 
     fn create_bloom_manager_with_addresses(
         addresses: Vec<Address>,
-    ) -> (
-        MempoolManager<MockWallet>,
-        RequestSender,
-        mpsc::UnboundedReceiver<NetworkRequest>,
-    ) {
+    ) -> (MempoolManager<MockWallet>, RequestSender, mpsc::UnboundedReceiver<NetworkRequest>) {
         let mut mock = MockWallet::new();
         mock.set_addresses(addresses);
         let wallet = Arc::new(RwLock::new(mock));
@@ -1276,9 +1270,7 @@ mod tests {
             .entry(test_socket_address(1))
             .or_default()
             .push_back(Txid::from_byte_array([2; 32]));
-        manager
-            .pending_is_locks
-            .insert(Txid::from_byte_array([3; 32]), Instant::now());
+        manager.pending_is_locks.insert(Txid::from_byte_array([3; 32]), Instant::now());
 
         manager.clear_pending();
 
@@ -1386,9 +1378,7 @@ mod tests {
 
         // A pending IS lock for a tx that hasn't arrived yet should survive pruning
         let pending_txid = Txid::from_byte_array([0xcc; 32]);
-        manager
-            .pending_is_locks
-            .insert(pending_txid, Instant::now());
+        manager.pending_is_locks.insert(pending_txid, Instant::now());
         manager.prune_expired().await;
         assert!(
             manager.pending_is_locks.contains_key(&pending_txid),
@@ -1412,14 +1402,8 @@ mod tests {
         // Add the tx with a timestamp far in the past so it expires
         {
             let mut state = manager.mempool_state.write().await;
-            let mut utx = UnconfirmedTransaction::new(
-                tx,
-                Amount::from_sat(0),
-                false,
-                false,
-                Vec::new(),
-                0,
-            );
+            let mut utx =
+                UnconfirmedTransaction::new(tx, Amount::from_sat(0), false, false, Vec::new(), 0);
             utx.first_seen = Instant::now() - MEMPOOL_TX_EXPIRY - Duration::from_secs(1);
             state.add_transaction(utx);
         }
@@ -1427,9 +1411,7 @@ mod tests {
         // Also store a pending IS lock for this txid and an unrelated one
         let unrelated_txid = Txid::from_byte_array([0xdd; 32]);
         manager.pending_is_locks.insert(txid, Instant::now());
-        manager
-            .pending_is_locks
-            .insert(unrelated_txid, Instant::now());
+        manager.pending_is_locks.insert(unrelated_txid, Instant::now());
 
         manager.prune_expired().await;
 
@@ -1457,9 +1439,7 @@ mod tests {
 
         // Insert a fresh pending IS lock
         let fresh_txid = Txid::from_byte_array([0xbb; 32]);
-        manager
-            .pending_is_locks
-            .insert(fresh_txid, Instant::now());
+        manager.pending_is_locks.insert(fresh_txid, Instant::now());
 
         manager.prune_expired().await;
 

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -4,7 +4,7 @@
 //! filters or local address matching to identify wallet-relevant
 //! transactions from the mempool.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -64,8 +64,12 @@ pub struct MempoolManager<W: WalletInterface> {
     /// failures: if no inventory response arrives within the timeout, activation
     /// is retried. Cleared when the first inventory message is received.
     activated_at: Option<Instant>,
-    /// IS lock txids that arrived before their corresponding transaction.
-    pending_is_locks: HashSet<Txid>,
+    /// IS lock txids that arrived before their corresponding transaction, with insertion time.
+    pending_is_locks: HashMap<Txid, Instant>,
+    // TODO: support multi-peer mempool relay for better coverage
+    /// The peer we activated mempool relay on. With `relay=false` in the handshake,
+    /// only this peer sends us transaction INV messages.
+    pub(super) mempool_peer: Option<SocketAddr>,
 }
 
 impl<W: WalletInterface> MempoolManager<W> {
@@ -90,11 +94,12 @@ impl<W: WalletInterface> MempoolManager<W> {
             filter_outpoint_count: 0,
             needs_filter_rebuild: false,
             activated_at: None,
-            pending_is_locks: HashSet::new(),
+            pending_is_locks: HashMap::new(),
+            mempool_peer: None,
         }
     }
 
-    /// Activate mempool monitoring after sync is complete.
+    /// Activate mempool monitoring on a specific peer after sync is complete.
     ///
     /// Since we connect with `relay=false`, peers won't send transaction INVs
     /// until we explicitly enable relay:
@@ -103,21 +108,26 @@ impl<W: WalletInterface> MempoolManager<W> {
     ///
     /// Sets `activated_at` so that `needs_activation_retry()` can detect
     /// activation failures if no inventory response arrives within the timeout.
-    pub(super) async fn activate(&mut self, requests: &RequestSender) -> SyncResult<()> {
-        tracing::info!("Activating mempool manager (strategy: {:?})", self.strategy);
+    pub(super) async fn activate(
+        &mut self,
+        peer: SocketAddr,
+        requests: &RequestSender,
+    ) -> SyncResult<()> {
+        tracing::info!("Activating mempool on peer {} (strategy: {:?})", peer, self.strategy);
 
         if self.strategy == MempoolStrategy::BloomFilter {
-            self.load_bloom_filter(requests).await?;
+            self.load_bloom_filter(peer, requests).await?;
         }
 
         // Request current mempool inventory
-        requests.request_mempool()?;
+        requests.request_mempool(peer)?;
 
         if self.strategy == MempoolStrategy::FetchAll {
             // Enable unfiltered transaction relay going forward
-            requests.send_filter_clear()?;
+            requests.send_filter_clear(peer)?;
         }
 
+        self.mempool_peer = Some(peer);
         self.activated_at = Some(Instant::now());
         Ok(())
     }
@@ -128,8 +138,12 @@ impl<W: WalletInterface> MempoolManager<W> {
         self.activated_at.is_some_and(|t| t.elapsed() >= ACTIVATION_TIMEOUT)
     }
 
-    /// Build and send a bloom filter to the peer.
-    async fn load_bloom_filter(&mut self, requests: &RequestSender) -> SyncResult<()> {
+    /// Build and send a bloom filter to the mempool peer.
+    async fn load_bloom_filter(
+        &mut self,
+        peer: SocketAddr,
+        requests: &RequestSender,
+    ) -> SyncResult<()> {
         let wallet = self.wallet.read().await;
         let addresses = wallet.monitored_addresses();
         let outpoints = wallet.watched_outpoints();
@@ -155,7 +169,7 @@ impl<W: WalletInterface> MempoolManager<W> {
                     filter_load.filter.len()
                 );
 
-                requests.send_filter_load(filter_load)?;
+                requests.send_filter_load(filter_load, peer)?;
 
                 self.filter_loaded = true;
                 self.filter_address_count = addresses.len();
@@ -172,25 +186,29 @@ impl<W: WalletInterface> MempoolManager<W> {
         Ok(())
     }
 
-    /// Rebuild the bloom filter (e.g., after new addresses are generated).
+    /// Rebuild the bloom filter on the current mempool peer.
     pub(super) async fn rebuild_filter(&mut self, requests: &RequestSender) -> SyncResult<()> {
         if self.strategy != MempoolStrategy::BloomFilter {
             return Ok(());
         }
 
+        let Some(peer) = self.mempool_peer else {
+            return Ok(());
+        };
+
         // Clear the old filter first
         if self.filter_loaded {
-            if let Err(e) = requests.send_filter_clear() {
+            if let Err(e) = requests.send_filter_clear(peer) {
                 tracing::warn!("Failed to send filter clear: {}", e);
             }
             self.filter_loaded = false;
         }
 
         // Build and load a new filter
-        self.load_bloom_filter(requests).await?;
+        self.load_bloom_filter(peer, requests).await?;
 
         // Re-request mempool with updated filter
-        requests.request_mempool()?;
+        requests.request_mempool(peer)?;
 
         Ok(())
     }
@@ -319,7 +337,7 @@ impl<W: WalletInterface> MempoolManager<W> {
         self.progress.add_received(1);
 
         // Check for a pre-arrived IS lock before wallet processing consumes it
-        let is_locked = self.pending_is_locks.remove(&txid);
+        let is_locked = self.pending_is_locks.remove(&txid).is_some();
 
         let result = {
             let mut wallet = self.wallet.write().await;
@@ -390,7 +408,7 @@ impl<W: WalletInterface> MempoolManager<W> {
             tracing::debug!("Marked mempool tx {} as InstantSend-locked", txid);
             true
         } else {
-            self.pending_is_locks.insert(*txid);
+            self.pending_is_locks.insert(*txid, Instant::now());
             tracing::debug!("IS lock arrived before tx {}, remembering for later", txid);
             false
         };
@@ -419,6 +437,20 @@ impl<W: WalletInterface> MempoolManager<W> {
                 self.pending_is_locks.remove(txid);
             }
         }
+
+        // Prune pending IS locks whose transaction never arrived
+        let before = self.pending_is_locks.len();
+        self.pending_is_locks
+            .retain(|_, inserted_at| inserted_at.elapsed() < MEMPOOL_TX_EXPIRY);
+        let expired = before - self.pending_is_locks.len();
+        if expired > 0 {
+            tracing::debug!("Pruned {} expired pending IS locks", expired);
+        }
+    }
+
+    /// Pick a connected peer for mempool relay.
+    pub(super) fn pick_peer(&self) -> Option<SocketAddr> {
+        self.queued.keys().choose(&mut rand::thread_rng()).copied()
     }
 
     fn is_queued(&self, txid: &Txid) -> bool {
@@ -431,14 +463,31 @@ impl<W: WalletInterface> MempoolManager<W> {
     }
 
     /// Remove a disconnected peer's queue, redistributing its txids to another peer.
-    pub(super) fn handle_peer_disconnected(&mut self, peer: SocketAddr) {
-        if let Some(orphaned) = self.queued.remove(&peer) {
-            if orphaned.is_empty() {
-                return;
+    /// Returns true if the mempool peer disconnected and re-activation is needed.
+    pub(super) fn handle_peer_disconnected(&mut self, peer: SocketAddr) -> bool {
+        if self.mempool_peer == Some(peer) {
+            tracing::info!("Mempool peer {} disconnected, need to re-activate", peer);
+            // Collect remaining peers before clear_pending wipes the map
+            let remaining_peers: Vec<SocketAddr> =
+                self.queued.keys().filter(|p| **p != peer).copied().collect();
+            self.clear_pending();
+            // Restore peer entries so pick_peer can find a replacement
+            for p in remaining_peers {
+                self.queued.entry(p).or_default();
             }
-            if let Some(queue) = self.queued.values_mut().choose(&mut rand::thread_rng()) {
-                queue.extend(orphaned);
+            true
+        } else {
+            // Non-mempool peer, remove its queue and redistribute txids
+            if let Some(orphaned) = self.queued.remove(&peer) {
+                if !orphaned.is_empty() {
+                    if let Some(queue) =
+                        self.queued.values_mut().choose(&mut rand::thread_rng())
+                    {
+                        queue.extend(orphaned);
+                    }
+                }
             }
+            false
         }
     }
 
@@ -448,6 +497,7 @@ impl<W: WalletInterface> MempoolManager<W> {
         self.queued.clear();
         self.pending_is_locks.clear();
         self.filter_loaded = false;
+        self.mempool_peer = None;
     }
 
     /// Remove pending requests that have timed out without receiving a response.
@@ -547,20 +597,22 @@ mod tests {
 
     #[tokio::test]
     async fn test_activation_fetch_all() {
+        let peer = test_socket_address(1);
         let (mut manager, requests, mut rx) = create_test_manager();
-        manager.activate(&requests).await.unwrap();
+        manager.activate(peer, &requests).await.unwrap();
 
-        // FetchAll activation sends mempool then filterclear
+        // FetchAll activation sends mempool then filterclear to the chosen peer
         let msg1 = rx.recv().await.unwrap();
-        assert!(matches!(msg1, NetworkRequest::SendMessage(NetworkMessage::MemPool)));
+        assert!(matches!(msg1, NetworkRequest::SendMessageToPeer(NetworkMessage::MemPool, p) if p == peer));
         let msg2 = rx.recv().await.unwrap();
-        assert!(matches!(msg2, NetworkRequest::SendMessage(NetworkMessage::FilterClear)));
+        assert!(matches!(msg2, NetworkRequest::SendMessageToPeer(NetworkMessage::FilterClear, p) if p == peer));
+        assert_eq!(manager.mempool_peer, Some(peer));
     }
 
     #[tokio::test]
     async fn test_activation_bloom_filter() {
         let (mut manager, requests, _rx) = create_bloom_manager();
-        manager.activate(&requests).await.unwrap();
+        manager.activate(test_socket_address(1), &requests).await.unwrap();
         // No addresses in mock wallet, so filter should not be loaded
         assert!(!manager.filter_loaded);
     }
@@ -929,7 +981,7 @@ mod tests {
         let addr = test_address(0xab);
 
         let (mut manager, requests, _rx) = create_bloom_manager_with_addresses(vec![addr]);
-        manager.activate(&requests).await.unwrap();
+        manager.activate(test_socket_address(1), &requests).await.unwrap();
 
         assert!(manager.filter_loaded);
         assert_eq!(manager.filter_address_count, 1);
@@ -940,7 +992,7 @@ mod tests {
         let addr = test_address(0xab);
 
         let (mut manager, requests, _rx) = create_bloom_manager_with_addresses(vec![addr]);
-        manager.activate(&requests).await.unwrap();
+        manager.activate(test_socket_address(1), &requests).await.unwrap();
         assert!(manager.filter_loaded);
 
         // Address count hasn't changed, so staleness check should be a no-op
@@ -954,7 +1006,7 @@ mod tests {
         let addr1 = test_address(0xab);
 
         let (mut manager, requests, _rx) = create_bloom_manager_with_addresses(vec![addr1.clone()]);
-        manager.activate(&requests).await.unwrap();
+        manager.activate(test_socket_address(1), &requests).await.unwrap();
         assert_eq!(manager.filter_address_count, 1);
 
         // Simulate wallet generating a new address
@@ -975,7 +1027,7 @@ mod tests {
         let addr = test_address(0xab);
 
         let (mut manager, requests, mut rx) = create_bloom_manager_with_addresses(vec![addr]);
-        manager.activate(&requests).await.unwrap();
+        manager.activate(test_socket_address(1), &requests).await.unwrap();
         assert_eq!(manager.filter_outpoint_count, 0);
 
         // Drain messages from activation
@@ -996,7 +1048,7 @@ mod tests {
         // Verify a FilterLoad message was sent
         let mut found_filter_load = false;
         while let Ok(msg) = rx.try_recv() {
-            if matches!(msg, NetworkRequest::SendMessage(NetworkMessage::FilterLoad(_))) {
+            if matches!(msg, NetworkRequest::SendMessageToPeer(NetworkMessage::FilterLoad(_), _)) {
                 found_filter_load = true;
             }
         }
@@ -1073,7 +1125,7 @@ mod tests {
         assert!(changes.is_empty());
 
         // But the txid is remembered for when the transaction arrives
-        assert!(manager.pending_is_locks.contains(&unknown_txid));
+        assert!(manager.pending_is_locks.contains_key(&unknown_txid));
     }
 
     #[tokio::test]
@@ -1227,7 +1279,9 @@ mod tests {
             .entry(test_socket_address(1))
             .or_default()
             .push_back(Txid::from_byte_array([2; 32]));
-        manager.pending_is_locks.insert(Txid::from_byte_array([3; 32]));
+        manager
+            .pending_is_locks
+            .insert(Txid::from_byte_array([3; 32]), Instant::now());
 
         manager.clear_pending();
 
@@ -1288,7 +1342,7 @@ mod tests {
 
         // IS lock arrives before the transaction
         manager.mark_instant_send(&txid).await;
-        assert!(manager.pending_is_locks.contains(&txid));
+        assert!(manager.pending_is_locks.contains_key(&txid));
 
         // Transaction arrives
         manager.handle_tx(tx).await.unwrap();
@@ -1316,7 +1370,7 @@ mod tests {
 
         // IS lock arrives before the transaction
         manager.mark_instant_send(&txid).await;
-        assert!(manager.pending_is_locks.contains(&txid));
+        assert!(manager.pending_is_locks.contains_key(&txid));
 
         // Transaction arrives but wallet says it's not relevant
         manager.handle_tx(tx).await.unwrap();
@@ -1335,10 +1389,12 @@ mod tests {
 
         // A pending IS lock for a tx that hasn't arrived yet should survive pruning
         let pending_txid = Txid::from_byte_array([0xcc; 32]);
-        manager.pending_is_locks.insert(pending_txid);
+        manager
+            .pending_is_locks
+            .insert(pending_txid, Instant::now());
         manager.prune_expired().await;
         assert!(
-            manager.pending_is_locks.contains(&pending_txid),
+            manager.pending_is_locks.contains_key(&pending_txid),
             "pending IS lock for non-expired tx should be preserved"
         );
     }
@@ -1373,20 +1429,50 @@ mod tests {
 
         // Also store a pending IS lock for this txid and an unrelated one
         let unrelated_txid = Txid::from_byte_array([0xdd; 32]);
-        manager.pending_is_locks.insert(txid);
-        manager.pending_is_locks.insert(unrelated_txid);
+        manager.pending_is_locks.insert(txid, Instant::now());
+        manager
+            .pending_is_locks
+            .insert(unrelated_txid, Instant::now());
 
         manager.prune_expired().await;
 
         // The expired tx's IS lock should be removed
         assert!(
-            !manager.pending_is_locks.contains(&txid),
+            !manager.pending_is_locks.contains_key(&txid),
             "IS lock for expired tx should be removed"
         );
         // The unrelated IS lock should be preserved
         assert!(
-            manager.pending_is_locks.contains(&unrelated_txid),
+            manager.pending_is_locks.contains_key(&unrelated_txid),
             "IS lock for non-expired tx should be preserved"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prune_expired_removes_stale_pending_is_locks() {
+        let (mut manager, _requests, _rx) = create_test_manager();
+
+        // Insert a pending IS lock that is older than the expiry threshold
+        let stale_txid = Txid::from_byte_array([0xaa; 32]);
+        manager
+            .pending_is_locks
+            .insert(stale_txid, Instant::now() - MEMPOOL_TX_EXPIRY - Duration::from_secs(1));
+
+        // Insert a fresh pending IS lock
+        let fresh_txid = Txid::from_byte_array([0xbb; 32]);
+        manager
+            .pending_is_locks
+            .insert(fresh_txid, Instant::now());
+
+        manager.prune_expired().await;
+
+        assert!(
+            !manager.pending_is_locks.contains_key(&stale_txid),
+            "stale pending IS lock should be pruned"
+        );
+        assert!(
+            manager.pending_is_locks.contains_key(&fresh_txid),
+            "fresh pending IS lock should be preserved"
         );
     }
 
@@ -1416,7 +1502,7 @@ mod tests {
     #[tokio::test]
     async fn test_activation_retry_on_timeout() {
         let (mut manager, requests, _rx) = create_test_manager();
-        manager.activate(&requests).await.unwrap();
+        manager.activate(test_socket_address(1), &requests).await.unwrap();
 
         // Right after activation, retry should not be needed
         assert!(!manager.needs_activation_retry());
@@ -1430,7 +1516,7 @@ mod tests {
     #[tokio::test]
     async fn test_activation_retry_cleared_by_inv() {
         let (mut manager, requests, _rx) = create_test_manager();
-        manager.activate(&requests).await.unwrap();
+        manager.activate(test_socket_address(1), &requests).await.unwrap();
         assert!(manager.activated_at.is_some());
 
         // Receiving inventory confirms activation
@@ -1459,7 +1545,7 @@ mod tests {
         drop(rx);
 
         // activate() should propagate the error
-        let result = manager.activate(&requests).await;
+        let result = manager.activate(test_socket_address(1), &requests).await;
         assert!(result.is_err());
         assert!(!manager.filter_loaded);
     }

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -8,7 +8,8 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use tokio::time::Instant;
 
 use dashcore::network::message_blockdata::Inventory;
 use dashcore::{Amount, Transaction, Txid};
@@ -135,7 +136,9 @@ impl<W: WalletInterface> MempoolManager<W> {
     /// Whether activation needs to be retried. Returns true if activation was
     /// attempted but no inventory response arrived within the timeout.
     pub(super) fn needs_activation_retry(&self) -> bool {
-        self.activated_at.is_some_and(|t| t.elapsed() >= ACTIVATION_TIMEOUT)
+        self.activated_at.is_some_and(|t| {
+            Instant::now().checked_duration_since(t).unwrap_or_default() >= ACTIVATION_TIMEOUT
+        })
     }
 
     /// Build and send a bloom filter to the mempool peer.
@@ -434,7 +437,10 @@ impl<W: WalletInterface> MempoolManager<W> {
 
         // Prune pending IS locks whose transaction never arrived
         let before = self.pending_is_locks.len();
-        self.pending_is_locks.retain(|_, inserted_at| inserted_at.elapsed() < MEMPOOL_TX_EXPIRY);
+        let now = Instant::now();
+        self.pending_is_locks.retain(|_, inserted_at| {
+            now.checked_duration_since(*inserted_at).unwrap_or_default() < MEMPOOL_TX_EXPIRY
+        });
         let expired = before - self.pending_is_locks.len();
         if expired > 0 {
             tracing::debug!("Pruned {} expired pending IS locks", expired);
@@ -496,7 +502,9 @@ impl<W: WalletInterface> MempoolManager<W> {
     pub(super) fn prune_pending_requests(&mut self) {
         let mut timed_out = Vec::new();
         self.pending_requests.retain(|txid, requested_at| {
-            if requested_at.elapsed() >= PENDING_REQUEST_TIMEOUT {
+            if Instant::now().checked_duration_since(*requested_at).unwrap_or_default()
+                >= PENDING_REQUEST_TIMEOUT
+            {
                 timed_out.push(*txid);
                 false
             } else {
@@ -717,8 +725,8 @@ mod tests {
         assert!(!manager.pending_requests.contains_key(&extra_txid));
     }
 
-    #[test]
-    fn test_prune_pending_requests_timeout() {
+    #[tokio::test(start_paused = true)]
+    async fn test_prune_pending_requests_timeout() {
         let wallet = Arc::new(RwLock::new(MockWallet::new()));
         let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
         let (tx, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
@@ -727,13 +735,14 @@ mod tests {
         let mut manager =
             MempoolManager::new(wallet, mempool_state, MempoolStrategy::FetchAll, 1000);
 
-        let fresh_txid = Txid::from_byte_array([1; 32]);
         let stale_txid = Txid::from_byte_array([2; 32]);
+        manager.pending_requests.insert(stale_txid, Instant::now());
 
+        // Advance time past the timeout so stale_txid expires
+        tokio::time::advance(PENDING_REQUEST_TIMEOUT + Duration::from_secs(1)).await;
+
+        let fresh_txid = Txid::from_byte_array([1; 32]);
         manager.pending_requests.insert(fresh_txid, Instant::now());
-        manager
-            .pending_requests
-            .insert(stale_txid, Instant::now() - PENDING_REQUEST_TIMEOUT - Duration::from_secs(1));
 
         manager.prune_pending_requests();
 
@@ -842,7 +851,7 @@ mod tests {
         assert_eq!(manager.pending_requests.len(), 1);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_prune_expired() {
         let (mut manager, _requests, _rx) = create_test_manager();
 
@@ -1372,7 +1381,7 @@ mod tests {
         assert!(!state.transactions.contains_key(&txid));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_prune_expired_preserves_unrelated_is_locks() {
         let (mut manager, _requests, _rx) = create_test_manager();
 
@@ -1386,7 +1395,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_prune_expired_removes_is_lock_for_expired_tx() {
         let (mut manager, _requests, _rx) = create_test_manager();
 
@@ -1399,16 +1408,18 @@ mod tests {
         };
         let txid = tx.txid();
 
-        // Add the tx with a timestamp far in the past so it expires
+        // Add the tx at T=0
         {
             let mut state = manager.mempool_state.write().await;
-            let mut utx =
+            let utx =
                 UnconfirmedTransaction::new(tx, Amount::from_sat(0), false, false, Vec::new(), 0);
-            utx.first_seen = Instant::now() - MEMPOOL_TX_EXPIRY - Duration::from_secs(1);
             state.add_transaction(utx);
         }
 
-        // Also store a pending IS lock for this txid and an unrelated one
+        // Advance time past the expiry threshold so the tx is now considered expired
+        tokio::time::advance(MEMPOOL_TX_EXPIRY + Duration::from_secs(1)).await;
+
+        // Insert IS locks after the time advance so they are fresh at the new "now"
         let unrelated_txid = Txid::from_byte_array([0xdd; 32]);
         manager.pending_is_locks.insert(txid, Instant::now());
         manager.pending_is_locks.insert(unrelated_txid, Instant::now());
@@ -1427,17 +1438,18 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_prune_expired_removes_stale_pending_is_locks() {
         let (mut manager, _requests, _rx) = create_test_manager();
 
-        // Insert a pending IS lock that is older than the expiry threshold
+        // Insert a pending IS lock at T=0; it will become stale after we advance time
         let stale_txid = Txid::from_byte_array([0xaa; 32]);
-        manager
-            .pending_is_locks
-            .insert(stale_txid, Instant::now() - MEMPOOL_TX_EXPIRY - Duration::from_secs(1));
+        manager.pending_is_locks.insert(stale_txid, Instant::now());
 
-        // Insert a fresh pending IS lock
+        // Advance time past the expiry threshold
+        tokio::time::advance(MEMPOOL_TX_EXPIRY + Duration::from_secs(1)).await;
+
+        // Insert a fresh pending IS lock at the new "now"
         let fresh_txid = Txid::from_byte_array([0xbb; 32]);
         manager.pending_is_locks.insert(fresh_txid, Instant::now());
 
@@ -1476,7 +1488,7 @@ mod tests {
         assert_eq!(manager.queued.values().map(|q| q.len()).sum::<usize>(), 1);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_activation_retry_on_timeout() {
         let (mut manager, requests, _rx) = create_test_manager();
         manager.activate(test_socket_address(1), &requests).await.unwrap();
@@ -1485,8 +1497,8 @@ mod tests {
         assert!(!manager.needs_activation_retry());
         assert!(manager.activated_at.is_some());
 
-        // Simulate timeout by backdating the activation timestamp
-        manager.activated_at = Some(Instant::now() - ACTIVATION_TIMEOUT);
+        // Simulate timeout by advancing time past the activation timeout
+        tokio::time::advance(ACTIVATION_TIMEOUT).await;
         assert!(manager.needs_activation_retry());
     }
 
@@ -1666,16 +1678,16 @@ mod tests {
         assert!(manager.queued.is_empty());
     }
 
-    #[test]
-    fn test_prune_pending_requeues_to_connected_peer() {
+    #[tokio::test(start_paused = true)]
+    async fn test_prune_pending_requeues_to_connected_peer() {
         let (mut manager, _requests, _rx) = create_test_manager();
         let peer = test_socket_address(1);
         manager.handle_peer_connected(peer);
 
         let txid = Txid::from_byte_array([1; 32]);
-        manager
-            .pending_requests
-            .insert(txid, Instant::now() - PENDING_REQUEST_TIMEOUT - Duration::from_secs(1));
+        manager.pending_requests.insert(txid, Instant::now());
+
+        tokio::time::advance(PENDING_REQUEST_TIMEOUT + Duration::from_secs(1)).await;
 
         manager.prune_pending_requests();
 
@@ -1683,14 +1695,14 @@ mod tests {
         assert!(manager.queued[&peer].contains(&txid));
     }
 
-    #[test]
-    fn test_prune_pending_drops_when_no_peers() {
+    #[tokio::test(start_paused = true)]
+    async fn test_prune_pending_drops_when_no_peers() {
         let (mut manager, _requests, _rx) = create_test_manager();
 
         let txid = Txid::from_byte_array([1; 32]);
-        manager
-            .pending_requests
-            .insert(txid, Instant::now() - PENDING_REQUEST_TIMEOUT - Duration::from_secs(1));
+        manager.pending_requests.insert(txid, Instant::now());
+
+        tokio::time::advance(PENDING_REQUEST_TIMEOUT + Duration::from_secs(1)).await;
 
         manager.prune_pending_requests();
 

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -5,12 +5,13 @@
 //! transactions from the mempool.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use dashcore::network::message_blockdata::Inventory;
-use dashcore::Txid;
+use dashcore::{Amount, Transaction, Txid};
 use rand::seq::IteratorRandom;
 use tokio::sync::RwLock;
 
@@ -95,8 +96,10 @@ impl<W: WalletInterface> MempoolManager<W> {
 
     /// Activate mempool monitoring after sync is complete.
     ///
-    /// For BloomFilter strategy: builds and sends a bloom filter, then sends `mempool`.
-    /// For FetchAll strategy: just sends `mempool`.
+    /// Since we connect with `relay=false`, peers won't send transaction INVs
+    /// until we explicitly enable relay:
+    /// - BloomFilter strategy: sends `filterload` (which enables filtered relay) + `mempool`
+    /// - FetchAll strategy: sends `mempool` + `filterclear` (which enables unfiltered relay)
     ///
     /// Sets `activated_at` so that `needs_activation_retry()` can detect
     /// activation failures if no inventory response arrives within the timeout.
@@ -109,6 +112,11 @@ impl<W: WalletInterface> MempoolManager<W> {
 
         // Request current mempool inventory
         requests.request_mempool()?;
+
+        if self.strategy == MempoolStrategy::FetchAll {
+            // Enable unfiltered transaction relay going forward
+            requests.send_filter_clear()?;
+        }
 
         self.activated_at = Some(Instant::now());
         Ok(())
@@ -299,7 +307,7 @@ impl<W: WalletInterface> MempoolManager<W> {
     /// Handle a received transaction.
     pub(super) async fn handle_tx(
         &mut self,
-        tx: dashcore::Transaction,
+        tx: Transaction,
     ) -> SyncResult<Vec<SyncEvent>> {
         let txid = tx.txid();
         self.pending_requests.remove(&txid);
@@ -324,7 +332,7 @@ impl<W: WalletInterface> MempoolManager<W> {
         // The wallet already confirmed relevance, so we store unconditionally.
         let unconfirmed_tx = UnconfirmedTransaction::new(
             tx,
-            dashcore::Amount::ZERO,
+            Amount::ZERO,
             is_locked,
             result.is_outgoing,
             result.addresses,
@@ -480,8 +488,8 @@ impl<W: WalletInterface> MempoolManager<W> {
     }
 }
 
-impl<W: WalletInterface> std::fmt::Debug for MempoolManager<W> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<W: WalletInterface> fmt::Debug for MempoolManager<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MempoolManager")
             .field("progress", &self.progress)
             .field("strategy", &self.strategy)
@@ -498,7 +506,7 @@ mod tests {
     use crate::network::NetworkRequest;
     use dashcore::hashes::Hash;
     use dashcore::network::message::NetworkMessage;
-    use dashcore::{Address, Network, OutPoint, ScriptBuf, Transaction};
+    use dashcore::{Address, BlockHash, Network, OutPoint, ScriptBuf, Transaction};
     use key_wallet::transaction_checking::TransactionContext;
     use key_wallet_manager::test_utils::MockWallet;
 
@@ -589,7 +597,7 @@ mod tests {
                 };
                 state.add_transaction(UnconfirmedTransaction::new(
                     tx,
-                    dashcore::Amount::from_sat(0),
+                    Amount::from_sat(0),
                     false,
                     false,
                     Vec::new(),
@@ -693,7 +701,7 @@ mod tests {
             let mut state = manager.mempool_state.write().await;
             state.add_transaction(UnconfirmedTransaction::new(
                 tx,
-                dashcore::Amount::from_sat(0),
+                Amount::from_sat(0),
                 false,
                 false,
                 Vec::new(),
@@ -724,7 +732,7 @@ mod tests {
             let mut state = manager.mempool_state.write().await;
             state.add_transaction(UnconfirmedTransaction::new(
                 tx,
-                dashcore::Amount::from_sat(0),
+                Amount::from_sat(0),
                 false,
                 false,
                 Vec::new(),
@@ -743,7 +751,7 @@ mod tests {
         let (mut manager, requests, _rx) = create_test_manager();
 
         let inv = vec![
-            Inventory::Block(dashcore::BlockHash::all_zeros()),
+            Inventory::Block(BlockHash::all_zeros()),
             Inventory::Transaction(Txid::from_byte_array([1u8; 32])),
         ];
 
@@ -769,7 +777,7 @@ mod tests {
             let mut state = manager.mempool_state.write().await;
             state.add_transaction(UnconfirmedTransaction::new(
                 tx,
-                dashcore::Amount::from_sat(0),
+                Amount::from_sat(0),
                 false,
                 false,
                 Vec::new(),
@@ -856,7 +864,7 @@ mod tests {
     ) -> (
         MempoolManager<MockWallet>,
         RequestSender,
-        tokio::sync::mpsc::UnboundedReceiver<NetworkRequest>,
+        mpsc::UnboundedReceiver<NetworkRequest>,
     ) {
         let mut mock = MockWallet::new();
         mock.set_addresses(addresses);
@@ -994,7 +1002,7 @@ mod tests {
             let mut state = manager.mempool_state.write().await;
             state.add_transaction(UnconfirmedTransaction::new(
                 tx,
-                dashcore::Amount::from_sat(0),
+                Amount::from_sat(0),
                 false,
                 false,
                 Vec::new(),
@@ -1050,7 +1058,7 @@ mod tests {
             let mut state = manager.mempool_state.write().await;
             state.add_transaction(UnconfirmedTransaction::new(
                 tx,
-                dashcore::Amount::from_sat(0),
+                Amount::from_sat(0),
                 false,
                 false,
                 Vec::new(),
@@ -1161,7 +1169,7 @@ mod tests {
             let mut state = manager.mempool_state.write().await;
             state.add_transaction(UnconfirmedTransaction::new(
                 tx,
-                dashcore::Amount::from_sat(0),
+                Amount::from_sat(0),
                 false,
                 false,
                 Vec::new(),
@@ -1319,7 +1327,7 @@ mod tests {
             let mut state = manager.mempool_state.write().await;
             let mut utx = UnconfirmedTransaction::new(
                 tx,
-                dashcore::Amount::from_sat(0),
+                Amount::from_sat(0),
                 false,
                 false,
                 Vec::new(),

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -99,7 +99,7 @@ impl<W: WalletInterface> MempoolManager<W> {
         }
     }
 
-    /// Activate mempool monitoring on a specific peer after sync is complete.
+    /// Activate mempool monitoring after sync is complete.
     ///
     /// Since we connect with `relay=false`, peers won't send transaction INVs
     /// until we explicitly enable relay:
@@ -307,9 +307,6 @@ impl<W: WalletInterface> MempoolManager<W> {
                 available -= 1;
             }
         }
-
-        // Remove empty queues
-        self.queued.retain(|_, q| !q.is_empty());
 
         let total_queued: usize = self.queued.values().map(|q| q.len()).sum();
         for (peer, inventory) in per_peer {

--- a/dash-spv/src/sync/mempool/mod.rs
+++ b/dash-spv/src/sync/mempool/mod.rs
@@ -1,0 +1,7 @@
+mod bloom;
+mod manager;
+mod progress;
+mod sync_manager;
+
+pub use manager::MempoolManager;
+pub use progress::MempoolProgress;

--- a/dash-spv/src/sync/mempool/progress.rs
+++ b/dash-spv/src/sync/mempool/progress.rs
@@ -1,0 +1,103 @@
+use crate::sync::SyncState;
+use std::fmt;
+use std::time::Instant;
+
+/// Progress tracking for mempool transaction monitoring.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MempoolProgress {
+    /// Current sync state.
+    state: SyncState,
+    /// Total transactions received from the network.
+    received: u32,
+    /// Transactions that matched wallet addresses.
+    relevant: u32,
+    /// Transactions currently tracked in mempool state (wallet-relevant).
+    tracked: u32,
+    /// Transactions removed (confirmed or expired).
+    removed: u32,
+    /// Time of last activity.
+    last_activity: Instant,
+}
+
+impl Default for MempoolProgress {
+    fn default() -> Self {
+        Self {
+            state: Default::default(),
+            received: 0,
+            relevant: 0,
+            tracked: 0,
+            removed: 0,
+            last_activity: Instant::now(),
+        }
+    }
+}
+
+impl MempoolProgress {
+    pub fn state(&self) -> SyncState {
+        self.state
+    }
+
+    pub fn received(&self) -> u32 {
+        self.received
+    }
+
+    pub fn relevant(&self) -> u32 {
+        self.relevant
+    }
+
+    pub fn tracked(&self) -> u32 {
+        self.tracked
+    }
+
+    pub fn removed(&self) -> u32 {
+        self.removed
+    }
+
+    pub fn last_activity(&self) -> Instant {
+        self.last_activity
+    }
+
+    pub(super) fn set_state(&mut self, state: SyncState) {
+        self.state = state;
+        self.bump_last_activity();
+    }
+
+    pub(super) fn add_received(&mut self, count: u32) {
+        self.received += count;
+        self.bump_last_activity();
+    }
+
+    pub(super) fn add_relevant(&mut self, count: u32) {
+        self.relevant += count;
+        self.bump_last_activity();
+    }
+
+    pub(super) fn set_tracked(&mut self, count: u32) {
+        self.tracked = count;
+        self.bump_last_activity();
+    }
+
+    pub(super) fn add_removed(&mut self, count: u32) {
+        self.removed += count;
+        self.bump_last_activity();
+    }
+
+    fn bump_last_activity(&mut self) {
+        self.last_activity = Instant::now();
+    }
+}
+
+impl fmt::Display for MempoolProgress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:?} received: {}, relevant: {}, tracked: {}, removed: {}, last_activity: {}s",
+            self.state,
+            self.received,
+            self.relevant,
+            self.tracked,
+            self.removed,
+            self.last_activity.elapsed().as_secs()
+        )
+    }
+}

--- a/dash-spv/src/sync/mempool/progress.rs
+++ b/dash-spv/src/sync/mempool/progress.rs
@@ -1,6 +1,6 @@
 use crate::sync::SyncState;
 use std::fmt;
-use std::time::Instant;
+use tokio::time::Instant;
 
 /// Progress tracking for mempool transaction monitoring.
 #[derive(Debug, Clone, PartialEq)]
@@ -97,7 +97,7 @@ impl fmt::Display for MempoolProgress {
             self.relevant,
             self.tracked,
             self.removed,
-            self.last_activity.elapsed().as_secs()
+            Instant::now().checked_duration_since(self.last_activity).unwrap_or_default().as_secs()
         )
     }
 }

--- a/dash-spv/src/sync/mempool/sync_manager.rs
+++ b/dash-spv/src/sync/mempool/sync_manager.rs
@@ -1,0 +1,476 @@
+use crate::error::SyncResult;
+use crate::network::{Message, MessageType, NetworkEvent, RequestSender};
+use crate::sync::{
+    ManagerIdentifier, MempoolManager, SyncEvent, SyncManager, SyncManagerProgress, SyncState,
+};
+use async_trait::async_trait;
+use dashcore::network::message::NetworkMessage;
+use key_wallet_manager::wallet_interface::WalletInterface;
+
+#[async_trait]
+impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
+    fn identifier(&self) -> ManagerIdentifier {
+        ManagerIdentifier::Mempool
+    }
+
+    fn state(&self) -> SyncState {
+        self.progress.state()
+    }
+
+    fn set_state(&mut self, state: SyncState) {
+        self.progress.set_state(state);
+    }
+
+    fn clear_in_flight_state(&mut self) {
+        self.clear_pending();
+    }
+
+    fn wanted_message_types(&self) -> &'static [MessageType] {
+        &[MessageType::Inv, MessageType::Tx]
+    }
+
+    async fn handle_message(
+        &mut self,
+        msg: Message,
+        requests: &RequestSender,
+    ) -> SyncResult<Vec<SyncEvent>> {
+        match msg.inner() {
+            NetworkMessage::Inv(inv) => self.handle_inv(inv, msg.peer_address(), requests),
+            NetworkMessage::Tx(tx) => self.handle_tx(tx.clone()).await,
+            _ => Ok(vec![]),
+        }
+    }
+
+    async fn handle_sync_event(
+        &mut self,
+        event: &SyncEvent,
+        requests: &RequestSender,
+    ) -> SyncResult<Vec<SyncEvent>> {
+        match event {
+            SyncEvent::SyncComplete {
+                ..
+            } => {
+                if self.state() != SyncState::Synced {
+                    // Activate (or re-activate after reconnect) mempool monitoring
+                    self.activate(requests).await?;
+                    self.set_state(SyncState::Synced);
+                    tracing::info!("Mempool manager activated after sync complete");
+                }
+                Ok(vec![])
+            }
+            SyncEvent::BlockProcessed {
+                new_addresses,
+                confirmed_txids,
+                ..
+            } => {
+                // Remove confirmed transactions from mempool
+                if !confirmed_txids.is_empty() {
+                    self.remove_confirmed(confirmed_txids).await;
+                }
+                // Rebuild bloom filter if new addresses were discovered
+                if !new_addresses.is_empty() && self.state() == SyncState::Synced {
+                    self.rebuild_filter(requests).await?;
+                }
+                Ok(vec![])
+            }
+            SyncEvent::InstantLockReceived {
+                instant_lock,
+                ..
+            } => {
+                self.mark_instant_send(&instant_lock.txid).await;
+                Ok(vec![])
+            }
+            SyncEvent::ChainLockReceived {
+                chain_lock,
+                ..
+            } => {
+                self.forward_chainlock(chain_lock.block_height).await;
+                Ok(vec![])
+            }
+            _ => Ok(vec![]),
+        }
+    }
+
+    async fn handle_network_event(
+        &mut self,
+        event: &NetworkEvent,
+        requests: &RequestSender,
+    ) -> SyncResult<Vec<SyncEvent>> {
+        match event {
+            NetworkEvent::PeerConnected {
+                address,
+            } => {
+                self.handle_peer_connected(*address);
+            }
+            NetworkEvent::PeerDisconnected {
+                address,
+            } => {
+                self.handle_peer_disconnected(*address);
+            }
+            NetworkEvent::PeersUpdated {
+                connected_count,
+                best_height,
+                ..
+            } => {
+                if let Some(best_height) = best_height {
+                    self.update_target_height(*best_height);
+                }
+                if *connected_count == 0 {
+                    self.stop_sync();
+                } else if self.state() == SyncState::WaitingForConnections {
+                    return self.start_sync(requests).await;
+                }
+            }
+        }
+        Ok(vec![])
+    }
+
+    async fn tick(&mut self, requests: &RequestSender) -> SyncResult<Vec<SyncEvent>> {
+        if self.state() != SyncState::Synced {
+            return Ok(vec![]);
+        }
+
+        // Retry activation if no inventory response arrived within the timeout
+        if self.needs_activation_retry() {
+            tracing::debug!("Retrying mempool activation (no response within timeout)");
+            self.activate(requests).await?;
+        }
+
+        // Prune expired transactions periodically
+        self.prune_expired().await;
+
+        // Prune pending requests that never received a response
+        self.prune_pending_requests();
+
+        // Send queued getdata requests now that slots may have freed up
+        self.send_queued(requests)?;
+
+        // Check if bloom filter needs rebuilding
+        self.check_filter_staleness(requests).await;
+
+        Ok(vec![])
+    }
+
+    fn progress(&self) -> SyncManagerProgress {
+        SyncManagerProgress::Mempool(self.progress.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::NetworkRequest;
+    use crate::types::UnconfirmedTransaction;
+    use dashcore::hashes::Hash;
+    use key_wallet_manager::test_utils::MockWallet;
+    use std::sync::Arc;
+    use tokio::sync::{mpsc, RwLock};
+
+    fn create_test_manager(
+    ) -> (MempoolManager<MockWallet>, RequestSender, mpsc::UnboundedReceiver<NetworkRequest>) {
+        let wallet = Arc::new(RwLock::new(MockWallet::new()));
+        let mempool_state = Arc::new(RwLock::new(crate::types::MempoolState::default()));
+        let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let requests = RequestSender::new(tx);
+
+        let manager = MempoolManager::new(
+            wallet,
+            mempool_state,
+            crate::client::config::MempoolStrategy::FetchAll,
+            1000,
+        );
+
+        (manager, requests, rx)
+    }
+
+    #[test]
+    fn test_identifier() {
+        let (manager, _, _rx) = create_test_manager();
+        assert_eq!(manager.identifier(), ManagerIdentifier::Mempool);
+    }
+
+    #[test]
+    fn test_initial_state() {
+        let (manager, _, _rx) = create_test_manager();
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
+    }
+
+    #[test]
+    fn test_wanted_message_types() {
+        let (manager, _, _rx) = create_test_manager();
+        let types = manager.wanted_message_types();
+        assert!(types.contains(&MessageType::Inv));
+        assert!(types.contains(&MessageType::Tx));
+        assert_eq!(types.len(), 2);
+    }
+
+    #[test]
+    fn test_set_state() {
+        let (mut manager, _, _rx) = create_test_manager();
+        manager.set_state(SyncState::Synced);
+        assert_eq!(manager.state(), SyncState::Synced);
+    }
+
+    #[test]
+    fn test_progress_variant() {
+        let (manager, _, _rx) = create_test_manager();
+        let progress = manager.progress();
+        assert!(matches!(progress, SyncManagerProgress::Mempool(_)));
+    }
+
+    #[tokio::test]
+    async fn test_handle_sync_complete_activates() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        let event = SyncEvent::SyncComplete {
+            header_tip: 1000,
+            cycle: 0,
+        };
+
+        let events = manager.handle_sync_event(&event, &requests).await.unwrap();
+        assert!(events.is_empty());
+        assert_eq!(manager.state(), SyncState::Synced);
+    }
+
+    #[tokio::test]
+    async fn test_handle_sync_complete_subsequent_cycles() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        // Activate first
+        let event0 = SyncEvent::SyncComplete {
+            header_tip: 1000,
+            cycle: 0,
+        };
+        manager.handle_sync_event(&event0, &requests).await.unwrap();
+
+        // Subsequent cycles should not change state
+        let event1 = SyncEvent::SyncComplete {
+            header_tip: 1001,
+            cycle: 1,
+        };
+        let events = manager.handle_sync_event(&event1, &requests).await.unwrap();
+        assert!(events.is_empty());
+        assert_eq!(manager.state(), SyncState::Synced);
+    }
+
+    #[tokio::test]
+    async fn test_tick_before_synced() {
+        let (mut manager, requests, _rx) = create_test_manager();
+        // Before sync complete, tick should do nothing
+        let events = manager.tick(&requests).await.unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_block_processed_removes_confirmed_txids() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        // Add two transactions to mempool state
+        let tx1 = dashcore::Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let tx2 = dashcore::Transaction {
+            version: 1,
+            lock_time: 1,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid1 = tx1.txid();
+        let txid2 = tx2.txid();
+        {
+            let mut state = manager.mempool_state.write().await;
+            state.add_transaction(UnconfirmedTransaction::new(
+                tx1,
+                dashcore::Amount::from_sat(0),
+                false,
+                false,
+                Vec::new(),
+                0,
+            ));
+            state.add_transaction(UnconfirmedTransaction::new(
+                tx2,
+                dashcore::Amount::from_sat(0),
+                false,
+                false,
+                Vec::new(),
+                0,
+            ));
+        }
+
+        let event = SyncEvent::BlockProcessed {
+            block_hash: dashcore::BlockHash::all_zeros(),
+            height: 100,
+            new_addresses: vec![],
+            confirmed_txids: vec![txid1],
+        };
+
+        let events = manager.handle_sync_event(&event, &requests).await.unwrap();
+        assert!(events.is_empty());
+
+        let state = manager.mempool_state.read().await;
+        assert!(!state.transactions.contains_key(&txid1));
+        assert!(state.transactions.contains_key(&txid2));
+        assert_eq!(manager.progress.removed(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_block_processed_with_unknown_txids() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        // Add one transaction to mempool
+        let tx = dashcore::Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        let txid = tx.txid();
+        let unknown_txid = dashcore::Txid::from_byte_array([0xaa; 32]);
+        {
+            let mut state = manager.mempool_state.write().await;
+            state.add_transaction(UnconfirmedTransaction::new(
+                tx,
+                dashcore::Amount::from_sat(0),
+                false,
+                false,
+                Vec::new(),
+                0,
+            ));
+        }
+
+        // Confirm with a mix of known and unknown txids
+        let event = SyncEvent::BlockProcessed {
+            block_hash: dashcore::BlockHash::all_zeros(),
+            height: 100,
+            new_addresses: vec![],
+            confirmed_txids: vec![unknown_txid, txid],
+        };
+
+        let events = manager.handle_sync_event(&event, &requests).await.unwrap();
+        assert!(events.is_empty());
+
+        let state = manager.mempool_state.read().await;
+        assert!(state.transactions.is_empty());
+        assert_eq!(manager.progress.removed(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_block_processed_empty_confirmed_txids() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        // Add a transaction to mempool
+        let tx = dashcore::Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: None,
+        };
+        {
+            let mut state = manager.mempool_state.write().await;
+            state.add_transaction(UnconfirmedTransaction::new(
+                tx,
+                dashcore::Amount::from_sat(0),
+                false,
+                false,
+                Vec::new(),
+                0,
+            ));
+        }
+
+        // Empty confirmed_txids should not remove anything
+        let event = SyncEvent::BlockProcessed {
+            block_hash: dashcore::BlockHash::all_zeros(),
+            height: 100,
+            new_addresses: vec![],
+            confirmed_txids: vec![],
+        };
+
+        manager.handle_sync_event(&event, &requests).await.unwrap();
+
+        let state = manager.mempool_state.read().await;
+        assert_eq!(state.transactions.len(), 1);
+        assert_eq!(manager.progress.removed(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_chainlock_received_notifies_wallet() {
+        use dashcore::ephemerealdata::chain_lock::ChainLock;
+
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        let event = SyncEvent::ChainLockReceived {
+            chain_lock: ChainLock {
+                block_height: 1000,
+                block_hash: dashcore::BlockHash::from_byte_array([0; 32]),
+                signature: [0u8; 96].into(),
+            },
+            validated: true,
+        };
+
+        let events = manager.handle_sync_event(&event, &requests).await.unwrap();
+        assert!(events.is_empty());
+
+        let wallet = manager.wallet.read().await;
+        let notifications = wallet.chainlock_notifications();
+        let notifications = notifications.lock().await;
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(notifications[0], 1000);
+    }
+
+    #[tokio::test]
+    async fn test_reactivation_after_disconnect() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        // Initial activation
+        let event = SyncEvent::SyncComplete {
+            header_tip: 1000,
+            cycle: 0,
+        };
+        manager.handle_sync_event(&event, &requests).await.unwrap();
+        assert_eq!(manager.state(), SyncState::Synced);
+
+        // Simulate disconnect by resetting state
+        manager.set_state(SyncState::WaitForEvents);
+
+        // Re-sync should re-activate
+        let event = SyncEvent::SyncComplete {
+            header_tip: 1001,
+            cycle: 1,
+        };
+        manager.handle_sync_event(&event, &requests).await.unwrap();
+        assert_eq!(manager.state(), SyncState::Synced);
+    }
+
+    #[tokio::test]
+    async fn test_network_event_peer_connect_disconnect() {
+        let (mut manager, requests, _rx) = create_test_manager();
+
+        let peer1 = crate::test_utils::test_socket_address(1);
+        let peer2 = crate::test_utils::test_socket_address(2);
+
+        // Connect and disconnect should not error
+        let connect1 = NetworkEvent::PeerConnected {
+            address: peer1,
+        };
+        manager.handle_network_event(&connect1, &requests).await.unwrap();
+        let connect2 = NetworkEvent::PeerConnected {
+            address: peer2,
+        };
+        manager.handle_network_event(&connect2, &requests).await.unwrap();
+
+        let disconnect1 = NetworkEvent::PeerDisconnected {
+            address: peer1,
+        };
+        manager.handle_network_event(&disconnect1, &requests).await.unwrap();
+
+        // Disconnecting an already-disconnected peer should not error
+        manager.handle_network_event(&disconnect1, &requests).await.unwrap();
+    }
+}

--- a/dash-spv/src/sync/mempool/sync_manager.rs
+++ b/dash-spv/src/sync/mempool/sync_manager.rs
@@ -51,10 +51,13 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
                 ..
             } => {
                 if self.state() != SyncState::Synced {
-                    // Activate (or re-activate after reconnect) mempool monitoring
-                    self.activate(requests).await?;
-                    self.set_state(SyncState::Synced);
-                    tracing::info!("Mempool manager activated after sync complete");
+                    if let Some(peer) = self.pick_peer() {
+                        self.activate(peer, requests).await?;
+                        self.set_state(SyncState::Synced);
+                        tracing::info!("Mempool manager activated on peer {}", peer);
+                    } else {
+                        tracing::warn!("Sync complete but no peers available for mempool activation");
+                    }
                 }
                 Ok(vec![])
             }
@@ -105,7 +108,15 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
             NetworkEvent::PeerDisconnected {
                 address,
             } => {
-                self.handle_peer_disconnected(*address);
+                let needs_reactivation = self.handle_peer_disconnected(*address);
+                if needs_reactivation && self.state() == SyncState::Synced {
+                    if let Some(new_peer) = self.pick_peer() {
+                        self.activate(new_peer, requests).await?;
+                        tracing::info!("Re-activated mempool on peer {}", new_peer);
+                    } else {
+                        tracing::warn!("Mempool peer lost and no peers available for re-activation");
+                    }
+                }
             }
             NetworkEvent::PeersUpdated {
                 connected_count,
@@ -132,8 +143,10 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
 
         // Retry activation if no inventory response arrived within the timeout
         if self.needs_activation_retry() {
-            tracing::debug!("Retrying mempool activation (no response within timeout)");
-            self.activate(requests).await?;
+            if let Some(peer) = self.pick_peer() {
+                tracing::debug!("Retrying mempool activation on peer {}", peer);
+                self.activate(peer, requests).await?;
+            }
         }
 
         // Prune expired transactions periodically
@@ -225,6 +238,8 @@ mod tests {
     #[tokio::test]
     async fn test_handle_sync_complete_activates() {
         let (mut manager, requests, _rx) = create_test_manager();
+        let peer = crate::test_utils::test_socket_address(1);
+        manager.handle_peer_connected(peer);
 
         let event = SyncEvent::SyncComplete {
             header_tip: 1000,
@@ -234,11 +249,13 @@ mod tests {
         let events = manager.handle_sync_event(&event, &requests).await.unwrap();
         assert!(events.is_empty());
         assert_eq!(manager.state(), SyncState::Synced);
+        assert_eq!(manager.mempool_peer, Some(peer));
     }
 
     #[tokio::test]
     async fn test_handle_sync_complete_subsequent_cycles() {
         let (mut manager, requests, _rx) = create_test_manager();
+        manager.handle_peer_connected(crate::test_utils::test_socket_address(1));
 
         // Activate first
         let event0 = SyncEvent::SyncComplete {
@@ -429,6 +446,8 @@ mod tests {
     #[tokio::test]
     async fn test_reactivation_after_disconnect() {
         let (mut manager, requests, _rx) = create_test_manager();
+        let peer = test_socket_address(1);
+        manager.handle_peer_connected(peer);
 
         // Initial activation
         let event = SyncEvent::SyncComplete {

--- a/dash-spv/src/sync/mempool/sync_manager.rs
+++ b/dash-spv/src/sync/mempool/sync_manager.rs
@@ -55,6 +55,7 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
                         self.activate(peer, requests).await?;
                         self.set_state(SyncState::Synced);
                         tracing::info!("Mempool manager activated on peer {}", peer);
+                        return Ok(vec![SyncEvent::MempoolActivated { peer }]);
                     } else {
                         tracing::warn!("Sync complete but no peers available for mempool activation");
                     }
@@ -113,6 +114,7 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
                     if let Some(new_peer) = self.pick_peer() {
                         self.activate(new_peer, requests).await?;
                         tracing::info!("Re-activated mempool on peer {}", new_peer);
+                        return Ok(vec![SyncEvent::MempoolActivated { peer: new_peer }]);
                     } else {
                         tracing::warn!("Mempool peer lost and no peers available for re-activation");
                     }
@@ -247,7 +249,8 @@ mod tests {
         };
 
         let events = manager.handle_sync_event(&event, &requests).await.unwrap();
-        assert!(events.is_empty());
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], SyncEvent::MempoolActivated { peer: p } if *p == peer));
         assert_eq!(manager.state(), SyncState::Synced);
         assert_eq!(manager.mempool_peer, Some(peer));
     }
@@ -454,7 +457,8 @@ mod tests {
             header_tip: 1000,
             cycle: 0,
         };
-        manager.handle_sync_event(&event, &requests).await.unwrap();
+        let events = manager.handle_sync_event(&event, &requests).await.unwrap();
+        assert!(matches!(&events[0], SyncEvent::MempoolActivated { .. }));
         assert_eq!(manager.state(), SyncState::Synced);
 
         // Simulate disconnect by resetting state
@@ -465,7 +469,8 @@ mod tests {
             header_tip: 1001,
             cycle: 1,
         };
-        manager.handle_sync_event(&event, &requests).await.unwrap();
+        let events = manager.handle_sync_event(&event, &requests).await.unwrap();
+        assert!(matches!(&events[0], SyncEvent::MempoolActivated { .. }));
         assert_eq!(manager.state(), SyncState::Synced);
     }
 

--- a/dash-spv/src/sync/mempool/sync_manager.rs
+++ b/dash-spv/src/sync/mempool/sync_manager.rs
@@ -159,9 +159,13 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::config::MempoolStrategy;
     use crate::network::NetworkRequest;
-    use crate::types::UnconfirmedTransaction;
+    use crate::test_utils::test_socket_address;
+    use crate::types::{MempoolState, UnconfirmedTransaction};
+    use dashcore::ephemerealdata::chain_lock::ChainLock;
     use dashcore::hashes::Hash;
+    use dashcore::{Amount, BlockHash, Transaction, Txid};
     use key_wallet_manager::test_utils::MockWallet;
     use std::sync::Arc;
     use tokio::sync::{mpsc, RwLock};
@@ -169,14 +173,14 @@ mod tests {
     fn create_test_manager(
     ) -> (MempoolManager<MockWallet>, RequestSender, mpsc::UnboundedReceiver<NetworkRequest>) {
         let wallet = Arc::new(RwLock::new(MockWallet::new()));
-        let mempool_state = Arc::new(RwLock::new(crate::types::MempoolState::default()));
+        let mempool_state = Arc::new(RwLock::new(MempoolState::default()));
         let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
         let manager = MempoolManager::new(
             wallet,
             mempool_state,
-            crate::client::config::MempoolStrategy::FetchAll,
+            MempoolStrategy::FetchAll,
             1000,
         );
 
@@ -266,14 +270,14 @@ mod tests {
         let (mut manager, requests, _rx) = create_test_manager();
 
         // Add two transactions to mempool state
-        let tx1 = dashcore::Transaction {
+        let tx1 = Transaction {
             version: 1,
             lock_time: 0,
             input: vec![],
             output: vec![],
             special_transaction_payload: None,
         };
-        let tx2 = dashcore::Transaction {
+        let tx2 = Transaction {
             version: 1,
             lock_time: 1,
             input: vec![],
@@ -286,7 +290,7 @@ mod tests {
             let mut state = manager.mempool_state.write().await;
             state.add_transaction(UnconfirmedTransaction::new(
                 tx1,
-                dashcore::Amount::from_sat(0),
+                Amount::from_sat(0),
                 false,
                 false,
                 Vec::new(),
@@ -294,7 +298,7 @@ mod tests {
             ));
             state.add_transaction(UnconfirmedTransaction::new(
                 tx2,
-                dashcore::Amount::from_sat(0),
+                Amount::from_sat(0),
                 false,
                 false,
                 Vec::new(),
@@ -303,7 +307,7 @@ mod tests {
         }
 
         let event = SyncEvent::BlockProcessed {
-            block_hash: dashcore::BlockHash::all_zeros(),
+            block_hash: BlockHash::all_zeros(),
             height: 100,
             new_addresses: vec![],
             confirmed_txids: vec![txid1],
@@ -323,7 +327,7 @@ mod tests {
         let (mut manager, requests, _rx) = create_test_manager();
 
         // Add one transaction to mempool
-        let tx = dashcore::Transaction {
+        let tx = Transaction {
             version: 1,
             lock_time: 0,
             input: vec![],
@@ -331,12 +335,12 @@ mod tests {
             special_transaction_payload: None,
         };
         let txid = tx.txid();
-        let unknown_txid = dashcore::Txid::from_byte_array([0xaa; 32]);
+        let unknown_txid = Txid::from_byte_array([0xaa; 32]);
         {
             let mut state = manager.mempool_state.write().await;
             state.add_transaction(UnconfirmedTransaction::new(
                 tx,
-                dashcore::Amount::from_sat(0),
+                Amount::from_sat(0),
                 false,
                 false,
                 Vec::new(),
@@ -346,7 +350,7 @@ mod tests {
 
         // Confirm with a mix of known and unknown txids
         let event = SyncEvent::BlockProcessed {
-            block_hash: dashcore::BlockHash::all_zeros(),
+            block_hash: BlockHash::all_zeros(),
             height: 100,
             new_addresses: vec![],
             confirmed_txids: vec![unknown_txid, txid],
@@ -365,7 +369,7 @@ mod tests {
         let (mut manager, requests, _rx) = create_test_manager();
 
         // Add a transaction to mempool
-        let tx = dashcore::Transaction {
+        let tx = Transaction {
             version: 1,
             lock_time: 0,
             input: vec![],
@@ -376,7 +380,7 @@ mod tests {
             let mut state = manager.mempool_state.write().await;
             state.add_transaction(UnconfirmedTransaction::new(
                 tx,
-                dashcore::Amount::from_sat(0),
+                Amount::from_sat(0),
                 false,
                 false,
                 Vec::new(),
@@ -386,7 +390,7 @@ mod tests {
 
         // Empty confirmed_txids should not remove anything
         let event = SyncEvent::BlockProcessed {
-            block_hash: dashcore::BlockHash::all_zeros(),
+            block_hash: BlockHash::all_zeros(),
             height: 100,
             new_addresses: vec![],
             confirmed_txids: vec![],
@@ -401,14 +405,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_chainlock_received_notifies_wallet() {
-        use dashcore::ephemerealdata::chain_lock::ChainLock;
-
         let (mut manager, requests, _rx) = create_test_manager();
 
         let event = SyncEvent::ChainLockReceived {
             chain_lock: ChainLock {
                 block_height: 1000,
-                block_hash: dashcore::BlockHash::from_byte_array([0; 32]),
+                block_hash: BlockHash::from_byte_array([0; 32]),
                 signature: [0u8; 96].into(),
             },
             validated: true,
@@ -452,8 +454,8 @@ mod tests {
     async fn test_network_event_peer_connect_disconnect() {
         let (mut manager, requests, _rx) = create_test_manager();
 
-        let peer1 = crate::test_utils::test_socket_address(1);
-        let peer2 = crate::test_utils::test_socket_address(2);
+        let peer1 = test_socket_address(1);
+        let peer2 = test_socket_address(2);
 
         // Connect and disconnect should not error
         let connect1 = NetworkEvent::PeerConnected {

--- a/dash-spv/src/sync/mempool/sync_manager.rs
+++ b/dash-spv/src/sync/mempool/sync_manager.rs
@@ -55,9 +55,13 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
                         self.activate(peer, requests).await?;
                         self.set_state(SyncState::Synced);
                         tracing::info!("Mempool manager activated on peer {}", peer);
-                        return Ok(vec![SyncEvent::MempoolActivated { peer }]);
+                        return Ok(vec![SyncEvent::MempoolActivated {
+                            peer,
+                        }]);
                     } else {
-                        tracing::warn!("Sync complete but no peers available for mempool activation");
+                        tracing::warn!(
+                            "Sync complete but no peers available for mempool activation"
+                        );
                     }
                 }
                 Ok(vec![])
@@ -114,9 +118,13 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
                     if let Some(new_peer) = self.pick_peer() {
                         self.activate(new_peer, requests).await?;
                         tracing::info!("Re-activated mempool on peer {}", new_peer);
-                        return Ok(vec![SyncEvent::MempoolActivated { peer: new_peer }]);
+                        return Ok(vec![SyncEvent::MempoolActivated {
+                            peer: new_peer,
+                        }]);
                     } else {
-                        tracing::warn!("Mempool peer lost and no peers available for re-activation");
+                        tracing::warn!(
+                            "Mempool peer lost and no peers available for re-activation"
+                        );
                     }
                 }
             }
@@ -192,12 +200,7 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
-        let manager = MempoolManager::new(
-            wallet,
-            mempool_state,
-            MempoolStrategy::FetchAll,
-            1000,
-        );
+        let manager = MempoolManager::new(wallet, mempool_state, MempoolStrategy::FetchAll, 1000);
 
         (manager, requests, rx)
     }

--- a/dash-spv/src/sync/mod.rs
+++ b/dash-spv/src/sync/mod.rs
@@ -10,6 +10,7 @@ mod filters;
 mod identifier;
 mod instantsend;
 mod masternodes;
+mod mempool;
 mod progress;
 mod sync_coordinator;
 mod sync_manager;
@@ -21,6 +22,7 @@ pub use filter_headers::{FilterHeadersManager, FilterHeadersProgress};
 pub use filters::{FiltersManager, FiltersProgress};
 pub use instantsend::{InstantSendManager, InstantSendProgress};
 pub use masternodes::{MasternodesManager, MasternodesProgress};
+pub use mempool::{MempoolManager, MempoolProgress};
 
 pub use events::SyncEvent;
 pub use identifier::ManagerIdentifier;

--- a/dash-spv/src/sync/progress.rs
+++ b/dash-spv/src/sync/progress.rs
@@ -1,7 +1,7 @@
 use crate::error::{SyncError, SyncResult};
 use crate::sync::{
     BlockHeadersProgress, BlocksProgress, ChainLockProgress, FilterHeadersProgress,
-    FiltersProgress, InstantSendProgress, MasternodesProgress,
+    FiltersProgress, InstantSendProgress, MasternodesProgress, MempoolProgress,
 };
 use dashcore::prelude::CoreBlockHeight;
 use std::fmt;
@@ -34,6 +34,8 @@ pub struct SyncProgress {
     chainlocks: Option<ChainLockProgress>,
     /// InstantSend synchronization progress.
     instantsend: Option<InstantSendProgress>,
+    /// Mempool monitoring progress.
+    mempool: Option<MempoolProgress>,
 }
 
 impl SyncProgress {
@@ -156,6 +158,12 @@ impl SyncProgress {
             .ok_or_else(|| SyncError::InvalidState("InstantSendManager not started".into()))
     }
 
+    pub fn mempool(&self) -> SyncResult<&MempoolProgress> {
+        self.mempool
+            .as_ref()
+            .ok_or_else(|| SyncError::InvalidState("MempoolManager not started".into()))
+    }
+
     pub fn update_headers(&mut self, progress: BlockHeadersProgress) {
         let updated_headers = Some(progress);
         if self.headers != updated_headers {
@@ -209,6 +217,14 @@ impl SyncProgress {
             self.instantsend = updated_instantsend;
         }
     }
+
+    /// Update mempool progress.
+    pub fn update_mempool(&mut self, progress: MempoolProgress) {
+        let updated_mempool = Some(progress);
+        if self.mempool != updated_mempool {
+            self.mempool = updated_mempool;
+        }
+    }
 }
 
 impl fmt::Display for SyncProgress {
@@ -234,6 +250,9 @@ impl fmt::Display for SyncProgress {
         }
         if let Some(i) = &self.instantsend {
             writeln!(f, "  InstantSend:    {}", i)?;
+        }
+        if let Some(m) = &self.mempool {
+            writeln!(f, "  Mempool:        {}", m)?;
         }
         Ok(())
     }

--- a/dash-spv/src/sync/sync_coordinator.rs
+++ b/dash-spv/src/sync/sync_coordinator.rs
@@ -20,8 +20,8 @@ use crate::storage::{
 use crate::sync::progress::ProgressPercentage;
 use crate::sync::{
     BlockHeadersManager, BlocksManager, ChainLockManager, FilterHeadersManager, FiltersManager,
-    InstantSendManager, ManagerIdentifier, MasternodesManager, SyncEvent, SyncManager,
-    SyncManagerProgress, SyncManagerTaskContext, SyncProgress,
+    InstantSendManager, ManagerIdentifier, MasternodesManager, MempoolManager, SyncEvent,
+    SyncManager, SyncManagerProgress, SyncManagerTaskContext, SyncProgress,
 };
 use crate::SyncError;
 use key_wallet_manager::wallet_interface::WalletInterface;
@@ -78,6 +78,7 @@ where
     pub masternode: Option<MasternodesManager<H>>,
     pub chainlock: Option<ChainLockManager<H, M>>,
     pub instantsend: Option<InstantSendManager>,
+    pub mempool: Option<MempoolManager<W>>,
 }
 
 impl<H, FH, F, B, M, W> Default for Managers<H, FH, F, B, M, W>
@@ -98,6 +99,7 @@ where
             masternode: None,
             chainlock: None,
             instantsend: None,
+            mempool: None,
         }
     }
 }
@@ -213,6 +215,7 @@ where
         let masternode = self.managers.masternode.take();
         let chainlock = self.managers.chainlock.take();
         let instantsend = self.managers.instantsend.take();
+        let mempool = self.managers.mempool.take();
 
         // Spawn each manager using the macro
         spawn_manager!(self, block_headers, network);
@@ -222,6 +225,7 @@ where
         spawn_manager!(self, masternode, network);
         spawn_manager!(self, chainlock, network);
         spawn_manager!(self, instantsend, network);
+        spawn_manager!(self, mempool, network);
 
         // Clone receivers for progress task
         let receivers = self.progress_receivers.clone();
@@ -402,6 +406,7 @@ fn update_progress_from_manager(
         SyncManagerProgress::Masternodes(m) => progress.update_masternodes(m),
         SyncManagerProgress::ChainLock(c) => progress.update_chainlocks(c),
         SyncManagerProgress::InstantSend(i) => progress.update_instantsend(i),
+        SyncManagerProgress::Mempool(m) => progress.update_mempool(m),
     }
 }
 

--- a/dash-spv/src/sync/sync_manager.rs
+++ b/dash-spv/src/sync/sync_manager.rs
@@ -2,8 +2,8 @@ use crate::error::SyncResult;
 use crate::network::{Message, MessageType, NetworkEvent, RequestSender};
 use crate::sync::{
     BlockHeadersProgress, BlocksProgress, ChainLockProgress, FilterHeadersProgress,
-    FiltersProgress, InstantSendProgress, ManagerIdentifier, MasternodesProgress, SyncEvent,
-    SyncState,
+    FiltersProgress, InstantSendProgress, ManagerIdentifier, MasternodesProgress, MempoolProgress,
+    SyncEvent, SyncState,
 };
 use async_trait::async_trait;
 
@@ -30,6 +30,7 @@ pub enum SyncManagerProgress {
     Masternodes(MasternodesProgress),
     ChainLock(ChainLockProgress),
     InstantSend(InstantSendProgress),
+    Mempool(MempoolProgress),
 }
 
 impl SyncManagerProgress {
@@ -42,6 +43,7 @@ impl SyncManagerProgress {
             SyncManagerProgress::Masternodes(progress) => progress.state(),
             SyncManagerProgress::ChainLock(progress) => progress.state(),
             SyncManagerProgress::InstantSend(progress) => progress.state(),
+            SyncManagerProgress::Mempool(progress) => progress.state(),
         }
     }
 }

--- a/dash-spv/src/test_utils/network.rs
+++ b/dash-spv/src/test_utils/network.rs
@@ -177,8 +177,7 @@ impl NetworkManager for MockNetworkManager {
 }
 
 impl Peer {
-    pub fn dummy() -> Self {
-        let addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
+    pub fn dummy(addr: SocketAddr) -> Self {
         Peer::new(addr, Duration::from_secs(10), Network::Mainnet)
     }
 }

--- a/dash-spv/src/test_utils/node.rs
+++ b/dash-spv/src/test_utils/node.rs
@@ -344,6 +344,30 @@ impl DashCoreNode {
         txid
     }
 
+    /// Connect this dashd node to another dashd node via P2P and wait for the
+    /// connection to be established.
+    pub async fn connect_to_node(&self, addr: SocketAddr) {
+        let client = self.rpc_client();
+        client.onetry_node(&addr.to_string()).expect("failed to connect to node");
+
+        for _ in 0..30 {
+            let peers = client.get_peer_info().expect("failed to get peer info");
+            if peers.iter().any(|p| p.addr.to_string().starts_with(&addr.ip().to_string())) {
+                tracing::info!("Connected to node {}", addr);
+                return;
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+        panic!("Timed out waiting for connection to {}", addr);
+    }
+
+    /// Disconnect a specific peer by address.
+    pub fn disconnect_peer(&self, addr: SocketAddr) {
+        let client = self.rpc_client();
+        client.disconnect_node(&addr.to_string()).expect("failed to disconnect peer");
+        tracing::info!("Disconnected peer {}", addr);
+    }
+
     /// Disconnect all currently connected peers.
     pub fn disconnect_all_peers(&self) {
         let client = self.rpc_client();

--- a/dash-spv/src/test_utils/node.rs
+++ b/dash-spv/src/test_utils/node.rs
@@ -3,10 +3,10 @@
 //! This provides utilities for managing a dashd instance and loading test wallet data.
 
 use dashcore::{Address, Amount, BlockHash, Transaction, Txid};
-use std::collections::HashMap;
 use dashcore_rpc::json as rpc_json;
 use dashcore_rpc::{Auth, Client, RpcApi};
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::fs;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};

--- a/dash-spv/src/test_utils/node.rs
+++ b/dash-spv/src/test_utils/node.rs
@@ -3,6 +3,7 @@
 //! This provides utilities for managing a dashd instance and loading test wallet data.
 
 use dashcore::{Address, Amount, BlockHash, Transaction, Txid};
+use std::collections::HashMap;
 use dashcore_rpc::json as rpc_json;
 use dashcore_rpc::{Auth, Client, RpcApi};
 use serde::Deserialize;
@@ -318,7 +319,7 @@ impl DashCoreNode {
             sequence: None,
         }];
         let send_amount = input_amount.checked_sub(fee).expect("fee exceeds input amount");
-        let mut outputs = std::collections::HashMap::new();
+        let mut outputs = HashMap::new();
         outputs.insert(destination.to_string(), send_amount);
 
         let raw_tx: Transaction = client

--- a/dash-spv/src/test_utils/node.rs
+++ b/dash-spv/src/test_utils/node.rs
@@ -2,7 +2,8 @@
 //!
 //! This provides utilities for managing a dashd instance and loading test wallet data.
 
-use dashcore::{Address, Amount, BlockHash, Txid};
+use dashcore::{Address, Amount, BlockHash, Transaction, Txid};
+use dashcore_rpc::json as rpc_json;
 use dashcore_rpc::{Auth, Client, RpcApi};
 use serde::Deserialize;
 use std::fs;
@@ -118,6 +119,7 @@ impl DashCoreNode {
             "-timestampindex=0".to_string(),
             "-blockfilterindex=1".to_string(),
             "-peerblockfilters=1".to_string(),
+            "-peerbloomfilters=1".to_string(),
             "-debug=all".to_string(),
             format!("-wallet={}", self.config.wallet),
         ];
@@ -263,13 +265,81 @@ impl DashCoreNode {
         hashes
     }
 
-    /// Send DASH to an address.
+    /// Send DASH to an address from the primary wallet.
     pub fn send_to_address(&self, address: &Address, amount: Amount) -> Txid {
         let client = self.rpc_client();
         let txid = client
             .send_to_address(address, amount, None, None, None, None, None, None, None, None)
             .expect("failed to send to address");
         tracing::info!("Sent {} to {}, txid: {}", amount, address, txid);
+        txid
+    }
+
+    /// Send DASH to an address from a specific wallet.
+    pub fn send_to_address_from_wallet(
+        &self,
+        wallet_name: &str,
+        address: &Address,
+        amount: Amount,
+    ) -> Txid {
+        let client = self.rpc_client_for_wallet(wallet_name);
+        let txid = client
+            .send_to_address(address, amount, None, None, None, None, None, None, None, None)
+            .expect("failed to send to address");
+        tracing::info!("Sent {} to {} (wallet: {}), txid: {}", amount, address, wallet_name, txid);
+        txid
+    }
+
+    /// List unspent outputs for a specific wallet.
+    pub fn list_unspent_from_wallet(
+        &self,
+        wallet_name: &str,
+    ) -> Vec<rpc_json::ListUnspentResultEntry> {
+        let client = self.rpc_client_for_wallet(wallet_name);
+        client.list_unspent(None, None, None, None, None).expect("failed to list unspent")
+    }
+
+    /// Create, sign, and broadcast a raw transaction spending a single UTXO.
+    /// Sends the input amount minus fee to the destination address.
+    pub fn send_raw_from_wallet(
+        &self,
+        wallet_name: &str,
+        input_txid: Txid,
+        input_vout: u32,
+        input_amount: Amount,
+        destination: &Address,
+        fee: Amount,
+    ) -> Txid {
+        let client = self.rpc_client_for_wallet(wallet_name);
+
+        let inputs = vec![rpc_json::CreateRawTransactionInput {
+            txid: input_txid,
+            vout: input_vout,
+            sequence: None,
+        }];
+        let send_amount = input_amount.checked_sub(fee).expect("fee exceeds input amount");
+        let mut outputs = std::collections::HashMap::new();
+        outputs.insert(destination.to_string(), send_amount);
+
+        let raw_tx: Transaction = client
+            .create_raw_transaction(&inputs, &outputs, None)
+            .expect("failed to create raw tx");
+
+        let signed = client
+            .sign_raw_transaction_with_wallet(&raw_tx, None, None)
+            .expect("failed to sign raw tx");
+        assert!(signed.complete, "raw transaction signing incomplete");
+
+        let txid = client
+            .send_raw_transaction(&signed.transaction().expect("invalid signed tx"))
+            .expect("failed to send raw tx");
+        tracing::info!(
+            "Sent raw tx from wallet '{}': {} -> {}, txid: {}",
+            wallet_name,
+            input_amount,
+            destination,
+            txid
+        );
         txid
     }
 

--- a/dash-spv/src/types.rs
+++ b/dash-spv/src/types.rs
@@ -159,6 +159,7 @@ impl std::fmt::Display for PeerId {
 
 /// Validation mode for the SPV client.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum ValidationMode {
     /// Validate only basic structure and signatures.
     Basic,

--- a/dash-spv/src/types.rs
+++ b/dash-spv/src/types.rs
@@ -1,6 +1,7 @@
 //! Common type definitions for the Dash SPV client.
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use tokio::time::Instant;
 
 use dashcore::{
     block::Header as BlockHeader,
@@ -266,7 +267,7 @@ impl UnconfirmedTransaction {
 
     /// Check if transaction has expired.
     pub fn is_expired(&self, timeout: Duration) -> bool {
-        self.first_seen.elapsed() > timeout
+        Instant::now().checked_duration_since(self.first_seen).unwrap_or_default() > timeout
     }
 
     /// Get fee rate in satoshis per byte.
@@ -337,8 +338,10 @@ impl MempoolState {
         });
 
         // Also prune old recent sends
-        let cutoff = Instant::now() - timeout;
-        self.recent_sends.retain(|_, &mut timestamp| timestamp > cutoff);
+        let now = Instant::now();
+        self.recent_sends.retain(|_, &mut timestamp| {
+            now.checked_duration_since(timestamp).unwrap_or_default() <= timeout
+        });
 
         expired
     }
@@ -350,7 +353,11 @@ impl MempoolState {
 
     /// Check if a transaction was recently sent.
     pub fn is_recent_send(&self, txid: &Txid, window: Duration) -> bool {
-        self.recent_sends.get(txid).map(|&timestamp| timestamp.elapsed() < window).unwrap_or(false)
+        let now = Instant::now();
+        self.recent_sends
+            .get(txid)
+            .map(|&timestamp| now.checked_duration_since(timestamp).unwrap_or_default() < window)
+            .unwrap_or(false)
     }
 
     /// Get total pending balance (regular + InstantSend).

--- a/dash-spv/tests/dashd_sync/helpers.rs
+++ b/dash-spv/tests/dashd_sync/helpers.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{broadcast, watch, RwLock};
+use tokio::time::sleep;
 
 use dash_spv::test_utils::SYNC_TIMEOUT;
 
@@ -21,7 +22,7 @@ pub(super) async fn wait_for_sync(
     progress_receiver: &mut watch::Receiver<SyncProgress>,
     target_height: u32,
 ) {
-    let timeout = tokio::time::sleep(SYNC_TIMEOUT);
+    let timeout = sleep(SYNC_TIMEOUT);
     tokio::pin!(timeout);
 
     loop {
@@ -109,7 +110,7 @@ pub(super) async fn wait_for_network_event(
     predicate: impl Fn(&NetworkEvent) -> bool,
     max_wait: Duration,
 ) -> bool {
-    let deadline = tokio::time::sleep(max_wait);
+    let deadline = sleep(max_wait);
     tokio::pin!(deadline);
 
     loop {
@@ -132,7 +133,7 @@ pub(super) async fn wait_for_mempool_tx(
     receiver: &mut broadcast::Receiver<WalletEvent>,
     max_wait: Duration,
 ) -> Option<Txid> {
-    let timeout = tokio::time::sleep(max_wait);
+    let timeout = sleep(max_wait);
     tokio::pin!(timeout);
 
     loop {
@@ -173,7 +174,7 @@ pub(super) async fn run_disconnect_loop(
     let mut disconnect_count = 0;
     let mut events_since_disconnect = 0;
 
-    let timeout = tokio::time::sleep(SYNC_TIMEOUT * 2);
+    let timeout = sleep(SYNC_TIMEOUT * 2);
     tokio::pin!(timeout);
 
     loop {

--- a/dash-spv/tests/dashd_sync/helpers.rs
+++ b/dash-spv/tests/dashd_sync/helpers.rs
@@ -150,6 +150,28 @@ pub(super) async fn wait_for_mempool_tx(
     }
 }
 
+/// Wait for a `MempoolActivated` sync event within a timeout.
+/// Returns `Some(peer)` if received, `None` on timeout.
+pub(super) async fn wait_for_mempool_activated(
+    receiver: &mut broadcast::Receiver<SyncEvent>,
+) -> Option<std::net::SocketAddr> {
+    let timeout = sleep(Duration::from_secs(30));
+    tokio::pin!(timeout);
+
+    loop {
+        tokio::select! {
+            _ = &mut timeout => return None,
+            result = receiver.recv() => {
+                match result {
+                    Ok(SyncEvent::MempoolActivated { peer }) => return Some(peer),
+                    Ok(_) => continue,
+                    Err(_) => return None,
+                }
+            }
+        }
+    }
+}
+
 /// Assert that no mempool `TransactionReceived` event arrives within the given duration.
 pub(super) async fn assert_no_mempool_tx(
     receiver: &mut broadcast::Receiver<WalletEvent>,

--- a/dash-spv/tests/dashd_sync/helpers.rs
+++ b/dash-spv/tests/dashd_sync/helpers.rs
@@ -1,9 +1,12 @@
 use dash_spv::network::NetworkEvent;
 use dash_spv::sync::{ProgressPercentage, SyncEvent, SyncProgress};
 use dash_spv::test_utils::DashCoreNode;
+use dashcore::Txid;
+use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::wallet_manager::{WalletId, WalletManager};
+use key_wallet_manager::WalletEvent;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -120,6 +123,39 @@ pub(super) async fn wait_for_network_event(
                 }
             }
         }
+    }
+}
+
+/// Wait for a wallet `TransactionReceived` event with mempool status within the given timeout.
+/// Returns `Some(txid)` if received, `None` on timeout.
+pub(super) async fn wait_for_mempool_tx(
+    receiver: &mut broadcast::Receiver<WalletEvent>,
+    max_wait: Duration,
+) -> Option<Txid> {
+    let timeout = tokio::time::sleep(max_wait);
+    tokio::pin!(timeout);
+
+    loop {
+        tokio::select! {
+            _ = &mut timeout => return None,
+            result = receiver.recv() => {
+                match result {
+                    Ok(WalletEvent::TransactionReceived { txid, status: TransactionContext::Mempool, .. }) => return Some(txid),
+                    Ok(_) => continue,
+                    Err(_) => return None,
+                }
+            }
+        }
+    }
+}
+
+/// Assert that no mempool `TransactionReceived` event arrives within the given duration.
+pub(super) async fn assert_no_mempool_tx(
+    receiver: &mut broadcast::Receiver<WalletEvent>,
+    wait: Duration,
+) {
+    if let Some(txid) = wait_for_mempool_tx(receiver, wait).await {
+        panic!("Unexpected mempool TransactionReceived event with txid: {}", txid);
     }
 }
 

--- a/dash-spv/tests/dashd_sync/main.rs
+++ b/dash-spv/tests/dashd_sync/main.rs
@@ -6,5 +6,6 @@ mod helpers;
 mod setup;
 mod tests_basic;
 mod tests_disconnect;
+mod tests_mempool;
 mod tests_restart;
 mod tests_transaction;

--- a/dash-spv/tests/dashd_sync/setup.rs
+++ b/dash-spv/tests/dashd_sync/setup.rs
@@ -15,6 +15,7 @@ use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::wallet_manager::{WalletId, WalletManager};
+use key_wallet_manager::WalletEvent;
 use std::collections::{BTreeSet, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -256,6 +257,8 @@ pub(super) struct ClientHandle {
     pub(super) sync_event_receiver: broadcast::Receiver<SyncEvent>,
     /// A channel for receiving network events.
     pub(super) network_event_receiver: broadcast::Receiver<NetworkEvent>,
+    /// A channel for receiving wallet events.
+    pub(super) wallet_event_receiver: broadcast::Receiver<WalletEvent>,
     /// A cancellation token for the client's run loop.
     pub(super) cancel_token: CancellationToken,
 }
@@ -289,6 +292,10 @@ pub(super) async fn create_and_start_client(
     let progress_receiver = client.subscribe_progress().await;
     let sync_event_receiver = client.subscribe_sync_events().await;
     let network_event_receiver = client.subscribe_network_events().await;
+    let wallet_event_receiver = {
+        let w = client.wallet().read().await;
+        w.subscribe_events()
+    };
     let cancel_token = CancellationToken::new();
     let run_token = cancel_token.clone();
 
@@ -301,6 +308,7 @@ pub(super) async fn create_and_start_client(
         progress_receiver,
         sync_event_receiver,
         network_event_receiver,
+        wallet_event_receiver,
         cancel_token,
     }
 }

--- a/dash-spv/tests/dashd_sync/tests_mempool.rs
+++ b/dash-spv/tests/dashd_sync/tests_mempool.rs
@@ -3,9 +3,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dash_spv::client::config::MempoolStrategy;
+use dash_spv::network::NetworkEvent;
+use dash_spv::test_utils::DashdTestContext;
 use dashcore::Amount;
 
-use super::helpers::{assert_no_mempool_tx, wait_for_mempool_tx, wait_for_sync};
+use super::helpers::{
+    assert_no_mempool_tx, wait_for_mempool_activated, wait_for_mempool_tx, wait_for_network_event,
+    wait_for_sync,
+};
 use super::setup::{create_and_start_client, TestContext};
 
 const MEMPOOL_TIMEOUT: Duration = Duration::from_secs(30);
@@ -363,4 +368,142 @@ async fn test_mempool_bloom_filter_incoming_and_outgoing_tx() {
 
     client_handle.stop().await;
     tracing::info!("test_mempool_bloom_filter_incoming_and_outgoing_tx passed");
+}
+
+/// Verify mempool handles peer disconnection and reactivation across multiple scenarios.
+///
+/// Uses two dashd nodes connected to each other. The SPV client connects to both peers and
+/// exercises these scenarios in sequence:
+/// 1. Mempool activates after sync — verify tx detection works
+/// 2. Disconnect the mempool peer — verify reactivation on the other peer, then tx detection
+/// 3. Disconnect both peers, reconnect one — verify mempool recovers and detects a tx
+#[tokio::test]
+async fn test_mempool_peer_disconnect_reactivation() {
+    let Some(ctx) = TestContext::new().await else {
+        return;
+    };
+    if !ctx.dashd.supports_mining {
+        eprintln!("Skipping test (dashd RPC miner not available)");
+        return;
+    }
+
+    let Some(dashd2) = DashdTestContext::new().await else {
+        eprintln!("Skipping test (could not create second dashd node)");
+        return;
+    };
+
+    // Connect the two dashd nodes so mempool transactions propagate between them
+    ctx.dashd.node.connect_to_node(dashd2.addr).await;
+
+    // Configure SPV client with both peers and sync
+    let mut config = ctx.client_config.clone();
+    config.add_peer(dashd2.addr);
+
+    let mut client_handle = create_and_start_client(&config, Arc::clone(&ctx.wallet)).await;
+    wait_for_sync(&mut client_handle.progress_receiver, ctx.dashd.initial_height).await;
+
+    // Identify which peer was chosen for mempool relay.
+    // Brief sleep lets the MemPool/FilterClear messages reach the peer before we send txs.
+    let mempool_peer = wait_for_mempool_activated(&mut client_handle.sync_event_receiver)
+        .await
+        .expect("Expected MempoolActivated event after sync");
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    tracing::info!("Mempool activated on peer {}", mempool_peer);
+
+    let (mempool_node, other_node, other_addr) = if mempool_peer == ctx.dashd.addr {
+        (&ctx.dashd.node, &dashd2.node, dashd2.addr)
+    } else {
+        (&dashd2.node, &ctx.dashd.node, ctx.dashd.addr)
+    };
+
+    // --- Scenario 1: baseline mempool detection with both peers ---
+    // Send from the mempool peer's node directly so the tx is immediately in its mempool
+    // and relayed to SPV without needing inter-node propagation.
+    let receive_address = ctx.receive_address().await;
+    let txid1 = mempool_node.send_to_address(&receive_address, Amount::from_sat(50_000_000));
+    tracing::info!("[scenario 1] sent tx {} from mempool peer", txid1);
+
+    let detected = wait_for_mempool_tx(&mut client_handle.wallet_event_receiver, MEMPOOL_TIMEOUT)
+        .await
+        .expect("Scenario 1: expected mempool tx detection");
+    assert_eq!(detected, txid1);
+
+    let mempool_count = client_handle.client.get_mempool_transaction_count().await;
+    assert_eq!(mempool_count, 1, "Scenario 1: expected 1 mempool tx");
+
+    // --- Scenario 2: disconnect the mempool peer, verify reactivation on the other ---
+    mempool_node.disconnect_all_peers();
+
+    let saw_disconnect = wait_for_network_event(
+        &mut client_handle.network_event_receiver,
+        |e| matches!(e, NetworkEvent::PeerDisconnected { address } if *address == mempool_peer),
+        Duration::from_secs(10),
+    )
+    .await;
+    assert!(saw_disconnect, "SPV should observe PeerDisconnected for mempool peer");
+
+    let new_mempool_peer = wait_for_mempool_activated(&mut client_handle.sync_event_receiver)
+        .await
+        .expect("Expected MempoolActivated after mempool peer disconnect");
+    assert_eq!(new_mempool_peer, other_addr, "Mempool should reactivate on the remaining peer");
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    tracing::info!("[scenario 2] mempool reactivated on {}", new_mempool_peer);
+
+    let txid2 = other_node.send_to_address(&receive_address, Amount::from_sat(60_000_000));
+    tracing::info!("[scenario 2] sent tx {} from reactivated mempool peer", txid2);
+
+    let detected = wait_for_mempool_tx(&mut client_handle.wallet_event_receiver, MEMPOOL_TIMEOUT)
+        .await
+        .expect("Scenario 2: expected mempool tx detection after reactivation");
+    assert_eq!(detected, txid2);
+
+    let mempool_count = client_handle.client.get_mempool_transaction_count().await;
+    assert_eq!(mempool_count, 2, "Scenario 2: expected 2 mempool txs (cumulative)");
+
+    // --- Scenario 3: disconnect both peers, verify recovery ---
+    // Reconnect dashd nodes so SPV can reach either after full disconnect.
+    mempool_node.connect_to_node(other_addr).await;
+    other_node.disconnect_all_peers();
+
+    let saw_disconnect = wait_for_network_event(
+        &mut client_handle.network_event_receiver,
+        |e| matches!(e, NetworkEvent::PeerDisconnected { address } if *address == other_addr),
+        Duration::from_secs(10),
+    )
+    .await;
+    assert!(saw_disconnect, "SPV should observe PeerDisconnected for other peer");
+
+    // SPV has no peers. Wait for reconnection and mempool reactivation.
+    let saw_reconnect = wait_for_network_event(
+        &mut client_handle.network_event_receiver,
+        |e| matches!(e, NetworkEvent::PeerConnected { .. }),
+        Duration::from_secs(30),
+    )
+    .await;
+    assert!(saw_reconnect, "SPV should reconnect to a peer");
+
+    let recovered_peer = wait_for_mempool_activated(&mut client_handle.sync_event_receiver)
+        .await
+        .expect("Expected MempoolActivated after full disconnect recovery");
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    tracing::info!("[scenario 3] mempool recovered on peer {}", recovered_peer);
+
+    let recovered_node = if recovered_peer == ctx.dashd.addr {
+        &ctx.dashd.node
+    } else {
+        &dashd2.node
+    };
+    let txid3 = recovered_node.send_to_address(&receive_address, Amount::from_sat(70_000_000));
+    tracing::info!("[scenario 3] sent tx {} from recovered mempool peer", txid3);
+
+    let detected = wait_for_mempool_tx(&mut client_handle.wallet_event_receiver, MEMPOOL_TIMEOUT)
+        .await
+        .expect("Scenario 3: expected mempool tx detection after full disconnect recovery");
+    assert_eq!(detected, txid3);
+
+    let mempool_count = client_handle.client.get_mempool_transaction_count().await;
+    assert_eq!(mempool_count, 3, "Scenario 3: expected 3 mempool txs (cumulative)");
+
+    client_handle.stop().await;
+    tracing::info!("test_mempool_peer_disconnect_reactivation passed");
 }

--- a/dash-spv/tests/dashd_sync/tests_mempool.rs
+++ b/dash-spv/tests/dashd_sync/tests_mempool.rs
@@ -1,0 +1,366 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dash_spv::client::config::MempoolStrategy;
+use dashcore::Amount;
+
+use super::helpers::{assert_no_mempool_tx, wait_for_mempool_tx, wait_for_sync};
+use super::setup::{create_and_start_client, TestContext};
+
+const MEMPOOL_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Verify mempool detects an incoming wallet transaction using the default FetchAll strategy.
+#[tokio::test]
+async fn test_mempool_detects_incoming_tx() {
+    let Some(ctx) = TestContext::new().await else {
+        return;
+    };
+    if !ctx.dashd.supports_mining {
+        eprintln!("Skipping test (dashd RPC miner not available)");
+        return;
+    }
+
+    let mut client_handle = ctx.spawn_new_client().await;
+    wait_for_sync(&mut client_handle.progress_receiver, ctx.dashd.initial_height).await;
+
+    let receive_address = ctx.receive_address().await;
+    let txid = ctx.dashd.node.send_to_address(&receive_address, Amount::from_sat(100_000_000));
+    tracing::info!("Sent tx to SPV wallet (no mine), txid: {}", txid);
+
+    let mempool_txid =
+        wait_for_mempool_tx(&mut client_handle.wallet_event_receiver, MEMPOOL_TIMEOUT)
+            .await
+            .expect("Expected mempool TransactionReceived event");
+    assert_eq!(mempool_txid, txid, "Mempool event txid should match sent txid");
+
+    let mempool_count = client_handle.client.get_mempool_transaction_count().await;
+    assert_eq!(
+        mempool_count, 1,
+        "Mempool should contain exactly 1 transaction, got {}",
+        mempool_count
+    );
+
+    client_handle.stop().await;
+    tracing::info!("test_mempool_detects_incoming_tx passed");
+}
+
+/// Verify mempool detects an incoming wallet transaction using the BloomFilter strategy.
+#[tokio::test]
+async fn test_mempool_bloom_filter_detects_incoming_tx() {
+    let Some(ctx) = TestContext::new().await else {
+        return;
+    };
+    if !ctx.dashd.supports_mining {
+        eprintln!("Skipping test (dashd RPC miner not available)");
+        return;
+    }
+
+    let mut config = ctx.client_config.clone();
+    config.mempool_strategy = MempoolStrategy::BloomFilter;
+
+    let mut client_handle = create_and_start_client(&config, Arc::clone(&ctx.wallet)).await;
+    wait_for_sync(&mut client_handle.progress_receiver, ctx.dashd.initial_height).await;
+
+    let receive_address = ctx.receive_address().await;
+    let txid = ctx.dashd.node.send_to_address(&receive_address, Amount::from_sat(100_000_000));
+    tracing::info!("Sent tx to SPV wallet (BloomFilter), txid: {}", txid);
+
+    let mempool_txid =
+        wait_for_mempool_tx(&mut client_handle.wallet_event_receiver, MEMPOOL_TIMEOUT)
+            .await
+            .expect("Expected mempool TransactionReceived event (BloomFilter)");
+    assert_eq!(mempool_txid, txid, "Mempool event txid should match sent txid");
+
+    let mempool_count = client_handle.client.get_mempool_transaction_count().await;
+    assert_eq!(
+        mempool_count, 1,
+        "Mempool should contain exactly 1 transaction, got {}",
+        mempool_count
+    );
+
+    client_handle.stop().await;
+    tracing::info!("test_mempool_bloom_filter_detects_incoming_tx passed");
+}
+
+/// Verify mempool ignores transactions not relevant to the SPV wallet.
+#[tokio::test]
+async fn test_mempool_ignores_irrelevant_tx() {
+    let Some(ctx) = TestContext::new().await else {
+        return;
+    };
+    if !ctx.dashd.supports_mining {
+        eprintln!("Skipping test (dashd RPC miner not available)");
+        return;
+    }
+
+    // Fund the "default" wallet with a regular (non-coinbase) output so it's
+    // immediately spendable. Send from the primary wallet and mine the tx.
+    let default_addr = ctx.dashd.node.get_new_address_from_wallet("default");
+    ctx.dashd.node.send_to_address(&default_addr, Amount::from_sat(100_000_000));
+    let miner_addr = ctx.dashd.node.get_new_address_from_wallet("default");
+    ctx.dashd.node.generate_blocks(1, &miner_addr);
+    let funded_height = ctx.dashd.initial_height + 1;
+
+    let mut client_handle = ctx.spawn_new_client().await;
+    wait_for_sync(&mut client_handle.progress_receiver, funded_height).await;
+
+    // Send from the "default" wallet to itself (no relation to SPV wallet)
+    let non_wallet_address = ctx.dashd.node.get_new_address_from_wallet("default");
+    let txid = ctx.dashd.node.send_to_address_from_wallet(
+        "default",
+        &non_wallet_address,
+        Amount::from_sat(50_000_000),
+    );
+    tracing::info!("Sent irrelevant tx (not to SPV wallet), txid: {}", txid);
+
+    assert_no_mempool_tx(&mut client_handle.wallet_event_receiver, Duration::from_secs(3)).await;
+
+    let mempool_count = client_handle.client.get_mempool_transaction_count().await;
+    assert_eq!(
+        mempool_count, 0,
+        "Mempool should have 0 wallet-relevant transactions, got {}",
+        mempool_count
+    );
+
+    client_handle.stop().await;
+    tracing::info!("test_mempool_ignores_irrelevant_tx passed");
+}
+
+/// Verify a mempool transaction transitions to confirmed after mining.
+#[tokio::test]
+async fn test_mempool_to_confirmed_lifecycle() {
+    let Some(ctx) = TestContext::new().await else {
+        return;
+    };
+    if !ctx.dashd.supports_mining {
+        eprintln!("Skipping test (dashd RPC miner not available)");
+        return;
+    }
+
+    let mut client_handle = ctx.spawn_new_client().await;
+    wait_for_sync(&mut client_handle.progress_receiver, ctx.dashd.initial_height).await;
+
+    let receive_address = ctx.receive_address().await;
+    let txid = ctx.dashd.node.send_to_address(&receive_address, Amount::from_sat(100_000_000));
+    tracing::info!("Sent tx to SPV wallet (lifecycle test), txid: {}", txid);
+
+    let mempool_txid =
+        wait_for_mempool_tx(&mut client_handle.wallet_event_receiver, MEMPOOL_TIMEOUT)
+            .await
+            .expect("Expected mempool TransactionReceived event");
+    assert_eq!(mempool_txid, txid);
+
+    let mempool_count = client_handle.client.get_mempool_transaction_count().await;
+    assert_eq!(mempool_count, 1, "Mempool should have exactly 1 tx before mining");
+
+    // Mine the transaction
+    let miner_address = ctx.dashd.node.get_new_address_from_wallet("default");
+    ctx.dashd.node.generate_blocks(1, &miner_address);
+    let new_height = ctx.dashd.initial_height + 1;
+    wait_for_sync(&mut client_handle.progress_receiver, new_height).await;
+
+    let mempool_count_after = client_handle.client.get_mempool_transaction_count().await;
+    assert_eq!(
+        mempool_count_after, 0,
+        "Mempool should be empty after confirmation, got {}",
+        mempool_count_after
+    );
+    assert!(ctx.has_transaction(&txid).await, "Confirmed transaction should be in wallet");
+
+    client_handle.stop().await;
+    tracing::info!("test_mempool_to_confirmed_lifecycle passed");
+}
+
+/// Verify multiple mempool transactions are all detected.
+#[tokio::test]
+async fn test_mempool_multiple_txs() {
+    let Some(ctx) = TestContext::new().await else {
+        return;
+    };
+    if !ctx.dashd.supports_mining {
+        eprintln!("Skipping test (dashd RPC miner not available)");
+        return;
+    }
+
+    let mut client_handle = ctx.spawn_new_client().await;
+    wait_for_sync(&mut client_handle.progress_receiver, ctx.dashd.initial_height).await;
+
+    let receive_address = ctx.receive_address().await;
+    let amounts =
+        [Amount::from_sat(50_000_000), Amount::from_sat(75_000_000), Amount::from_sat(120_000_000)];
+    let mut expected_txids = HashSet::new();
+    for amount in &amounts {
+        let txid = ctx.dashd.node.send_to_address(&receive_address, *amount);
+        tracing::info!("Sent {} to SPV wallet (multi-tx test), txid: {}", amount, txid);
+        expected_txids.insert(txid);
+    }
+
+    // Collect 3 mempool events
+    let mut received_txids = HashSet::new();
+    for _ in 0..3 {
+        let txid = wait_for_mempool_tx(&mut client_handle.wallet_event_receiver, MEMPOOL_TIMEOUT)
+            .await
+            .expect("Expected mempool TransactionReceived event");
+        received_txids.insert(txid);
+    }
+
+    assert_eq!(received_txids, expected_txids, "Received mempool txids should match sent txids");
+
+    let mempool_count = client_handle.client.get_mempool_transaction_count().await;
+    assert_eq!(
+        mempool_count, 3,
+        "Mempool should contain exactly 3 transactions, got {}",
+        mempool_count
+    );
+
+    client_handle.stop().await;
+    tracing::info!("test_mempool_multiple_txs passed");
+}
+
+/// Verify mempool detects both incoming (address match) and outgoing (outpoint match) transactions.
+///
+/// 1. Sync to tip
+/// 2. Send from "default" wallet TO the SPV wallet receive address (incoming)
+/// 3. Wait for mempool event (address match)
+/// 4. Mine the tx so it becomes a confirmed UTXO in the SPV wallet
+/// 5. Craft a raw tx that spends the wallet UTXO with all outputs going to an external
+///    "default" address (no change back to the wallet) and broadcast it
+/// 6. Wait for mempool event (outpoint match only, no address match)
+/// 7. Assert both txids were detected
+#[tokio::test]
+async fn test_mempool_incoming_and_outgoing_tx() {
+    let Some(ctx) = TestContext::new().await else {
+        return;
+    };
+    if !ctx.dashd.supports_mining {
+        eprintln!("Skipping test (dashd RPC miner not available)");
+        return;
+    }
+
+    let mut client_handle = ctx.spawn_new_client().await;
+    wait_for_sync(&mut client_handle.progress_receiver, ctx.dashd.initial_height).await;
+
+    // Step 1: Send an incoming transaction to the SPV wallet
+    let receive_address = ctx.receive_address().await;
+    let incoming_amount = Amount::from_sat(200_000_000);
+    let incoming_txid = ctx.dashd.node.send_to_address(&receive_address, incoming_amount);
+    tracing::info!("Sent incoming tx to SPV wallet, txid: {}", incoming_txid);
+
+    let mempool_txid =
+        wait_for_mempool_tx(&mut client_handle.wallet_event_receiver, MEMPOOL_TIMEOUT)
+            .await
+            .expect("Expected mempool event for incoming tx");
+    assert_eq!(mempool_txid, incoming_txid);
+
+    // Step 2: Mine the incoming tx so it becomes a confirmed UTXO
+    let miner_address = ctx.dashd.node.get_new_address_from_wallet("default");
+    ctx.dashd.node.generate_blocks(1, &miner_address);
+    let mined_height = ctx.dashd.initial_height + 1;
+    wait_for_sync(&mut client_handle.progress_receiver, mined_height).await;
+
+    // Step 3: Craft a raw transaction that spends the wallet UTXO with all outputs
+    // going to an external address. This ensures the mempool detects it purely via
+    // the watched outpoint, not via any output address match.
+    let wallet_name = &ctx.dashd.wallet.wallet_name;
+    let utxos = ctx.dashd.node.list_unspent_from_wallet(wallet_name);
+    let utxo = utxos
+        .iter()
+        .find(|u| u.txid == incoming_txid)
+        .expect("Incoming tx UTXO not found in wallet");
+
+    let external_address = ctx.dashd.node.get_new_address_from_wallet("default");
+    let fee = Amount::from_sat(10_000);
+    let outgoing_txid = ctx.dashd.node.send_raw_from_wallet(
+        wallet_name,
+        utxo.txid,
+        utxo.vout,
+        utxo.amount,
+        &external_address,
+        fee,
+    );
+    tracing::info!("Sent raw outgoing tx (outpoint-only match), txid: {}", outgoing_txid);
+
+    let mempool_txid =
+        wait_for_mempool_tx(&mut client_handle.wallet_event_receiver, MEMPOOL_TIMEOUT)
+            .await
+            .expect("Expected mempool event for outgoing tx (outpoint match)");
+    assert_eq!(mempool_txid, outgoing_txid);
+
+    client_handle.stop().await;
+    tracing::info!("test_mempool_incoming_and_outgoing_tx passed");
+}
+
+/// Verify mempool detects both incoming and outgoing transactions using the BloomFilter strategy.
+///
+/// This validates that `rebuild_filter()` correctly includes new watched outpoints in the
+/// bloom filter after block processing. The bloom filter must be rebuilt after a new UTXO
+/// is confirmed so that spending transactions (outpoint matches) are detected.
+#[tokio::test]
+async fn test_mempool_bloom_filter_incoming_and_outgoing_tx() {
+    let Some(ctx) = TestContext::new().await else {
+        return;
+    };
+    if !ctx.dashd.supports_mining {
+        eprintln!("Skipping test (dashd RPC miner not available)");
+        return;
+    }
+
+    let mut config = ctx.client_config.clone();
+    config.mempool_strategy = MempoolStrategy::BloomFilter;
+
+    let mut client_handle = create_and_start_client(&config, Arc::clone(&ctx.wallet)).await;
+    wait_for_sync(&mut client_handle.progress_receiver, ctx.dashd.initial_height).await;
+
+    // Step 1: Send an incoming transaction to the SPV wallet
+    let receive_address = ctx.receive_address().await;
+    let incoming_amount = Amount::from_sat(200_000_000);
+    let incoming_txid = ctx.dashd.node.send_to_address(&receive_address, incoming_amount);
+    tracing::info!("Sent incoming tx to SPV wallet (BloomFilter), txid: {}", incoming_txid);
+
+    let mempool_txid =
+        wait_for_mempool_tx(&mut client_handle.wallet_event_receiver, MEMPOOL_TIMEOUT)
+            .await
+            .expect("Expected mempool event for incoming tx (BloomFilter)");
+    assert_eq!(mempool_txid, incoming_txid);
+
+    // Step 2: Mine the incoming tx so it becomes a confirmed UTXO
+    let miner_address = ctx.dashd.node.get_new_address_from_wallet("default");
+    ctx.dashd.node.generate_blocks(1, &miner_address);
+    let mined_height = ctx.dashd.initial_height + 1;
+    wait_for_sync(&mut client_handle.progress_receiver, mined_height).await;
+
+    // Step 3: Craft a raw transaction that spends the wallet UTXO with all outputs
+    // going to an external address. The bloom filter must have been rebuilt after
+    // block processing to include the new outpoint for this to be detected.
+    let wallet_name = &ctx.dashd.wallet.wallet_name;
+    let utxos = ctx.dashd.node.list_unspent_from_wallet(wallet_name);
+    let utxo = utxos
+        .iter()
+        .find(|u| u.txid == incoming_txid)
+        .expect("Incoming tx UTXO not found in wallet");
+
+    let external_address = ctx.dashd.node.get_new_address_from_wallet("default");
+    let fee = Amount::from_sat(10_000);
+    let outgoing_txid = ctx.dashd.node.send_raw_from_wallet(
+        wallet_name,
+        utxo.txid,
+        utxo.vout,
+        utxo.amount,
+        &external_address,
+        fee,
+    );
+    tracing::info!(
+        "Sent raw outgoing tx (BloomFilter, outpoint-only match), txid: {}",
+        outgoing_txid
+    );
+
+    let mempool_txid =
+        wait_for_mempool_tx(&mut client_handle.wallet_event_receiver, MEMPOOL_TIMEOUT)
+            .await
+            .expect("Expected mempool event for outgoing tx (BloomFilter, outpoint match)");
+    assert_eq!(mempool_txid, outgoing_txid);
+
+    client_handle.stop().await;
+    tracing::info!("test_mempool_bloom_filter_incoming_and_outgoing_tx passed");
+}

--- a/dash-spv/tests/handshake_test.rs
+++ b/dash-spv/tests/handshake_test.rs
@@ -3,7 +3,6 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use dash_spv::client::config::MempoolStrategy;
 use dash_spv::network::{HandshakeManager, NetworkManager, Peer, PeerNetworkManager};
 use dash_spv::{ClientConfig, Network};
 
@@ -19,7 +18,7 @@ async fn test_handshake_with_mainnet_peer() {
         Ok(mut connection) => {
             let mut handshake_manager = HandshakeManager::new(
                 Network::Mainnet,
-                MempoolStrategy::BloomFilter,
+                false,
                 Some("handshake_test".parse().unwrap()),
             );
             handshake_manager.perform_handshake(&mut connection).await.expect("Handshake failed");

--- a/dash-spv/tests/test_handshake_logic.rs
+++ b/dash-spv/tests/test_handshake_logic.rs
@@ -1,12 +1,11 @@
 //! Unit tests for handshake logic
 
-use dash_spv::client::config::MempoolStrategy;
 use dash_spv::network::{HandshakeManager, HandshakeState};
 use dashcore::Network;
 
 #[test]
 fn test_handshake_state_transitions() {
-    let mut handshake = HandshakeManager::new(Network::Mainnet, MempoolStrategy::BloomFilter, None);
+    let mut handshake = HandshakeManager::new(Network::Mainnet, false, None);
 
     // Initial state should be Init
     assert_eq!(*handshake.state(), HandshakeState::Init);

--- a/dash/src/bloom/filter.rs
+++ b/dash/src/bloom/filter.rs
@@ -50,23 +50,28 @@ impl BloomFilter {
             return Err(BloomError::InvalidFalsePositiveRate(false_positive_rate));
         }
 
-        // Calculate optimal filter size and hash count
+        // Calculate optimal filter size and hash count matching Dash Core's C++ implementation.
+        // The filter size is computed in bits, then truncated to a whole number of bytes.
+        // The hash modulus must use the byte-aligned bit count (bytes * 8) so that both
+        // the Rust inserter and the C++ checker agree on bit positions.
         let ln2 = std::f64::consts::LN_2;
         let ln2_squared = ln2 * ln2;
 
-        let filter_size =
-            (-(elements as f64) * false_positive_rate.ln() / ln2_squared).ceil() as usize;
-        let filter_size = filter_size.clamp(1, MAX_BLOOM_FILTER_SIZE * 8);
+        let filter_bits =
+            (-1.0 / ln2_squared * elements as f64 * false_positive_rate.ln()) as usize;
+        let filter_bits = filter_bits.clamp(8, MAX_BLOOM_FILTER_SIZE * 8);
+        let filter_bytes = filter_bits / 8;
 
-        let n_hash_funcs = (filter_size as f64 / elements as f64 * ln2).ceil() as u32;
-        let n_hash_funcs = n_hash_funcs.clamp(1, MAX_HASH_FUNCS);
-
-        let filter_bytes = filter_size.div_ceil(8);
         if filter_bytes > MAX_BLOOM_FILTER_SIZE {
             return Err(BloomError::FilterTooLarge(filter_bytes));
         }
 
-        let filter = bitvec![u8, Lsb0; 0; filter_size];
+        let aligned_bits = filter_bytes * 8;
+
+        let n_hash_funcs = (aligned_bits as f64 / elements as f64 * ln2) as u32;
+        let n_hash_funcs = n_hash_funcs.clamp(1, MAX_HASH_FUNCS);
+
+        let filter = bitvec![u8, Lsb0; 0; aligned_bits];
 
         Ok(BloomFilter {
             filter,
@@ -206,6 +211,7 @@ impl Decodable for BloomFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::crypto::key::{PrivateKey, secp256k1};
 
     #[test]
     fn test_bloom_filter_basic() {
@@ -281,6 +287,18 @@ mod tests {
         ));
     }
 
+    /// Verify that the minimum clamp (8 bits) produces a valid 1-byte filter
+    /// even with parameters that would otherwise compute fewer than 8 bits.
+    #[test]
+    fn test_bloom_filter_minimum_clamp() {
+        let mut filter = BloomFilter::new(1, 0.999, 0, BloomFlags::None).unwrap();
+        assert_eq!(filter.size(), 1, "Minimum filter size should be 1 byte");
+        assert!(filter.hash_funcs() >= 1, "Should have at least 1 hash function");
+
+        filter.insert(b"test");
+        assert!(filter.contains(b"test"), "Filter should contain inserted data");
+    }
+
     #[test]
     fn test_bloom_filter_serialization() {
         let filter = BloomFilter::new(10, 0.001, 12345, BloomFlags::All).unwrap();
@@ -293,5 +311,105 @@ mod tests {
         let decoded = BloomFilter::consensus_decode(&mut &encoded[..]).unwrap();
 
         assert_eq!(filter, decoded);
+    }
+
+    /// Verify serialized output matches Dash Core's C++ bloom_tests.cpp test vector.
+    /// Filter: 3 elements, 0.01 fp rate, tweak 0, BLOOM_UPDATE_ALL.
+    /// Data inserted: three 20-byte hashes from the C++ test.
+    /// Expected serialized bytes: "03614e9b050000000000000001"
+    #[test]
+    fn test_bloom_filter_dash_core_compatibility() {
+        let mut filter = BloomFilter::new(3, 0.01, 0, BloomFlags::All).unwrap();
+
+        let data1 = hex::decode("99108ad8ed9bb6274d3980bab5a85c048f0950c8").unwrap();
+        let data2 = hex::decode("b5a2c786d9ef4658287ced5914b37a1b4aa32eee").unwrap();
+        let data3 = hex::decode("b9300670b4c5366e95b2699e8b18bc75e5f729c5").unwrap();
+
+        assert!(!filter.contains(&data1));
+
+        filter.insert(&data1);
+        assert!(filter.contains(&data1));
+        assert!(
+            !filter.contains(&hex::decode("19108ad8ed9bb6274d3980bab5a85c048f0950c8").unwrap())
+        );
+
+        filter.insert(&data2);
+        assert!(filter.contains(&data2));
+
+        filter.insert(&data3);
+        assert!(filter.contains(&data3));
+
+        let mut encoded = Vec::new();
+        filter.consensus_encode(&mut encoded).unwrap();
+
+        let expected = hex::decode("03614e9b050000000000000001").unwrap();
+        assert_eq!(encoded, expected, "Serialized bloom filter must match Dash Core test vector");
+    }
+
+    /// Verify bloom filter with pubkey and pubkey hash insertion matches Dash Core's
+    /// bloom_create_insert_key test (bloom_tests.cpp).
+    /// Filter: 2 elements, 0.001 fp rate, tweak 0, BLOOM_UPDATE_ALL.
+    /// Data inserted: uncompressed pubkey bytes and Hash160(pubkey) bytes.
+    /// Expected serialized bytes: "038fc16b080000000000000001"
+    #[test]
+    fn test_bloom_create_insert_key() {
+        let secp = secp256k1::Secp256k1::new();
+
+        // Private key from Dash Core test WIF: 7sQb6QHALg4XyHsJHsSNXnEHGhZfzTTUPJXJqaqK7CavQkiL9Ms
+        let privkey_bytes: [u8; 32] =
+            hex::decode("f49addfd726a59abde172c86452f5f73038a02f4415878dc14934175e8418aff")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let secret_key = secp256k1::SecretKey::from_byte_array(&privkey_bytes).unwrap();
+        let privkey = PrivateKey::new_uncompressed(secret_key, crate::network::constants::Network::Mainnet);
+        let pubkey = privkey.public_key(&secp);
+
+        let mut filter = BloomFilter::new(2, 0.001, 0, BloomFlags::All).unwrap();
+
+        // Insert serialized uncompressed public key
+        let pubkey_bytes = pubkey.to_bytes();
+        filter.insert(&pubkey_bytes);
+
+        // Insert pubkey hash (Hash160 of the serialized pubkey)
+        let pubkey_hash = pubkey.pubkey_hash();
+        filter.insert(pubkey_hash.as_ref());
+
+        let mut encoded = Vec::new();
+        filter.consensus_encode(&mut encoded).unwrap();
+
+        let expected = hex::decode("038fc16b080000000000000001").unwrap();
+        assert_eq!(encoded, expected, "Serialized bloom filter must match Dash Core bloom_create_insert_key test vector");
+    }
+
+    /// Verify with tweak = 2147483649 (from Dash Core bloom_create_insert_serialize_with_tweak).
+    #[test]
+    fn test_bloom_filter_dash_core_compatibility_with_tweak() {
+        let mut filter = BloomFilter::new(3, 0.01, 2147483649, BloomFlags::All).unwrap();
+
+        let data1 = hex::decode("99108ad8ed9bb6274d3980bab5a85c048f0950c8").unwrap();
+        let data2 = hex::decode("b5a2c786d9ef4658287ced5914b37a1b4aa32eee").unwrap();
+        let data3 = hex::decode("b9300670b4c5366e95b2699e8b18bc75e5f729c5").unwrap();
+
+        filter.insert(&data1);
+        assert!(filter.contains(&data1));
+        assert!(
+            !filter.contains(&hex::decode("19108ad8ed9bb6274d3980bab5a85c048f0950c8").unwrap())
+        );
+
+        filter.insert(&data2);
+        assert!(filter.contains(&data2));
+
+        filter.insert(&data3);
+        assert!(filter.contains(&data3));
+
+        let mut encoded = Vec::new();
+        filter.consensus_encode(&mut encoded).unwrap();
+
+        let expected = hex::decode("03ce4299050000000100008001").unwrap();
+        assert_eq!(
+            encoded, expected,
+            "Serialized bloom filter must match Dash Core test vector (with tweak)"
+        );
     }
 }

--- a/dash/src/bloom/filter.rs
+++ b/dash/src/bloom/filter.rs
@@ -212,6 +212,7 @@ impl Decodable for BloomFilter {
 mod tests {
     use super::*;
     use crate::crypto::key::{PrivateKey, secp256k1};
+    use crate::Network;
 
     #[test]
     fn test_bloom_filter_basic() {
@@ -363,7 +364,7 @@ mod tests {
                 .unwrap();
         let secret_key = secp256k1::SecretKey::from_byte_array(&privkey_bytes).unwrap();
         let privkey =
-            PrivateKey::new_uncompressed(secret_key, crate::network::constants::Network::Mainnet);
+            PrivateKey::new_uncompressed(secret_key, Network::Mainnet);
         let pubkey = privkey.public_key(&secp);
 
         let mut filter = BloomFilter::new(2, 0.001, 0, BloomFlags::All).unwrap();

--- a/dash/src/bloom/filter.rs
+++ b/dash/src/bloom/filter.rs
@@ -362,7 +362,8 @@ mod tests {
                 .try_into()
                 .unwrap();
         let secret_key = secp256k1::SecretKey::from_byte_array(&privkey_bytes).unwrap();
-        let privkey = PrivateKey::new_uncompressed(secret_key, crate::network::constants::Network::Mainnet);
+        let privkey =
+            PrivateKey::new_uncompressed(secret_key, crate::network::constants::Network::Mainnet);
         let pubkey = privkey.public_key(&secp);
 
         let mut filter = BloomFilter::new(2, 0.001, 0, BloomFlags::All).unwrap();
@@ -379,7 +380,10 @@ mod tests {
         filter.consensus_encode(&mut encoded).unwrap();
 
         let expected = hex::decode("038fc16b080000000000000001").unwrap();
-        assert_eq!(encoded, expected, "Serialized bloom filter must match Dash Core bloom_create_insert_key test vector");
+        assert_eq!(
+            encoded, expected,
+            "Serialized bloom filter must match Dash Core bloom_create_insert_key test vector"
+        );
     }
 
     /// Verify with tweak = 2147483649 (from Dash Core bloom_create_insert_serialize_with_tweak).

--- a/dash/src/bloom/filter.rs
+++ b/dash/src/bloom/filter.rs
@@ -211,8 +211,8 @@ impl Decodable for BloomFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crypto::key::{PrivateKey, secp256k1};
     use crate::Network;
+    use crate::crypto::key::{PrivateKey, secp256k1};
 
     #[test]
     fn test_bloom_filter_basic() {
@@ -363,8 +363,7 @@ mod tests {
                 .try_into()
                 .unwrap();
         let secret_key = secp256k1::SecretKey::from_byte_array(&privkey_bytes).unwrap();
-        let privkey =
-            PrivateKey::new_uncompressed(secret_key, Network::Mainnet);
+        let privkey = PrivateKey::new_uncompressed(secret_key, Network::Mainnet);
         let pubkey = privkey.public_key(&secp);
 
         let mut filter = BloomFilter::new(2, 0.001, 0, BloomFlags::All).unwrap();

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,8 @@ ignore = [
     # bincode is unmaintained but used throughout the codebase, need to find a solution here.
     # https://rustsec.org/advisories/RUSTSEC-2025-0141.html
     "RUSTSEC-2025-0141",
+    # paste is unmaintained, pulled in transitively by uniffi
+    "RUSTSEC-2024-0436",
 ]
 
 [licenses]

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -178,13 +178,17 @@ typedef enum {
      */
     MEMPOOL = 0,
     /*
+     Transaction is in the mempool with an InstantSend lock
+     */
+    INSTANT_SEND = 1,
+    /*
      Transaction is in a block at the given height
      */
-    IN_BLOCK = 1,
+    IN_BLOCK = 2,
     /*
      Transaction is in a chain-locked block at the given height
      */
-    IN_CHAIN_LOCKED_BLOCK = 2,
+    IN_CHAIN_LOCKED_BLOCK = 3,
 } FFITransactionContext;
 
 /*

--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -462,6 +462,7 @@ pub unsafe extern "C" fn wallet_check_transaction(
                     },
                 }
             }
+            FFITransactionContext::InstantSend => TransactionContext::InstantSend,
         };
 
         // Create a ManagedWalletInfo from the wallet

--- a/key-wallet-ffi/src/transaction_checking.rs
+++ b/key-wallet-ffi/src/transaction_checking.rs
@@ -183,6 +183,7 @@ pub unsafe extern "C" fn managed_wallet_check_transaction(
                 },
             }
         }
+        FFITransactionContext::InstantSend => TransactionContext::InstantSend,
     };
 
     // Check the transaction - wallet is now required
@@ -615,7 +616,8 @@ mod tests {
     fn test_transaction_context_conversion() {
         // Test that FFI transaction context values match expectations
         assert_eq!(FFITransactionContext::Mempool as u32, 0);
-        assert_eq!(FFITransactionContext::InBlock as u32, 1);
-        assert_eq!(FFITransactionContext::InChainLockedBlock as u32, 2);
+        assert_eq!(FFITransactionContext::InstantSend as u32, 1);
+        assert_eq!(FFITransactionContext::InBlock as u32, 2);
+        assert_eq!(FFITransactionContext::InChainLockedBlock as u32, 3);
     }
 }

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -727,10 +727,12 @@ impl From<TransactionContext> for FFITransactionContext {
         match ctx {
             TransactionContext::Mempool => FFITransactionContext::Mempool,
             TransactionContext::InstantSend => FFITransactionContext::InstantSend,
-            TransactionContext::InBlock { .. } => FFITransactionContext::InBlock,
-            TransactionContext::InChainLockedBlock { .. } => {
-                FFITransactionContext::InChainLockedBlock
-            }
+            TransactionContext::InBlock {
+                ..
+            } => FFITransactionContext::InBlock,
+            TransactionContext::InChainLockedBlock {
+                ..
+            } => FFITransactionContext::InChainLockedBlock,
         }
     }
 }

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -712,10 +712,31 @@ impl FFIWalletAccountCreationOptions {
 pub enum FFITransactionContext {
     /// Transaction is in the mempool (unconfirmed)
     Mempool = 0,
+    /// Transaction is in the mempool with an InstantSend lock
+    InstantSend = 1,
     /// Transaction is in a block at the given height
-    InBlock = 1,
+    InBlock = 2,
     /// Transaction is in a chain-locked block at the given height
-    InChainLockedBlock = 2,
+    InChainLockedBlock = 3,
+}
+
+impl From<key_wallet::transaction_checking::TransactionContext> for FFITransactionContext {
+    fn from(ctx: key_wallet::transaction_checking::TransactionContext) -> Self {
+        match ctx {
+            key_wallet::transaction_checking::TransactionContext::Mempool => {
+                FFITransactionContext::Mempool
+            }
+            key_wallet::transaction_checking::TransactionContext::InstantSend => {
+                FFITransactionContext::InstantSend
+            }
+            key_wallet::transaction_checking::TransactionContext::InBlock {
+                ..
+            } => FFITransactionContext::InBlock,
+            key_wallet::transaction_checking::TransactionContext::InChainLockedBlock {
+                ..
+            } => FFITransactionContext::InChainLockedBlock,
+        }
+    }
 }
 
 /// FFI-compatible transaction context details
@@ -815,6 +836,7 @@ impl FFITransactionContextDetails {
                     },
                 }
             }
+            FFITransactionContext::InstantSend => TransactionContext::InstantSend,
         }
     }
 }

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -1,5 +1,7 @@
 //! Common types for FFI interface
 
+use dashcore::hashes::Hash;
+use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::{Network, Wallet};
 use std::os::raw::{c_char, c_uint};
 use std::sync::Arc;
@@ -720,21 +722,15 @@ pub enum FFITransactionContext {
     InChainLockedBlock = 3,
 }
 
-impl From<key_wallet::transaction_checking::TransactionContext> for FFITransactionContext {
-    fn from(ctx: key_wallet::transaction_checking::TransactionContext) -> Self {
+impl From<TransactionContext> for FFITransactionContext {
+    fn from(ctx: TransactionContext) -> Self {
         match ctx {
-            key_wallet::transaction_checking::TransactionContext::Mempool => {
-                FFITransactionContext::Mempool
+            TransactionContext::Mempool => FFITransactionContext::Mempool,
+            TransactionContext::InstantSend => FFITransactionContext::InstantSend,
+            TransactionContext::InBlock { .. } => FFITransactionContext::InBlock,
+            TransactionContext::InChainLockedBlock { .. } => {
+                FFITransactionContext::InChainLockedBlock
             }
-            key_wallet::transaction_checking::TransactionContext::InstantSend => {
-                FFITransactionContext::InstantSend
-            }
-            key_wallet::transaction_checking::TransactionContext::InBlock {
-                ..
-            } => FFITransactionContext::InBlock,
-            key_wallet::transaction_checking::TransactionContext::InChainLockedBlock {
-                ..
-            } => FFITransactionContext::InChainLockedBlock,
         }
     }
 }
@@ -785,9 +781,7 @@ impl FFITransactionContextDetails {
     }
 
     /// Convert to the native TransactionContext
-    pub fn to_transaction_context(&self) -> key_wallet::transaction_checking::TransactionContext {
-        use key_wallet::transaction_checking::TransactionContext;
-
+    pub fn to_transaction_context(&self) -> TransactionContext {
         match self.context_type {
             FFITransactionContext::Mempool => TransactionContext::Mempool,
             FFITransactionContext::InBlock => {
@@ -799,7 +793,6 @@ impl FFITransactionContextDetails {
                     unsafe {
                         std::ptr::copy_nonoverlapping(self.block_hash, hash_bytes.as_mut_ptr(), 32);
                     }
-                    use dashcore::hashes::Hash;
                     Some(dashcore::BlockHash::from_byte_array(hash_bytes))
                 };
 
@@ -822,7 +815,6 @@ impl FFITransactionContextDetails {
                     unsafe {
                         std::ptr::copy_nonoverlapping(self.block_hash, hash_bytes.as_mut_ptr(), 32);
                     }
-                    use dashcore::hashes::Hash;
                     Some(dashcore::BlockHash::from_byte_array(hash_bytes))
                 };
 

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -7,6 +7,7 @@ use crate::wallet_manager::WalletId;
 use alloc::string::String;
 use alloc::vec::Vec;
 use dashcore::{Address, Txid};
+use key_wallet::transaction_checking::TransactionContext;
 
 /// Events emitted by the wallet manager.
 ///
@@ -14,10 +15,12 @@ use dashcore::{Address, Txid};
 /// may want to react to.
 #[derive(Debug, Clone)]
 pub enum WalletEvent {
-    /// A transaction relevant to the wallet was received.
+    /// A transaction relevant to the wallet was received for the first time.
     TransactionReceived {
         /// ID of the affected wallet.
         wallet_id: WalletId,
+        /// Context at the time the transaction was first seen.
+        status: TransactionContext,
         /// Account index within the wallet.
         account_index: u32,
         /// Transaction ID.
@@ -26,6 +29,13 @@ pub enum WalletEvent {
         amount: i64,
         /// Addresses involved in the transaction.
         addresses: Vec<Address>,
+    },
+    /// The confirmation status of a previously seen transaction has changed.
+    TransactionStatusChanged {
+        /// Transaction ID.
+        txid: Txid,
+        /// New transaction context.
+        status: TransactionContext,
     },
     /// The wallet balance has changed.
     BalanceUpdated {
@@ -49,9 +59,16 @@ impl WalletEvent {
             WalletEvent::TransactionReceived {
                 txid,
                 amount,
+                status,
                 ..
             } => {
-                format!("TransactionReceived(txid={}, amount={})", txid, amount)
+                format!("TransactionReceived(txid={}, amount={}, status={})", txid, amount, status)
+            }
+            WalletEvent::TransactionStatusChanged {
+                txid,
+                status,
+            } => {
+                format!("TransactionStatusChanged(txid={}, status={})", txid, status)
             }
             WalletEvent::BalanceUpdated {
                 spendable,

--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -45,5 +45,5 @@ pub use key_wallet::wallet::managed_wallet_info::coin_selection::{
 };
 pub use key_wallet::wallet::managed_wallet_info::fee::FeeRate;
 pub use key_wallet::wallet::managed_wallet_info::transaction_builder::TransactionBuilder;
-pub use wallet_interface::BlockProcessingResult;
+pub use wallet_interface::{BlockProcessingResult, MempoolTransactionResult};
 pub use wallet_manager::{WalletError, WalletManager};

--- a/key-wallet-manager/src/test_utils/wallet.rs
+++ b/key-wallet-manager/src/test_utils/wallet.rs
@@ -1,28 +1,36 @@
-use crate::{wallet_interface::WalletInterface, BlockProcessingResult};
+use crate::{wallet_interface::WalletInterface, BlockProcessingResult, WalletEvent};
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, Block, Transaction, Txid};
 use std::{collections::BTreeMap, sync::Arc};
-use tokio::sync::Mutex;
+use tokio::sync::{broadcast, Mutex};
 
 // Type alias for transaction effects map
 type TransactionEffectsMap = Arc<Mutex<BTreeMap<Txid, (i64, Vec<String>)>>>;
 
-#[derive(Default)]
 pub struct MockWallet {
     processed_blocks: Arc<Mutex<Vec<(dashcore::BlockHash, u32)>>>,
     processed_transactions: Arc<Mutex<Vec<dashcore::Txid>>>,
     // Map txid -> (net_amount, addresses)
     effects: TransactionEffectsMap,
     synced_height: CoreBlockHeight,
+    event_sender: broadcast::Sender<WalletEvent>,
+}
+
+impl Default for MockWallet {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MockWallet {
     pub fn new() -> Self {
+        let (event_sender, _) = broadcast::channel(16);
         Self {
             processed_blocks: Arc::new(Mutex::new(Vec::new())),
             processed_transactions: Arc::new(Mutex::new(Vec::new())),
             effects: Arc::new(Mutex::new(BTreeMap::new())),
             synced_height: 0,
+            event_sender,
         }
     }
 
@@ -78,18 +86,30 @@ impl WalletInterface for MockWallet {
     fn update_synced_height(&mut self, height: CoreBlockHeight) {
         self.synced_height = height;
     }
+
+    fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent> {
+        self.event_sender.subscribe()
+    }
 }
 
 /// Mock wallet that returns false for filter checks
-#[derive(Default)]
 pub struct NonMatchingMockWallet {
     synced_height: CoreBlockHeight,
+    event_sender: broadcast::Sender<WalletEvent>,
+}
+
+impl Default for NonMatchingMockWallet {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl NonMatchingMockWallet {
     pub fn new() -> Self {
+        let (event_sender, _) = broadcast::channel(16);
         Self {
             synced_height: 0,
+            event_sender,
         }
     }
 }
@@ -112,6 +132,10 @@ impl WalletInterface for NonMatchingMockWallet {
 
     fn update_synced_height(&mut self, height: CoreBlockHeight) {
         self.synced_height = height;
+    }
+
+    fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent> {
+        self.event_sender.subscribe()
     }
 
     async fn describe(&self) -> String {

--- a/key-wallet-manager/src/test_utils/wallet.rs
+++ b/key-wallet-manager/src/test_utils/wallet.rs
@@ -1,6 +1,11 @@
-use crate::{wallet_interface::WalletInterface, BlockProcessingResult, WalletEvent};
+use crate::{
+    wallet_interface::WalletInterface, BlockProcessingResult, MempoolTransactionResult, WalletEvent,
+};
+use dashcore::address::NetworkUnchecked;
 use dashcore::prelude::CoreBlockHeight;
-use dashcore::{Address, Block, Transaction, Txid};
+use dashcore::{Address, Block, OutPoint, Transaction, Txid};
+use key_wallet::transaction_checking::TransactionContext;
+use std::str::FromStr;
 use std::{collections::BTreeMap, sync::Arc};
 use tokio::sync::{broadcast, Mutex};
 
@@ -14,12 +19,18 @@ pub struct MockWallet {
     effects: TransactionEffectsMap,
     synced_height: CoreBlockHeight,
     event_sender: broadcast::Sender<WalletEvent>,
-}
-
-impl Default for MockWallet {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// When true, process_mempool_transaction returns is_relevant=true.
+    mempool_relevant: bool,
+    /// Addresses returned by monitored_addresses.
+    addresses: Vec<Address>,
+    /// Outpoints returned by watched_outpoints.
+    outpoints: Vec<OutPoint>,
+    /// New addresses returned by process_mempool_transaction.
+    mempool_new_addresses: Vec<Address>,
+    /// Recorded status change notifications for test assertions.
+    status_changes: Arc<Mutex<Vec<(Txid, TransactionContext)>>>,
+    /// Recorded chainlock notification heights for test assertions.
+    chainlock_notifications: Arc<Mutex<Vec<u32>>>,
 }
 
 impl MockWallet {
@@ -31,7 +42,33 @@ impl MockWallet {
             effects: Arc::new(Mutex::new(BTreeMap::new())),
             synced_height: 0,
             event_sender,
+            mempool_relevant: false,
+            addresses: Vec::new(),
+            outpoints: Vec::new(),
+            mempool_new_addresses: Vec::new(),
+            status_changes: Arc::new(Mutex::new(Vec::new())),
+            chainlock_notifications: Arc::new(Mutex::new(Vec::new())),
         }
+    }
+
+    /// Configure whether mempool transactions are reported as relevant.
+    pub fn set_mempool_relevant(&mut self, relevant: bool) {
+        self.mempool_relevant = relevant;
+    }
+
+    /// Set the addresses returned by monitored_addresses.
+    pub fn set_addresses(&mut self, addresses: Vec<Address>) {
+        self.addresses = addresses;
+    }
+
+    /// Set the outpoints returned by watched_outpoints.
+    pub fn set_outpoints(&mut self, outpoints: Vec<OutPoint>) {
+        self.outpoints = outpoints;
+    }
+
+    /// Set new addresses returned by process_mempool_transaction.
+    pub fn set_mempool_new_addresses(&mut self, addresses: Vec<Address>) {
+        self.mempool_new_addresses = addresses;
     }
 
     pub async fn set_effect(&self, txid: dashcore::Txid, net: i64, addresses: Vec<String>) {
@@ -46,11 +83,30 @@ impl MockWallet {
     pub fn processed_transactions(&self) -> Arc<Mutex<Vec<dashcore::Txid>>> {
         self.processed_transactions.clone()
     }
+
+    pub fn status_changes(&self) -> Arc<Mutex<Vec<(Txid, TransactionContext)>>> {
+        self.status_changes.clone()
+    }
+
+    pub fn chainlock_notifications(&self) -> Arc<Mutex<Vec<u32>>> {
+        self.chainlock_notifications.clone()
+    }
+}
+
+impl Default for MockWallet {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[async_trait::async_trait]
 impl WalletInterface for MockWallet {
-    async fn process_block(&mut self, block: &Block, height: u32) -> BlockProcessingResult {
+    async fn process_block(
+        &mut self,
+        block: &Block,
+        height: u32,
+        _best_chainlock_height: Option<u32>,
+    ) -> BlockProcessingResult {
         let mut processed = self.processed_blocks.lock().await;
         processed.push((block.block_hash(), height));
 
@@ -61,9 +117,38 @@ impl WalletInterface for MockWallet {
         }
     }
 
-    async fn process_mempool_transaction(&mut self, tx: &Transaction) {
+    async fn process_mempool_transaction(
+        &mut self,
+        tx: &Transaction,
+        _is_instant_send: bool,
+    ) -> MempoolTransactionResult {
         let mut processed = self.processed_transactions.lock().await;
         processed.push(tx.txid());
+
+        if !self.mempool_relevant {
+            return MempoolTransactionResult::default();
+        }
+
+        let effects = self.effects.lock().await;
+        let (net_amount, addresses) = if let Some((net, addr_strs)) = effects.get(&tx.txid()) {
+            let addrs = addr_strs
+                .iter()
+                .filter_map(|s| {
+                    Address::<NetworkUnchecked>::from_str(s).ok().map(|a| a.assume_checked())
+                })
+                .collect();
+            (*net, addrs)
+        } else {
+            (0, Vec::new())
+        };
+
+        MempoolTransactionResult {
+            is_relevant: true,
+            net_amount,
+            is_outgoing: net_amount < 0,
+            addresses,
+            new_addresses: self.mempool_new_addresses.clone(),
+        }
     }
 
     async fn describe(&self) -> String {
@@ -76,7 +161,11 @@ impl WalletInterface for MockWallet {
     }
 
     fn monitored_addresses(&self) -> Vec<Address> {
-        Vec::new()
+        self.addresses.clone()
+    }
+
+    fn watched_outpoints(&self) -> Vec<OutPoint> {
+        self.outpoints.clone()
     }
 
     fn synced_height(&self) -> CoreBlockHeight {
@@ -89,6 +178,22 @@ impl WalletInterface for MockWallet {
 
     fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent> {
         self.event_sender.subscribe()
+    }
+
+    fn notify_transaction_status_changed(&self, txid: Txid, status: TransactionContext) {
+        if let Ok(mut changes) = self.status_changes.try_lock() {
+            changes.push((txid, status));
+        }
+    }
+
+    fn process_instant_send_lock(&mut self, txid: Txid) {
+        self.notify_transaction_status_changed(txid, TransactionContext::InstantSend);
+    }
+
+    fn process_chainlock(&mut self, height: u32) {
+        if let Ok(mut notifications) = self.chainlock_notifications.try_lock() {
+            notifications.push(height);
+        }
     }
 }
 
@@ -116,11 +221,22 @@ impl NonMatchingMockWallet {
 
 #[async_trait::async_trait]
 impl WalletInterface for NonMatchingMockWallet {
-    async fn process_block(&mut self, _block: &Block, _height: u32) -> BlockProcessingResult {
+    async fn process_block(
+        &mut self,
+        _block: &Block,
+        _height: u32,
+        _best_chainlock_height: Option<u32>,
+    ) -> BlockProcessingResult {
         BlockProcessingResult::default()
     }
 
-    async fn process_mempool_transaction(&mut self, _tx: &Transaction) {}
+    async fn process_mempool_transaction(
+        &mut self,
+        _tx: &Transaction,
+        _is_instant_send: bool,
+    ) -> MempoolTransactionResult {
+        MempoolTransactionResult::default()
+    }
 
     fn monitored_addresses(&self) -> Vec<Address> {
         Vec::new()

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -7,7 +7,8 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use async_trait::async_trait;
 use dashcore::prelude::CoreBlockHeight;
-use dashcore::{Address, Block, Transaction, Txid};
+use dashcore::{Address, Block, OutPoint, Transaction, Txid};
+use key_wallet::transaction_checking::TransactionContext;
 use tokio::sync::broadcast;
 
 /// Result of processing a block through the wallet
@@ -18,6 +19,21 @@ pub struct BlockProcessingResult {
     /// Transaction IDs that were already in wallet history
     pub existing_txids: Vec<Txid>,
     /// New addresses generated during gap limit maintenance
+    pub new_addresses: Vec<Address>,
+}
+
+/// Result of processing a mempool transaction through the wallet
+#[derive(Debug, Default, Clone)]
+pub struct MempoolTransactionResult {
+    /// Whether the transaction was relevant to any wallet.
+    pub is_relevant: bool,
+    /// Net amount change for the wallet (received - sent) in satoshis.
+    pub net_amount: i64,
+    /// Whether this is an outgoing transaction (net_amount < 0).
+    pub is_outgoing: bool,
+    /// Addresses involved in this transaction.
+    pub addresses: Vec<Address>,
+    /// New addresses generated during gap limit maintenance.
     pub new_addresses: Vec<Address>,
 }
 
@@ -43,13 +59,26 @@ pub trait WalletInterface: Send + Sync + 'static {
         &mut self,
         block: &Block,
         height: CoreBlockHeight,
+        best_chainlock_height: Option<u32>,
     ) -> BlockProcessingResult;
 
-    /// Called when a transaction is seen in the mempool
-    async fn process_mempool_transaction(&mut self, tx: &Transaction);
+    /// Called when a transaction is seen in the mempool.
+    /// Returns whether the transaction was relevant and any new addresses generated.
+    /// When `is_instant_send` is true, the transaction already has an IS lock.
+    async fn process_mempool_transaction(
+        &mut self,
+        tx: &Transaction,
+        is_instant_send: bool,
+    ) -> MempoolTransactionResult;
 
     /// Get all addresses the wallet is monitoring for incoming transactions
     fn monitored_addresses(&self) -> Vec<Address>;
+
+    /// Get all outpoints the wallet is watching (unspent outputs).
+    /// Used for bloom filter construction to detect spends of our UTXOs.
+    fn watched_outpoints(&self) -> Vec<OutPoint> {
+        Vec::new()
+    }
 
     /// Return the wallet's per-transaction net change and involved addresses if known.
     /// Returns (net_amount, addresses) where net_amount is received - sent in satoshis.
@@ -94,6 +123,18 @@ pub trait WalletInterface: Send + Sync + 'static {
 
     /// Subscribe to wallet events (e.g. transactions received, balance changes).
     fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent>;
+
+    /// Notify consumers that a transaction's confirmation status has changed.
+    fn notify_transaction_status_changed(&self, _txid: Txid, _status: TransactionContext) {}
+
+    /// Process an InstantSend lock for a transaction already in the wallet.
+    /// Marks UTXOs as IS-locked, emits status change and balance update events.
+    fn process_instant_send_lock(&mut self, _txid: Txid) {}
+
+    /// Process a chainlock at the given height.
+    /// Marks all confirmed transactions at or below this height as chainlocked
+    /// and emits status change events.
+    fn process_chainlock(&mut self, _height: u32) {}
 
     /// Provide a human-readable description of the wallet implementation.
     ///

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -2,11 +2,13 @@
 //!
 //! This module defines the trait that SPV clients use to interact with wallets.
 
+use crate::WalletEvent;
 use alloc::string::String;
 use alloc::vec::Vec;
 use async_trait::async_trait;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, Block, Transaction, Txid};
+use tokio::sync::broadcast;
 
 /// Result of processing a block through the wallet
 #[derive(Debug, Default, Clone)]
@@ -89,6 +91,9 @@ pub trait WalletInterface: Send + Sync + 'static {
             self.update_synced_height(height);
         }
     }
+
+    /// Subscribe to wallet events (e.g. transactions received, balance changes).
+    fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent>;
 
     /// Provide a human-readable description of the wallet implementation.
     ///

--- a/key-wallet-manager/src/wallet_manager/event_tests.rs
+++ b/key-wallet-manager/src/wallet_manager/event_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::wallet_interface::WalletInterface;
 use dashcore::hashes::Hash;
-use dashcore::{BlockHash, OutPoint, ScriptBuf, TxIn, Txid, TxOut, Witness};
+use dashcore::{BlockHash, OutPoint, ScriptBuf, TxIn, TxOut, Txid, Witness};
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;

--- a/key-wallet-manager/src/wallet_manager/event_tests.rs
+++ b/key-wallet-manager/src/wallet_manager/event_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::wallet_interface::WalletInterface;
 use dashcore::hashes::Hash;
-use dashcore::{BlockHash, ScriptBuf, TxOut, Witness};
+use dashcore::{BlockHash, OutPoint, ScriptBuf, TxIn, Txid, TxOut, Witness};
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
@@ -27,9 +27,9 @@ fn create_tx_paying_to(addr: &Address, input_seed: u8) -> Transaction {
     Transaction {
         version: 2,
         lock_time: 0,
-        input: vec![dashcore::TxIn {
-            previous_output: dashcore::OutPoint {
-                txid: dashcore::Txid::from_byte_array([input_seed; 32]),
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: Txid::from_byte_array([input_seed; 32]),
                 vout: 0,
             },
             script_sig: ScriptBuf::new(),

--- a/key-wallet-manager/src/wallet_manager/event_tests.rs
+++ b/key-wallet-manager/src/wallet_manager/event_tests.rs
@@ -705,3 +705,32 @@ async fn test_check_transaction_populates_totals() {
         "involved_addresses should contain the target address"
     );
 }
+
+// ============ get_aggregated_balance tests ============
+
+#[test]
+fn test_get_aggregated_balance_empty_manager() {
+    let manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
+    let balance = manager.get_aggregated_balance();
+    assert_eq!(balance.spendable(), 0);
+    assert_eq!(balance.unconfirmed(), 0);
+    assert_eq!(balance.immature(), 0);
+    assert_eq!(balance.total(), 0);
+}
+
+#[test]
+fn test_get_aggregated_balance_fresh_wallet_is_zero() {
+    let (manager, _wallet_id, _addr) = setup_manager_with_wallet();
+    let balance = manager.get_aggregated_balance();
+    assert_eq!(balance.spendable(), 0);
+    assert_eq!(balance.unconfirmed(), 0);
+    assert_eq!(balance.immature(), 0);
+    assert_eq!(balance.total(), 0);
+}
+
+#[test]
+fn test_get_aggregated_balance_matches_get_total_balance() {
+    let (manager, _wallet_id, _addr) = setup_manager_with_wallet();
+    let aggregated = manager.get_aggregated_balance();
+    assert_eq!(aggregated.total(), manager.get_total_balance());
+}

--- a/key-wallet-manager/src/wallet_manager/event_tests.rs
+++ b/key-wallet-manager/src/wallet_manager/event_tests.rs
@@ -1,0 +1,707 @@
+use super::*;
+use crate::wallet_interface::WalletInterface;
+use dashcore::hashes::Hash;
+use dashcore::{BlockHash, ScriptBuf, TxOut, Witness};
+use key_wallet::wallet::initialization::WalletAccountCreationOptions;
+use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
+use tokio::sync::broadcast;
+
+const TEST_MNEMONIC: &str =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+const TX_AMOUNT: u64 = 100_000;
+
+fn setup_manager_with_wallet() -> (WalletManager<ManagedWalletInfo>, WalletId, Address) {
+    let mut manager = WalletManager::new(Network::Testnet);
+    let wallet_id = manager
+        .create_wallet_from_mnemonic(TEST_MNEMONIC, "", 0, WalletAccountCreationOptions::Default)
+        .unwrap();
+    let addresses = manager.monitored_addresses();
+    assert!(!addresses.is_empty(), "wallet should have monitored addresses");
+    let addr = addresses[0].clone();
+    (manager, wallet_id, addr)
+}
+
+fn create_tx_paying_to(addr: &Address, input_seed: u8) -> Transaction {
+    Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![dashcore::TxIn {
+            previous_output: dashcore::OutPoint {
+                txid: dashcore::Txid::from_byte_array([input_seed; 32]),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: u32::MAX,
+            witness: Witness::default(),
+        }],
+        output: vec![TxOut {
+            value: TX_AMOUNT,
+            script_pubkey: addr.script_pubkey(),
+        }],
+        special_transaction_payload: None,
+    }
+}
+
+fn drain_events(rx: &mut broadcast::Receiver<WalletEvent>) -> Vec<WalletEvent> {
+    let mut events = Vec::new();
+    while let Ok(e) = rx.try_recv() {
+        events.push(e);
+    }
+    events
+}
+
+/// Drain events from the receiver, assert exactly one was emitted, and return it.
+fn assert_single_event(rx: &mut broadcast::Receiver<WalletEvent>) -> WalletEvent {
+    let events = drain_events(rx);
+    assert_eq!(events.len(), 1, "expected 1 event, got {}: {:?}", events.len(), events);
+    events.into_iter().next().unwrap()
+}
+
+/// Drain events and assert none were emitted.
+fn assert_no_events(rx: &mut broadcast::Receiver<WalletEvent>) {
+    let events = drain_events(rx);
+    assert!(events.is_empty(), "expected no events, got {}: {:?}", events.len(), events);
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle flow tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_mempool_to_confirmed_event_flow() {
+    let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0xaa);
+
+    // First time in mempool
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(
+        matches!(
+            event,
+            WalletEvent::TransactionReceived {
+                status: TransactionContext::Mempool,
+                ..
+            }
+        ),
+        "expected TransactionReceived(Mempool), got {:?}",
+        event
+    );
+
+    // Same tx now confirmed in a block
+    let block_ctx = TransactionContext::InBlock {
+        height: 100,
+        block_hash: Some(BlockHash::from_byte_array([0xaa; 32])),
+        timestamp: Some(1000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, block_ctx, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(
+        matches!(
+            event,
+            WalletEvent::TransactionStatusChanged {
+                status: TransactionContext::InBlock {
+                    height: 100,
+                    ..
+                },
+                ..
+            }
+        ),
+        "expected TransactionStatusChanged(InBlock), got {:?}",
+        event
+    );
+}
+
+#[tokio::test]
+async fn test_mempool_to_instantsend_to_confirmed_event_flow() {
+    let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0xbb);
+
+    // Mempool
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(matches!(
+        event,
+        WalletEvent::TransactionReceived {
+            status: TransactionContext::Mempool,
+            ..
+        }
+    ));
+
+    // InstantSend
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::InstantSend, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(matches!(
+        event,
+        WalletEvent::TransactionStatusChanged {
+            status: TransactionContext::InstantSend,
+            ..
+        }
+    ));
+
+    // Confirmed in block
+    let block_ctx = TransactionContext::InBlock {
+        height: 200,
+        block_hash: Some(BlockHash::from_byte_array([0xbb; 32])),
+        timestamp: Some(2000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, block_ctx, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(matches!(
+        event,
+        WalletEvent::TransactionStatusChanged {
+            status: TransactionContext::InBlock {
+                height: 200,
+                ..
+            },
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn test_mempool_to_confirmed_to_chainlocked_event_flow() {
+    let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0xcc);
+    let txid = tx.txid();
+
+    // Mempool
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(matches!(
+        event,
+        WalletEvent::TransactionReceived {
+            status: TransactionContext::Mempool,
+            ..
+        }
+    ));
+
+    // Confirmed in block
+    let block_hash = BlockHash::from_byte_array([0xbb; 32]);
+    let block_ctx = TransactionContext::InBlock {
+        height: 500,
+        block_hash: Some(block_hash),
+        timestamp: Some(5000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, block_ctx, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(matches!(
+        event,
+        WalletEvent::TransactionStatusChanged {
+            status: TransactionContext::InBlock { .. },
+            ..
+        }
+    ));
+
+    // Chainlock at height 500
+    manager.process_chainlock(500);
+    let event = assert_single_event(&mut rx);
+    assert!(
+        matches!(
+            &event,
+            WalletEvent::TransactionStatusChanged {
+                txid: event_txid,
+                status: TransactionContext::InChainLockedBlock { height: 500, .. },
+            } if *event_txid == txid
+        ),
+        "expected TransactionStatusChanged(InChainLockedBlock), got {:?}",
+        event
+    );
+}
+
+#[tokio::test]
+async fn test_first_seen_in_block_event_flow() {
+    let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0xdd);
+
+    let block_ctx = TransactionContext::InBlock {
+        height: 1000,
+        block_hash: Some(BlockHash::from_byte_array([0xdd; 32])),
+        timestamp: Some(10000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, block_ctx, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(
+        matches!(
+            event,
+            WalletEvent::TransactionReceived {
+                status: TransactionContext::InBlock {
+                    height: 1000,
+                    ..
+                },
+                ..
+            }
+        ),
+        "expected TransactionReceived(InBlock), got {:?}",
+        event
+    );
+}
+
+#[tokio::test]
+async fn test_first_seen_in_chainlocked_block_event_flow() {
+    let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0xee);
+
+    let ctx = TransactionContext::InChainLockedBlock {
+        height: 2000,
+        block_hash: Some(BlockHash::from_byte_array([0xee; 32])),
+        timestamp: Some(20000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, ctx, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(
+        matches!(
+            event,
+            WalletEvent::TransactionReceived {
+                status: TransactionContext::InChainLockedBlock {
+                    height: 2000,
+                    ..
+                },
+                ..
+            }
+        ),
+        "expected TransactionReceived(InChainLockedBlock), got {:?}",
+        event
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Duplicate suppression tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_duplicate_mempool_emits_no_event() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0x11);
+
+    // First mempool submission
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+    assert_single_event(&mut rx);
+
+    // Duplicate mempool submission — no state change, no event
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+    assert_no_events(&mut rx);
+
+    // Wallet state: still exactly 1 record for this txid
+    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+    assert_eq!(history.iter().filter(|r| r.txid == tx.txid()).count(), 1);
+}
+
+#[tokio::test]
+async fn test_duplicate_instantsend_emits_no_event() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0x22);
+
+    // Mempool, then IS
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+    assert_single_event(&mut rx);
+
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::InstantSend, true).await;
+    assert_single_event(&mut rx);
+
+    // Duplicate IS — no state change, no event
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::InstantSend, true).await;
+    assert_no_events(&mut rx);
+
+    // Wallet state: still exactly 1 record
+    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+    assert_eq!(history.iter().filter(|r| r.txid == tx.txid()).count(), 1);
+}
+
+#[tokio::test]
+async fn test_duplicate_confirmed_emits_no_event() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0x33);
+
+    // First seen in block
+    let block_ctx = TransactionContext::InBlock {
+        height: 300,
+        block_hash: Some(BlockHash::from_byte_array([0x33; 32])),
+        timestamp: Some(3000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, block_ctx, true).await;
+    assert_single_event(&mut rx);
+
+    // Same block context again — no event
+    manager.check_transaction_in_all_wallets(&tx, block_ctx, true).await;
+    assert_no_events(&mut rx);
+
+    // Wallet state: still exactly 1 record at height 300
+    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+    let records: Vec<_> = history.iter().filter(|r| r.txid == tx.txid()).collect();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].height, Some(300));
+}
+
+#[tokio::test]
+async fn test_duplicate_chainlock_emits_no_event() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0x44);
+
+    // Mempool -> Confirmed -> ChainLocked
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+    assert_single_event(&mut rx);
+
+    let block_ctx = TransactionContext::InBlock {
+        height: 400,
+        block_hash: Some(BlockHash::from_byte_array([0x44; 32])),
+        timestamp: Some(4000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, block_ctx, true).await;
+    assert_single_event(&mut rx);
+
+    manager.process_chainlock(400);
+    assert_single_event(&mut rx);
+
+    // Duplicate chainlock at same height — no event
+    manager.process_chainlock(400);
+    assert_no_events(&mut rx);
+
+    // Wallet state: still exactly 1 record, still chainlocked
+    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+    assert_eq!(history.iter().filter(|r| r.txid == tx.txid()).count(), 1);
+    let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+    assert!(info.is_transaction_chainlocked(&tx.txid()));
+}
+
+// ---------------------------------------------------------------------------
+// Edge case tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_first_seen_as_instantsend_then_duplicate() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0x55);
+
+    // First seen directly as IS (skipping mempool)
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::InstantSend, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(
+        matches!(
+            event,
+            WalletEvent::TransactionReceived {
+                status: TransactionContext::InstantSend,
+                ..
+            }
+        ),
+        "expected TransactionReceived(InstantSend), got {:?}",
+        event
+    );
+
+    // Duplicate IS should trigger no event
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::InstantSend, true).await;
+    assert_no_events(&mut rx);
+
+    // Wallet state: still exactly 1 record
+    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+    assert_eq!(history.iter().filter(|r| r.txid == tx.txid()).count(), 1);
+}
+
+#[tokio::test]
+async fn test_first_seen_in_chainlocked_block_then_process_chainlock() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0x66);
+
+    // First seen in a chainlocked block
+    let ctx = TransactionContext::InChainLockedBlock {
+        height: 700,
+        block_hash: Some(BlockHash::from_byte_array([0x66; 32])),
+        timestamp: Some(7000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, ctx, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(matches!(
+        event,
+        WalletEvent::TransactionReceived {
+            status: TransactionContext::InChainLockedBlock { .. },
+            ..
+        }
+    ));
+
+    // process_chainlock at the same height — tx is already in the chainlock set
+    manager.process_chainlock(700);
+    assert_no_events(&mut rx);
+
+    // Wallet state: tx remains chainlocked with correct height
+    let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+    assert!(info.is_transaction_chainlocked(&tx.txid()));
+    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].height, Some(700));
+}
+
+#[tokio::test]
+async fn test_late_instantsend_after_confirmation_is_ignored() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0x77);
+
+    // Mempool
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+    assert_single_event(&mut rx);
+
+    // Confirmed in block
+    let block_ctx = TransactionContext::InBlock {
+        height: 800,
+        block_hash: Some(BlockHash::from_byte_array([0x77; 32])),
+        timestamp: Some(8000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, block_ctx, true).await;
+    assert_single_event(&mut rx);
+
+    // Late IS lock arrives after confirmation — should be suppressed
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::InstantSend, true).await;
+    assert_no_events(&mut rx);
+
+    // Wallet state: tx still confirmed at height 800, not regressed to IS
+    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+    let records: Vec<_> = history.iter().filter(|r| r.txid == tx.txid()).collect();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].height, Some(800));
+}
+
+#[tokio::test]
+async fn test_instantsend_to_confirmed_to_chainlocked() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0x88);
+    let txid = tx.txid();
+
+    // First seen as IS (skipping mempool)
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::InstantSend, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(matches!(
+        event,
+        WalletEvent::TransactionReceived {
+            status: TransactionContext::InstantSend,
+            ..
+        }
+    ));
+
+    // Confirmed in block
+    let block_ctx = TransactionContext::InBlock {
+        height: 900,
+        block_hash: Some(BlockHash::from_byte_array([0x88; 32])),
+        timestamp: Some(9000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, block_ctx, true).await;
+    let event = assert_single_event(&mut rx);
+    assert!(matches!(
+        event,
+        WalletEvent::TransactionStatusChanged {
+            status: TransactionContext::InBlock {
+                height: 900,
+                ..
+            },
+            ..
+        }
+    ));
+
+    // Chainlocked
+    manager.process_chainlock(900);
+    let event = assert_single_event(&mut rx);
+    assert!(
+        matches!(
+            &event,
+            WalletEvent::TransactionStatusChanged {
+                txid: event_txid,
+                status: TransactionContext::InChainLockedBlock { height: 900, .. },
+            } if *event_txid == txid
+        ),
+        "expected TransactionStatusChanged(InChainLockedBlock), got {:?}",
+        event
+    );
+
+    // Wallet state: tx confirmed at height 900 and chainlocked
+    let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+    assert!(info.is_transaction_chainlocked(&txid));
+    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+    let records: Vec<_> = history.iter().filter(|r| r.txid == txid).collect();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].height, Some(900));
+}
+
+#[tokio::test]
+async fn test_chainlock_via_check_transaction_deduplicates_with_notify() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0x99);
+
+    // Mempool -> Confirmed
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+    assert_single_event(&mut rx);
+
+    let block_ctx = TransactionContext::InBlock {
+        height: 1100,
+        block_hash: Some(BlockHash::from_byte_array([0x99; 32])),
+        timestamp: Some(11000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, block_ctx, true).await;
+    assert_single_event(&mut rx);
+
+    // Chainlock arrives via check_transaction_in_all_wallets
+    let cl_ctx = TransactionContext::InChainLockedBlock {
+        height: 1100,
+        block_hash: Some(BlockHash::from_byte_array([0x99; 32])),
+        timestamp: Some(11000),
+    };
+    manager.check_transaction_in_all_wallets(&tx, cl_ctx, true).await;
+    assert_single_event(&mut rx);
+
+    // process_chainlock at the same height — already handled, no event
+    manager.process_chainlock(1100);
+    assert_no_events(&mut rx);
+
+    // Wallet state: tx chainlocked at height 1100
+    let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+    assert!(info.is_transaction_chainlocked(&tx.txid()));
+    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+    assert_eq!(history.iter().filter(|r| r.txid == tx.txid()).count(), 1);
+}
+
+#[tokio::test]
+async fn test_mempool_after_instantsend_is_suppressed() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0xab);
+
+    // Mempool first
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+    assert_single_event(&mut rx);
+
+    // IS lock
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::InstantSend, true).await;
+    assert_single_event(&mut rx);
+
+    // Mempool re-broadcast — should be suppressed
+    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+    assert_no_events(&mut rx);
+
+    // Wallet state: still exactly 1 record
+    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+    assert_eq!(history.iter().filter(|r| r.txid == tx.txid()).count(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// BalanceUpdated event tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_mempool_tx_emits_balance_updated() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0xf1);
+
+    manager.process_mempool_transaction(&tx, false).await;
+
+    let events = drain_events(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            WalletEvent::BalanceUpdated {
+                wallet_id: wid,
+                unconfirmed,
+                ..
+            } if *wid == wallet_id && *unconfirmed == TX_AMOUNT
+        )),
+        "expected BalanceUpdated with unconfirmed={TX_AMOUNT}, got {:?}",
+        events
+    );
+}
+
+#[tokio::test]
+async fn test_instantsend_tx_emits_balance_updated_spendable() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0xf2);
+
+    manager.process_mempool_transaction(&tx, true).await;
+
+    let events = drain_events(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            WalletEvent::BalanceUpdated {
+                wallet_id: wid,
+                spendable,
+                ..
+            } if *wid == wallet_id && *spendable == TX_AMOUNT
+        )),
+        "expected BalanceUpdated with spendable={TX_AMOUNT}, got {:?}",
+        events
+    );
+}
+
+#[tokio::test]
+async fn test_mempool_to_instantsend_transitions_balance() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0xf3);
+
+    // Mempool tx: balance should be unconfirmed
+    manager.process_mempool_transaction(&tx, false).await;
+    let events = drain_events(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            WalletEvent::BalanceUpdated {
+                wallet_id: wid,
+                unconfirmed,
+                spendable,
+                ..
+            } if *wid == wallet_id && *unconfirmed == TX_AMOUNT && *spendable == 0
+        )),
+        "expected unconfirmed balance after mempool, got {:?}",
+        events
+    );
+
+    // IS lock: balance should move from unconfirmed to spendable
+    manager.process_instant_send_lock(tx.txid());
+    let events = drain_events(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            WalletEvent::BalanceUpdated {
+                wallet_id: wid,
+                spendable,
+                unconfirmed,
+                ..
+            } if *wid == wallet_id && *spendable == TX_AMOUNT && *unconfirmed == 0
+        )),
+        "expected spendable balance after IS lock, got {:?}",
+        events
+    );
+}
+
+#[tokio::test]
+async fn test_check_transaction_populates_totals() {
+    let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
+
+    let tx = create_tx_paying_to(&addr, 0xf0);
+    let result =
+        manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true).await;
+
+    assert!(!result.affected_wallets.is_empty());
+    assert_eq!(result.total_received, TX_AMOUNT);
+    assert_eq!(result.total_sent, 0);
+    assert!(
+        !result.involved_addresses.is_empty(),
+        "involved_addresses should contain the target address"
+    );
+    assert!(
+        result.involved_addresses.contains(&addr),
+        "involved_addresses should contain the target address"
+    );
+}

--- a/key-wallet-manager/src/wallet_manager/mod.rs
+++ b/key-wallet-manager/src/wallet_manager/mod.rs
@@ -67,6 +67,12 @@ pub struct CheckTransactionsResult {
     pub is_new_transaction: bool,
     /// New addresses generated during gap limit maintenance
     pub new_addresses: Vec<Address>,
+    /// Total value received across all wallets
+    pub total_received: u64,
+    /// Total value sent across all wallets
+    pub total_sent: u64,
+    /// Addresses involved across all wallets
+    pub involved_addresses: Vec<Address>,
 }
 
 /// High-level wallet manager that manages multiple wallets
@@ -524,27 +530,48 @@ impl<T: WalletInfoInterface> WalletManager<T> {
                         result.is_new_transaction = true;
                     }
 
-                    // Emit TransactionReceived events for each affected account
-                    #[cfg(feature = "std")]
+                    // Aggregate totals and involved addresses across wallets
+                    result.total_received =
+                        result.total_received.saturating_add(check_result.total_received);
+                    result.total_sent = result.total_sent.saturating_add(check_result.total_sent);
                     for account_match in &check_result.affected_accounts {
-                        let Some(account_index) = account_match.account_type_match.account_index()
-                        else {
-                            continue;
-                        };
-                        let amount = account_match.received as i64 - account_match.sent as i64;
-                        let addresses: Vec<Address> = account_match
-                            .account_type_match
-                            .all_involved_addresses()
-                            .into_iter()
-                            .map(|info| info.address)
-                            .collect();
+                        for addr_info in account_match.account_type_match.all_involved_addresses() {
+                            result.involved_addresses.push(addr_info.address);
+                        }
+                    }
 
-                        let event = WalletEvent::TransactionReceived {
-                            wallet_id,
-                            account_index,
+                    #[cfg(feature = "std")]
+                    if check_result.is_new_transaction {
+                        // First time seeing this transaction — emit TransactionReceived
+                        for account_match in &check_result.affected_accounts {
+                            let Some(account_index) =
+                                account_match.account_type_match.account_index()
+                            else {
+                                continue;
+                            };
+                            let amount = account_match.received as i64 - account_match.sent as i64;
+                            let addresses: Vec<Address> = account_match
+                                .account_type_match
+                                .all_involved_addresses()
+                                .into_iter()
+                                .map(|info| info.address)
+                                .collect();
+
+                            let event = WalletEvent::TransactionReceived {
+                                wallet_id,
+                                status: context,
+                                account_index,
+                                txid: tx.txid(),
+                                amount,
+                                addresses,
+                            };
+                            let _ = self.event_sender.send(event);
+                        }
+                    } else if check_result.status_changed {
+                        // Known transaction whose confirmation status actually changed.
+                        let event = WalletEvent::TransactionStatusChanged {
                             txid: tx.txid(),
-                            amount,
-                            addresses,
+                            status: context,
                         };
                         let _ = self.event_sender.send(event);
                     }
@@ -1015,6 +1042,16 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         }
         addresses
     }
+
+    /// Get all outpoints from wallet UTXOs across all managed wallets.
+    /// Used for bloom filter construction to detect spends of our UTXOs.
+    pub fn watched_outpoints(&self) -> Vec<dashcore::OutPoint> {
+        let mut outpoints = Vec::new();
+        for info in self.wallet_infos.values() {
+            outpoints.extend(info.utxos().into_iter().map(|u| u.outpoint));
+        }
+        outpoints
+    }
 }
 
 /// Wallet manager errors
@@ -1091,6 +1128,9 @@ fn current_timestamp() -> u64 {
 
 #[cfg(feature = "std")]
 impl std::error::Error for WalletError {}
+
+#[cfg(test)]
+mod event_tests;
 
 /// Conversion from key_wallet::Error to WalletError
 impl From<key_wallet::Error> for WalletError {

--- a/key-wallet-manager/src/wallet_manager/mod.rs
+++ b/key-wallet-manager/src/wallet_manager/mod.rs
@@ -984,6 +984,18 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         self.wallet_infos.values().map(|info| info.balance().total()).sum()
     }
 
+    /// Get aggregated balance breakdown across all wallets.
+    ///
+    /// Returns the sum of confirmed (spendable), unconfirmed, and immature
+    /// balances across every managed wallet.
+    pub fn get_aggregated_balance(&self) -> WalletCoreBalance {
+        let mut total = WalletCoreBalance::default();
+        for info in self.wallet_infos.values() {
+            total += info.balance();
+        }
+        total
+    }
+
     /// Get balance for a specific wallet
     pub fn get_wallet_balance(
         &self,

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -1,4 +1,4 @@
-use crate::wallet_interface::{BlockProcessingResult, WalletInterface};
+use crate::wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
 use crate::WalletEvent;
 use crate::WalletManager;
 use alloc::string::String;
@@ -6,10 +6,11 @@ use alloc::vec::Vec;
 use async_trait::async_trait;
 use core::fmt::Write as _;
 use dashcore::prelude::CoreBlockHeight;
-use dashcore::{Address, Block, Transaction};
+use dashcore::{Address, Block, Transaction, Txid};
 use key_wallet::transaction_checking::transaction_router::TransactionRouter;
 use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+use std::collections::HashSet;
 use tokio::sync::broadcast;
 
 #[async_trait]
@@ -18,6 +19,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         &mut self,
         block: &Block,
         height: CoreBlockHeight,
+        best_chainlock_height: Option<u32>,
     ) -> BlockProcessingResult {
         let mut result = BlockProcessingResult::default();
         let block_hash = Some(block.block_hash());
@@ -25,10 +27,18 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
         // Process each transaction using the base manager
         for tx in &block.txdata {
-            let context = TransactionContext::InBlock {
-                height,
-                block_hash,
-                timestamp: Some(timestamp),
+            let context = if best_chainlock_height.is_some_and(|cl| height <= cl) {
+                TransactionContext::InChainLockedBlock {
+                    height,
+                    block_hash,
+                    timestamp: Some(timestamp),
+                }
+            } else {
+                TransactionContext::InBlock {
+                    height,
+                    block_hash,
+                    timestamp: Some(timestamp),
+                }
             };
 
             let check_result = self.check_transaction_in_all_wallets(tx, context, true).await;
@@ -49,18 +59,68 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         result
     }
 
-    async fn process_mempool_transaction(&mut self, tx: &Transaction) {
-        let context = TransactionContext::Mempool;
+    async fn process_mempool_transaction(
+        &mut self,
+        tx: &Transaction,
+        is_instant_send: bool,
+    ) -> MempoolTransactionResult {
+        let context = if is_instant_send {
+            TransactionContext::InstantSend
+        } else {
+            TransactionContext::Mempool
+        };
 
-        // Check transaction against all wallets
-        self.check_transaction_in_all_wallets(
-            tx, context, true, // update state
-        )
-        .await;
+        // Capture balances before processing so we can detect changes
+        let old_balances: Vec<_> =
+            self.wallet_infos.iter().map(|(id, info)| (*id, info.balance())).collect();
+
+        let check_result = self
+            .check_transaction_in_all_wallets(
+                tx, context, true, // update state
+            )
+            .await;
+
+        let is_relevant = !check_result.affected_wallets.is_empty();
+        let net_amount = if is_relevant {
+            check_result.total_received as i64 - check_result.total_sent as i64
+        } else {
+            0
+        };
+
+        // Emit BalanceUpdated for any wallets whose balance changed
+        if is_relevant {
+            for (wallet_id, old_balance) in &old_balances {
+                if let Some(info) = self.wallet_infos.get(wallet_id) {
+                    let new_balance = info.balance();
+                    if *old_balance != new_balance {
+                        let event = WalletEvent::BalanceUpdated {
+                            wallet_id: *wallet_id,
+                            spendable: new_balance.spendable(),
+                            unconfirmed: new_balance.unconfirmed(),
+                            immature: new_balance.immature(),
+                            locked: new_balance.locked(),
+                        };
+                        let _ = self.event_sender.send(event);
+                    }
+                }
+            }
+        }
+
+        MempoolTransactionResult {
+            is_relevant,
+            net_amount,
+            is_outgoing: net_amount < 0,
+            addresses: check_result.involved_addresses,
+            new_addresses: check_result.new_addresses,
+        }
     }
 
     fn monitored_addresses(&self) -> Vec<Address> {
         self.monitored_addresses()
+    }
+
+    fn watched_outpoints(&self) -> Vec<dashcore::OutPoint> {
+        self.watched_outpoints()
     }
 
     async fn transaction_effect(&self, tx: &Transaction) -> Option<(i64, Vec<String>)> {
@@ -150,6 +210,82 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         self.event_sender.subscribe()
     }
 
+    fn notify_transaction_status_changed(&self, txid: Txid, status: TransactionContext) {
+        let event = WalletEvent::TransactionStatusChanged {
+            txid,
+            status,
+        };
+        let _ = self.event_sender().send(event);
+    }
+
+    fn process_instant_send_lock(&mut self, txid: Txid) {
+        let old_balances: Vec<_> =
+            self.wallet_infos.iter().map(|(id, info)| (*id, info.balance())).collect();
+
+        for info in self.wallet_infos.values_mut() {
+            info.mark_instant_send_utxos(&txid);
+            info.update_balance();
+        }
+
+        let event = WalletEvent::TransactionStatusChanged {
+            txid,
+            status: TransactionContext::InstantSend,
+        };
+        let _ = self.event_sender().send(event);
+
+        for (wallet_id, old_balance) in &old_balances {
+            if let Some(info) = self.wallet_infos.get(wallet_id) {
+                let new_balance = info.balance();
+                if *old_balance != new_balance {
+                    let event = WalletEvent::BalanceUpdated {
+                        wallet_id: *wallet_id,
+                        spendable: new_balance.spendable(),
+                        unconfirmed: new_balance.unconfirmed(),
+                        immature: new_balance.immature(),
+                        locked: new_balance.locked(),
+                    };
+                    let _ = self.event_sender().send(event);
+                }
+            }
+        }
+    }
+
+    fn process_chainlock(&mut self, height: u32) {
+        // Collect (wallet_id, txid, context) triples to avoid borrow conflicts.
+        // A txid may appear in multiple accounts/wallets, so we dedup by txid
+        // for event emission while marking each owning wallet individually.
+        let mut pending = Vec::new();
+        for (wallet_id, info) in &self.wallet_infos {
+            for account in info.accounts().all_accounts() {
+                for record in account.transactions.values() {
+                    if let Some(tx_height) = record.height {
+                        if tx_height <= height && !info.is_transaction_chainlocked(&record.txid) {
+                            pending.push((
+                                *wallet_id,
+                                record.txid,
+                                TransactionContext::InChainLockedBlock {
+                                    height: tx_height,
+                                    block_hash: record.block_hash,
+                                    timestamp: Some(record.timestamp as u32),
+                                },
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut emitted = HashSet::new();
+        for (wallet_id, txid, context) in &pending {
+            if let Some(info) = self.wallet_infos.get_mut(wallet_id) {
+                info.mark_transaction_chainlocked(*txid);
+            }
+            if emitted.insert(*txid) {
+                self.notify_transaction_status_changed(*txid, *context);
+            }
+        }
+    }
+
     async fn describe(&self) -> String {
         let wallet_count = self.wallet_infos.len();
         if wallet_count == 0 {
@@ -183,8 +319,66 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dashcore::Network;
+    use crate::wallet_manager::WalletId;
+    use dashcore::hashes::Hash;
+    use dashcore::{Network, ScriptBuf, TxOut, Witness};
+    use key_wallet::wallet::initialization::WalletAccountCreationOptions;
+    use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
     use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
+
+    const TEST_MNEMONIC: &str =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn setup_manager_with_wallet() -> (WalletManager<ManagedWalletInfo>, WalletId, Address) {
+        let mut manager = WalletManager::new(Network::Testnet);
+        let wallet_id = manager
+            .create_wallet_from_mnemonic(
+                TEST_MNEMONIC,
+                "",
+                0,
+                WalletAccountCreationOptions::Default,
+            )
+            .unwrap();
+        let addresses = manager.monitored_addresses();
+        assert!(!addresses.is_empty());
+        let addr = addresses[0].clone();
+        (manager, wallet_id, addr)
+    }
+
+    fn create_tx_paying_to(addr: &Address, input_seed: u8) -> Transaction {
+        Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![dashcore::TxIn {
+                previous_output: dashcore::OutPoint {
+                    txid: dashcore::Txid::from_byte_array([input_seed; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: u32::MAX,
+                witness: Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: 100_000,
+                script_pubkey: addr.script_pubkey(),
+            }],
+            special_transaction_payload: None,
+        }
+    }
+
+    fn make_block(txdata: Vec<Transaction>) -> Block {
+        Block {
+            header: dashcore::block::Header {
+                version: dashcore::block::Version::ONE,
+                prev_blockhash: dashcore::BlockHash::from_byte_array([0; 32]),
+                merkle_root: dashcore::TxMerkleNode::from_byte_array([0; 32]),
+                time: 1000,
+                bits: dashcore::CompactTarget::from_consensus(0x1d00ffff),
+                nonce: 0,
+            },
+            txdata,
+        }
+    }
 
     #[tokio::test]
     async fn test_synced_height() {
@@ -200,5 +394,124 @@ mod tests {
         // Decrease synced height
         manager.update_synced_height(10);
         assert_eq!(manager.synced_height(), 10);
+    }
+
+    #[tokio::test]
+    async fn test_process_chainlock_idempotent() {
+        let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+        let tx = create_tx_paying_to(&addr, 0xaa);
+        let txid = tx.txid();
+        let block = make_block(vec![tx]);
+
+        // Process block at height 500 so the wallet has a confirmed tx
+        let result = manager.process_block(&block, 500, None).await;
+        assert_eq!(result.new_txids, vec![txid]);
+
+        // First chainlock marks the transaction
+        manager.process_chainlock(500);
+        let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+        assert!(info.is_transaction_chainlocked(&txid));
+        let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+        assert_eq!(history.len(), 1);
+
+        // Calling again with same height is idempotent
+        manager.process_chainlock(500);
+        let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+        assert!(info.is_transaction_chainlocked(&txid));
+        let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+        assert_eq!(history.len(), 1);
+
+        // Calling with lower height is safe
+        manager.process_chainlock(300);
+        let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+        assert!(info.is_transaction_chainlocked(&txid));
+    }
+
+    #[tokio::test]
+    async fn test_process_chainlock_incremental() {
+        let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+        let tx1 = create_tx_paying_to(&addr, 0xaa);
+        let tx2 = create_tx_paying_to(&addr, 0xbb);
+        let txid1 = tx1.txid();
+        let txid2 = tx2.txid();
+
+        // Process two blocks at different heights
+        let block1 = make_block(vec![tx1]);
+        let block2 = make_block(vec![tx2]);
+        manager.process_block(&block1, 500, None).await;
+        manager.process_block(&block2, 600, None).await;
+
+        let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+        assert!(!info.is_transaction_chainlocked(&txid1));
+        assert!(!info.is_transaction_chainlocked(&txid2));
+
+        // Chainlock at 500 marks only the first tx
+        manager.process_chainlock(500);
+        let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+        assert!(info.is_transaction_chainlocked(&txid1));
+        assert!(!info.is_transaction_chainlocked(&txid2));
+
+        // Chainlock at 600 also marks the second tx
+        manager.process_chainlock(600);
+        let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+        assert!(info.is_transaction_chainlocked(&txid1));
+        assert!(info.is_transaction_chainlocked(&txid2));
+    }
+
+    #[tokio::test]
+    async fn test_process_block_uses_chainlocked_context() {
+        let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+        let tx = create_tx_paying_to(&addr, 0xcc);
+        let txid = tx.txid();
+        let block = make_block(vec![tx]);
+
+        // Process block at height 500 with best_chainlock_height=1000 (height <= cl)
+        let result = manager.process_block(&block, 500, Some(1000)).await;
+        assert_eq!(result.new_txids, vec![txid]);
+        assert_eq!(manager.synced_height(), 500);
+
+        // Transaction should be in history and already marked as chainlocked
+        let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].txid, txid);
+        assert_eq!(history[0].height, Some(500));
+
+        let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+        assert!(info.is_transaction_chainlocked(&txid));
+    }
+
+    #[tokio::test]
+    async fn test_process_block_uses_confirmed_context() {
+        let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+        let tx = create_tx_paying_to(&addr, 0xdd);
+        let txid = tx.txid();
+        let block = make_block(vec![tx]);
+
+        // Process block at height 500 with best_chainlock_height=100 (height > cl)
+        let result = manager.process_block(&block, 500, Some(100)).await;
+        assert_eq!(result.new_txids, vec![txid]);
+        assert_eq!(manager.synced_height(), 500);
+
+        // Transaction should be confirmed but not chainlocked
+        let history = manager.wallet_transaction_history(&wallet_id).unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].txid, txid);
+        assert_eq!(history[0].height, Some(500));
+
+        let info = manager.get_all_wallet_infos().get(&wallet_id).unwrap();
+        assert!(!info.is_transaction_chainlocked(&txid));
+    }
+
+    #[tokio::test]
+    async fn test_mempool_transaction_result_contains_wallet_effect_data() {
+        let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
+        let tx = create_tx_paying_to(&addr, 0xaa);
+
+        let result = manager.process_mempool_transaction(&tx, false).await;
+
+        assert!(result.is_relevant);
+        assert_eq!(result.net_amount, 100_000);
+        assert!(!result.is_outgoing);
+        assert!(!result.addresses.is_empty());
     }
 }

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -1,4 +1,5 @@
 use crate::wallet_interface::{BlockProcessingResult, WalletInterface};
+use crate::WalletEvent;
 use crate::WalletManager;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -9,6 +10,7 @@ use dashcore::{Address, Block, Transaction};
 use key_wallet::transaction_checking::transaction_router::TransactionRouter;
 use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+use tokio::sync::broadcast;
 
 #[async_trait]
 impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletManager<T> {
@@ -121,7 +123,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             // Emit event if balance changed
             #[cfg(feature = "std")]
             if old_balance != new_balance {
-                let event = crate::WalletEvent::BalanceUpdated {
+                let event = WalletEvent::BalanceUpdated {
                     wallet_id: *wallet_id,
                     spendable: new_balance.spendable(),
                     unconfirmed: new_balance.unconfirmed(),
@@ -142,6 +144,10 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         if height > self.synced_height {
             self.update_synced_height(height);
         }
+    }
+
+    fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent> {
+        self.event_sender.subscribe()
     }
 
     async fn describe(&self) -> String {

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -321,7 +321,9 @@ mod tests {
     use super::*;
     use crate::wallet_manager::WalletId;
     use dashcore::hashes::Hash;
-    use dashcore::{Network, ScriptBuf, TxOut, Witness};
+    use dashcore::block::{Header, Version};
+    use dashcore::pow::CompactTarget;
+    use dashcore::{BlockHash, Network, OutPoint, ScriptBuf, TxIn, Txid, TxMerkleNode, TxOut, Witness};
     use key_wallet::wallet::initialization::WalletAccountCreationOptions;
     use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
     use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
@@ -349,9 +351,9 @@ mod tests {
         Transaction {
             version: 2,
             lock_time: 0,
-            input: vec![dashcore::TxIn {
-                previous_output: dashcore::OutPoint {
-                    txid: dashcore::Txid::from_byte_array([input_seed; 32]),
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([input_seed; 32]),
                     vout: 0,
                 },
                 script_sig: ScriptBuf::new(),
@@ -368,12 +370,12 @@ mod tests {
 
     fn make_block(txdata: Vec<Transaction>) -> Block {
         Block {
-            header: dashcore::block::Header {
-                version: dashcore::block::Version::ONE,
-                prev_blockhash: dashcore::BlockHash::from_byte_array([0; 32]),
-                merkle_root: dashcore::TxMerkleNode::from_byte_array([0; 32]),
+            header: Header {
+                version: Version::ONE,
+                prev_blockhash: BlockHash::from_byte_array([0; 32]),
+                merkle_root: TxMerkleNode::from_byte_array([0; 32]),
                 time: 1000,
-                bits: dashcore::CompactTarget::from_consensus(0x1d00ffff),
+                bits: CompactTarget::from_consensus(0x1d00ffff),
                 nonce: 0,
             },
             txdata,

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -320,10 +320,12 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 mod tests {
     use super::*;
     use crate::wallet_manager::WalletId;
-    use dashcore::hashes::Hash;
     use dashcore::block::{Header, Version};
+    use dashcore::hashes::Hash;
     use dashcore::pow::CompactTarget;
-    use dashcore::{BlockHash, Network, OutPoint, ScriptBuf, TxIn, Txid, TxMerkleNode, TxOut, Witness};
+    use dashcore::{
+        BlockHash, Network, OutPoint, ScriptBuf, TxIn, TxMerkleNode, TxOut, Txid, Witness,
+    };
     use key_wallet::wallet::initialization::WalletAccountCreationOptions;
     use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
     use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;

--- a/key-wallet-manager/tests/spv_integration_tests.rs
+++ b/key-wallet-manager/tests/spv_integration_tests.rs
@@ -29,7 +29,7 @@ async fn test_block_processing() {
     let tx3 = Transaction::dummy(&external, 0..0, &[300_000]);
 
     let block = Block::dummy(100, vec![tx1.clone(), tx2.clone(), tx3.clone()]);
-    let result = manager.process_block(&block, 100).await;
+    let result = manager.process_block(&block, 100, None).await;
 
     // Both transactions should be new (first time seen)
     assert_eq!(result.new_txids.len(), 2);
@@ -61,7 +61,7 @@ async fn test_block_processing_result_empty() {
     let tx2 = Transaction::dummy(&external, 0..0, &[200_000]);
 
     let block = Block::dummy(100, vec![tx1, tx2]);
-    let result = manager.process_block(&block, 100).await;
+    let result = manager.process_block(&block, 100, None).await;
 
     assert!(result.new_txids.is_empty());
     assert!(result.existing_txids.is_empty());
@@ -96,7 +96,7 @@ async fn test_height_updated_after_block_processing() {
     for height in [1000, 2000, 3000] {
         let tx = Transaction::dummy(&Address::dummy(Network::Testnet, 0), 0..0, &[100000]);
         let block = Block::dummy(height, vec![tx]);
-        manager.process_block(&block, height).await;
+        manager.process_block(&block, height, None).await;
         assert_wallet_heights(&manager, height);
     }
 }
@@ -133,7 +133,7 @@ async fn test_immature_balance_matures_during_block_processing() {
     // Process the coinbase at height 1000
     let coinbase_height = 1000;
     let coinbase_block = Block::dummy(coinbase_height, vec![coinbase_tx.clone()]);
-    manager.process_block(&coinbase_block, coinbase_height).await;
+    manager.process_block(&coinbase_block, coinbase_height, None).await;
 
     // Verify the coinbase is detected and stored as immature
     let wallet_info = manager.get_wallet_info(&wallet_id).expect("Wallet info should exist");
@@ -152,7 +152,7 @@ async fn test_immature_balance_matures_during_block_processing() {
     let tx = Transaction::dummy(&Address::dummy(Network::Regtest, 0), 0..0, &[1000]);
     for height in (coinbase_height + 1)..maturity_height {
         let block = Block::dummy(height, vec![tx.clone()]);
-        manager.process_block(&block, height).await;
+        manager.process_block(&block, height, None).await;
     }
 
     // Verify still immature just before maturity
@@ -165,7 +165,7 @@ async fn test_immature_balance_matures_during_block_processing() {
 
     // Process the maturity block
     let maturity_block = Block::dummy(maturity_height, vec![tx.clone()]);
-    manager.process_block(&maturity_block, maturity_height).await;
+    manager.process_block(&maturity_block, maturity_height, None).await;
 
     // Verify the coinbase has matured
     let wallet_info = manager.get_wallet_info(&wallet_id).expect("Wallet info should exist");
@@ -196,7 +196,7 @@ async fn test_block_rescan_marks_transactions_as_existing() {
     let block = Block::dummy(100, vec![tx1.clone()]);
 
     // First processing - transaction should be new
-    let result1 = manager.process_block(&block, 100).await;
+    let result1 = manager.process_block(&block, 100, None).await;
 
     assert_eq!(result1.new_txids.len(), 1, "First processing should have 1 new transaction");
     assert!(
@@ -210,7 +210,7 @@ async fn test_block_rescan_marks_transactions_as_existing() {
     let tx_history_count = wallet_info.transaction_history().len();
 
     // Second processing (simulating rescan) - transaction should be existing
-    let result2 = manager.process_block(&block, 100).await;
+    let result2 = manager.process_block(&block, 100, None).await;
 
     assert!(result2.new_txids.is_empty(), "Rescan should have no new transactions");
     assert_eq!(result2.existing_txids.len(), 1, "Rescan should have 1 existing transaction");

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -352,6 +352,8 @@ impl ManagedCoreAccount {
                                 tx.is_coin_base(),
                             );
                             utxo.is_confirmed = context.confirmed();
+                            utxo.is_instantlocked =
+                                matches!(context, TransactionContext::InstantSend);
                             self.utxos.insert(outpoint, utxo);
                         }
                     }
@@ -372,6 +374,30 @@ impl ManagedCoreAccount {
             }
             _ => {}
         }
+    }
+
+    /// Re-process an existing transaction with updated context (e.g., mempool→block confirmation)
+    /// and potentially new address matches from gap limit rescans.
+    pub(crate) fn confirm_transaction(
+        &mut self,
+        tx: &Transaction,
+        account_match: &AccountMatch,
+        context: TransactionContext,
+    ) -> bool {
+        let mut changed = false;
+        if let Some(tx_record) = self.transactions.get_mut(&tx.txid()) {
+            if !tx_record.is_confirmed() {
+                if let (Some(height), Some(hash)) = (context.block_height(), context.block_hash()) {
+                    tx_record.mark_confirmed(height, hash);
+                    changed = true;
+                }
+                if let Some(ts) = context.timestamp() {
+                    tx_record.timestamp = ts as u64;
+                }
+            }
+        }
+        self.update_utxos(tx, account_match, context);
+        changed
     }
 
     /// Record a new transaction and update UTXOs for spendable account types
@@ -397,6 +423,15 @@ impl ManagedCoreAccount {
         self.transactions.insert(tx.txid(), tx_record);
 
         self.update_utxos(tx, account_match, context);
+    }
+
+    /// Mark all UTXOs belonging to a transaction as InstantSend-locked.
+    pub(crate) fn mark_utxos_instant_send(&mut self, txid: &Txid) {
+        for utxo in self.utxos.values_mut() {
+            if utxo.outpoint.txid == *txid {
+                utxo.is_instantlocked = true;
+            }
+        }
     }
 
     /// Update the account balance

--- a/key-wallet/src/transaction_checking/account_checker.rs
+++ b/key-wallet/src/transaction_checking/account_checker.rs
@@ -32,6 +32,8 @@ pub struct TransactionCheckResult {
     pub is_relevant: bool,
     /// Set to false if the transaction was already stored and is being re-processed (e.g., during rescan)
     pub is_new_transaction: bool,
+    /// Whether the transaction's confirmation status actually changed during this check.
+    pub status_changed: bool,
     /// Accounts that the transaction affects
     pub affected_accounts: Vec<AccountMatch>,
     /// Total value received by our accounts
@@ -290,6 +292,7 @@ impl ManagedAccountCollection {
         let mut result = TransactionCheckResult {
             is_relevant: false,
             is_new_transaction: true,
+            status_changed: false,
             affected_accounts: Vec::new(),
             total_received: 0,
             total_sent: 0,

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -5,6 +5,7 @@
 
 pub(crate) use super::account_checker::TransactionCheckResult;
 use super::transaction_router::TransactionRouter;
+use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use crate::wallet::managed_wallet_info::ManagedWalletInfo;
 use crate::{KeySource, Wallet};
 use async_trait::async_trait;
@@ -13,10 +14,12 @@ use dashcore::prelude::CoreBlockHeight;
 use dashcore::BlockHash;
 
 /// Context for transaction processing
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransactionContext {
     /// Transaction is in the mempool (unconfirmed)
     Mempool,
+    /// Transaction is in the mempool with an InstantSend lock
+    InstantSend,
     /// Transaction is in a block at the given height
     InBlock {
         height: u32,
@@ -35,6 +38,7 @@ impl std::fmt::Display for TransactionContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TransactionContext::Mempool => write!(f, "mempool"),
+            TransactionContext::InstantSend => write!(f, "instant send"),
             TransactionContext::InBlock {
                 height,
                 ..
@@ -60,7 +64,7 @@ impl TransactionContext {
     /// Returns the block height if confirmed.
     pub(crate) fn block_height(&self) -> Option<CoreBlockHeight> {
         match self {
-            TransactionContext::Mempool => None,
+            TransactionContext::Mempool | TransactionContext::InstantSend => None,
             TransactionContext::InBlock {
                 height,
                 ..
@@ -74,7 +78,7 @@ impl TransactionContext {
     /// Returns the block hash if confirmed.
     pub(crate) fn block_hash(&self) -> Option<BlockHash> {
         match self {
-            TransactionContext::Mempool => None,
+            TransactionContext::Mempool | TransactionContext::InstantSend => None,
             TransactionContext::InBlock {
                 block_hash,
                 ..
@@ -88,7 +92,7 @@ impl TransactionContext {
     /// Returns the block time if confirmed.
     pub(crate) fn timestamp(&self) -> Option<u32> {
         match self {
-            TransactionContext::Mempool => None,
+            TransactionContext::Mempool | TransactionContext::InstantSend => None,
             TransactionContext::InBlock {
                 timestamp,
                 ..
@@ -148,14 +152,60 @@ impl WalletTransactionChecker for ManagedWalletInfo {
 
         // Check if this transaction already exists in any affected account
         let txid = tx.txid();
+        let mut is_new = true;
         for account_match in &result.affected_accounts {
             if let Some(account) =
                 self.accounts.get_by_account_type_match(&account_match.account_type_match)
             {
                 if account.transactions.contains_key(&txid) {
-                    result.is_new_transaction = false;
+                    is_new = false;
+                    break;
+                }
+            }
+        }
+        result.is_new_transaction = is_new;
+
+        if !is_new {
+            // IS lock on a transaction that is already confirmed is stale — ignore
+            if context == TransactionContext::InstantSend {
+                if self.instant_send_locks.contains(&txid) {
                     return result;
                 }
+                // Only accept IS transitions for unconfirmed transactions
+                let already_confirmed = result.affected_accounts.iter().any(|am| {
+                    self.accounts
+                        .get_by_account_type_match(&am.account_type_match)
+                        .and_then(|a| a.transactions.get(&txid))
+                        .map_or(false, |r| r.is_confirmed())
+                });
+                if already_confirmed {
+                    self.instant_send_locks.insert(txid);
+                    return result;
+                }
+                self.instant_send_locks.insert(txid);
+                // Mark UTXOs as IS-locked in affected accounts
+                for account_match in &result.affected_accounts {
+                    if let Some(account) = self
+                        .accounts
+                        .get_by_account_type_match_mut(&account_match.account_type_match)
+                    {
+                        account.mark_utxos_instant_send(&txid);
+                    }
+                }
+                result.status_changed = true;
+                return result;
+            }
+            // Check for chainlock transition on a confirmed transaction
+            if matches!(context, TransactionContext::InChainLockedBlock { .. })
+                && !self.chainlocked_transactions.contains(&txid)
+            {
+                self.chainlocked_transactions.insert(txid);
+                result.status_changed = true;
+                return result;
+            }
+            // Only proceed if the new context is a block confirmation
+            if !context.confirmed() {
+                return result;
             }
         }
 
@@ -167,7 +217,12 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                 continue;
             };
 
-            account.record_transaction(tx, &account_match, context);
+            if is_new {
+                account.record_transaction(tx, &account_match, context);
+                result.status_changed = true;
+            } else if account.confirm_transaction(tx, &account_match, context) {
+                result.status_changed = true;
+            }
 
             for address_info in account_match.account_type_match.all_involved_addresses() {
                 account.mark_address_used(&address_info.address);
@@ -196,17 +251,29 @@ impl WalletTransactionChecker for ManagedWalletInfo {
             }
         }
 
-        self.increment_transactions();
+        if is_new {
+            // Populate dedup sets when a tx arrives with an elevated initial status
+            if context == TransactionContext::InstantSend {
+                self.instant_send_locks.insert(txid);
+            }
+            if matches!(context, TransactionContext::InChainLockedBlock { .. }) {
+                self.chainlocked_transactions.insert(txid);
+            }
+            self.increment_transactions();
 
-        let wallet_net = result.total_received as i64 - result.total_sent as i64;
-        tracing::info!(
-            txid = %tx.txid(),
-            context = %context,
-            net_change = wallet_net,
-            received = result.total_received,
-            sent = result.total_sent,
-            "New wallet transaction detected"
-        );
+            let wallet_net = result.total_received as i64 - result.total_sent as i64;
+            tracing::info!(
+                txid = %tx.txid(),
+                context = %context,
+                net_change = wallet_net,
+                received = result.total_received,
+                sent = result.total_sent,
+                "New wallet transaction detected"
+            );
+        }
+
+        // Keep cached balance in sync after any UTXO changes
+        self.update_balance();
 
         result
     }
@@ -926,5 +993,141 @@ mod tests {
             "UTXO should be from spend_tx (change), not funding_tx"
         );
         assert_eq!(utxo.txout.value, 50_000, "UTXO value should be 50k (change amount)");
+    }
+
+    /// Test that a mempool transaction gets confirmed when later seen in a block
+    #[tokio::test]
+    async fn test_mempool_transaction_confirmed_by_block() {
+        let network = Network::Testnet;
+        let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
+            .expect("Should create wallet");
+
+        let mut managed_wallet =
+            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
+
+        let account =
+            wallet.accounts.standard_bip44_accounts.get(&0).expect("Should have BIP44 account");
+        let xpub = account.account_xpub;
+
+        let address = managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("Should have managed account")
+            .next_receive_address(Some(&xpub), true)
+            .expect("Should get address");
+
+        let tx = create_transaction_to_address(&address, 200_000);
+        let txid = tx.txid();
+
+        // First: process as mempool transaction
+        let result1 = managed_wallet
+            .check_core_transaction(&tx, TransactionContext::Mempool, &mut wallet, true)
+            .await;
+
+        assert!(result1.is_relevant);
+        assert!(result1.is_new_transaction);
+
+        // Verify unconfirmed state
+        let account = managed_wallet.first_bip44_managed_account().expect("Should have account");
+        let record = account.transactions.get(&txid).expect("Should have tx record");
+        assert!(!record.is_confirmed(), "Mempool tx should be unconfirmed");
+        assert_eq!(record.height, None);
+
+        let utxo = account.utxos.values().next().expect("Should have UTXO");
+        assert!(!utxo.is_confirmed, "Mempool UTXO should be unconfirmed");
+
+        let total_tx_before = managed_wallet.metadata.total_transactions;
+
+        // Second: same transaction now seen in a block
+        let block_hash = BlockHash::from_slice(&[5u8; 32]).expect("Should create block hash");
+        let block_context = TransactionContext::InBlock {
+            height: 500,
+            block_hash: Some(block_hash),
+            timestamp: Some(1700000000),
+        };
+
+        let result2 =
+            managed_wallet.check_core_transaction(&tx, block_context, &mut wallet, true).await;
+
+        assert!(result2.is_relevant);
+        assert!(!result2.is_new_transaction, "Re-processing should mark as existing");
+
+        // Verify confirmed state
+        let account = managed_wallet.first_bip44_managed_account().expect("Should have account");
+        let record = account.transactions.get(&txid).expect("Should have tx record");
+        assert!(record.is_confirmed(), "Tx should now be confirmed");
+        assert_eq!(record.height, Some(500));
+        assert_eq!(record.block_hash, Some(block_hash));
+        assert_eq!(record.timestamp, 1700000000);
+
+        let utxo = account.utxos.values().next().expect("Should have UTXO");
+        assert!(utxo.is_confirmed, "UTXO should now be confirmed");
+
+        // Transaction counter should not have increased
+        assert_eq!(
+            managed_wallet.metadata.total_transactions, total_tx_before,
+            "total_transactions should not increase for confirmation of existing tx"
+        );
+    }
+
+    /// Test that re-processing an already confirmed transaction is idempotent
+    #[tokio::test]
+    async fn test_confirmed_transaction_stays_confirmed_on_rescan() {
+        let network = Network::Testnet;
+        let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
+            .expect("Should create wallet");
+
+        let mut managed_wallet =
+            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
+
+        let account =
+            wallet.accounts.standard_bip44_accounts.get(&0).expect("Should have BIP44 account");
+        let xpub = account.account_xpub;
+
+        let address = managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("Should have managed account")
+            .next_receive_address(Some(&xpub), true)
+            .expect("Should get address");
+
+        let tx = create_transaction_to_address(&address, 300_000);
+        let txid = tx.txid();
+
+        let block_hash = BlockHash::from_slice(&[7u8; 32]).expect("Should create block hash");
+        let context = TransactionContext::InBlock {
+            height: 1000,
+            block_hash: Some(block_hash),
+            timestamp: Some(1700001000),
+        };
+
+        // First: process in block
+        let result1 = managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+
+        assert!(result1.is_relevant);
+        assert!(result1.is_new_transaction);
+
+        let total_tx_after_first = managed_wallet.metadata.total_transactions;
+
+        // Second: rescan the same block
+        let result2 = managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+
+        assert!(result2.is_relevant);
+        assert!(!result2.is_new_transaction);
+
+        // Verify state is unchanged
+        let account = managed_wallet.first_bip44_managed_account().expect("Should have account");
+        let record = account.transactions.get(&txid).expect("Should have tx record");
+        assert!(record.is_confirmed());
+        assert_eq!(record.height, Some(1000));
+        assert_eq!(record.block_hash, Some(block_hash));
+
+        assert_eq!(account.utxos.len(), 1, "Should still have exactly one UTXO");
+        let utxo = account.utxos.values().next().expect("Should have UTXO");
+        assert!(utxo.is_confirmed);
+        assert_eq!(utxo.txout.value, 300_000);
+
+        assert_eq!(
+            managed_wallet.metadata.total_transactions, total_tx_after_first,
+            "total_transactions should not increase on rescan"
+        );
     }
 }

--- a/key-wallet/src/wallet/managed_wallet_info/mod.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/mod.rs
@@ -20,8 +20,10 @@ use crate::account::ManagedAccountCollection;
 use crate::Network;
 use alloc::string::String;
 use dashcore::prelude::CoreBlockHeight;
+use dashcore::Txid;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 /// Information about a managed wallet
 ///
@@ -45,6 +47,12 @@ pub struct ManagedWalletInfo {
     pub accounts: ManagedAccountCollection,
     /// Cached wallet core balance - should be updated when accounts change
     pub balance: WalletCoreBalance,
+    /// Transactions that have received an InstantSend lock.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub(crate) instant_send_locks: HashSet<Txid>,
+    /// Transactions that have been confirmed in a chainlocked block.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub(crate) chainlocked_transactions: HashSet<Txid>,
 }
 
 impl ManagedWalletInfo {
@@ -58,6 +66,8 @@ impl ManagedWalletInfo {
             metadata: WalletMetadata::default(),
             accounts: ManagedAccountCollection::new(),
             balance: WalletCoreBalance::default(),
+            instant_send_locks: HashSet::new(),
+            chainlocked_transactions: HashSet::new(),
         }
     }
 
@@ -71,6 +81,8 @@ impl ManagedWalletInfo {
             metadata: WalletMetadata::default(),
             accounts: ManagedAccountCollection::new(),
             balance: WalletCoreBalance::default(),
+            instant_send_locks: HashSet::new(),
+            chainlocked_transactions: HashSet::new(),
         }
     }
 
@@ -84,6 +96,8 @@ impl ManagedWalletInfo {
             metadata: WalletMetadata::default(),
             accounts: ManagedAccountCollection::from_account_collection(&wallet.accounts),
             balance: WalletCoreBalance::default(),
+            instant_send_locks: HashSet::new(),
+            chainlocked_transactions: HashSet::new(),
         }
     }
 

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -90,6 +90,15 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Update chain state and process any matured transactions
     /// This should be called when the chain tip advances to a new height
     fn update_synced_height(&mut self, current_height: u32);
+
+    /// Returns whether a transaction has been marked as chainlocked.
+    fn is_transaction_chainlocked(&self, txid: &Txid) -> bool;
+
+    /// Mark a transaction as chainlocked. Returns true if it was newly marked.
+    fn mark_transaction_chainlocked(&mut self, txid: Txid) -> bool;
+
+    /// Mark UTXOs for a transaction as InstantSend-locked across all accounts.
+    fn mark_instant_send_utxos(&mut self, txid: &Txid);
 }
 
 /// Default implementation for ManagedWalletInfo
@@ -227,5 +236,19 @@ impl WalletInfoInterface for ManagedWalletInfo {
         self.metadata.synced_height = current_height;
         // Update cached balance
         self.update_balance();
+    }
+
+    fn is_transaction_chainlocked(&self, txid: &Txid) -> bool {
+        self.chainlocked_transactions.contains(txid)
+    }
+
+    fn mark_transaction_chainlocked(&mut self, txid: Txid) -> bool {
+        self.chainlocked_transactions.insert(txid)
+    }
+
+    fn mark_instant_send_utxos(&mut self, txid: &Txid) {
+        for account in self.accounts.all_accounts_mut() {
+            account.mark_utxos_instant_send(txid);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Exposes mempool state through the UniFFI bridge for Phase 3 (Send & Mempool) UI work.

- Adds `MempoolTransactionInfo` and `MempoolBalanceInfo` record types
- Adds `MempoolActivated` variant to bridge `SyncEvent` enum
- Three new `SpvClient` methods: `get_mempool_transactions`, `get_mempool_transaction_count`, `get_mempool_balance`

Closes #54