### PR TITLE
ci: add Manki AI code review configuration

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -26,3 +26,4 @@ jobs:
       - uses: xdustinface/manki@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -1,0 +1,28 @@
+name: Manki Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+concurrency:
+  group: manki-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: xdustinface/manki@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.manki.yml
+++ b/.manki.yml
@@ -1,0 +1,18 @@
+# Manki — AI Code Review Configuration
+# https://github.com/xdustinface/manki
+
+auto_review: true
+auto_approve: true
+
+exclude_paths:
+  - "*.lock"
+  - "fuzz/**"
+
+instructions: |
+  This is a Rust implementation of the Dash cryptocurrency protocol.
+  Pay special attention to:
+  - Consensus-critical code paths — changes here can cause chain splits
+  - FFI safety for C/Swift bindings in dash-spv-* crates
+  - Proper error handling — prefer Result over unwrap/expect in library code
+  - DIP (Dash Improvement Proposal) compliance for protocol changes
+  - Memory safety in hash/crypto implementations


### PR DESCRIPTION
## Summary
- Add `.manki.yml` with project-specific review instructions for Dash protocol
- Add `.github/workflows/manki.yml` workflow trigger

Manki is a multi-agent AI code review action that provides specialized review feedback. Configuration includes:
- Auto-review on PR open/update
- Auto-approve when findings are resolved
- Instructions tailored for Dash protocol, consensus safety, FFI, and crypto
- Excluded paths for lock files and fuzz corpus