### PR TITLE
feat: add persistent unconfirmed transaction store at wallet level

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -1,0 +1,29 @@
+name: Manki Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+concurrency:
+  group: manki-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: xdustinface/manki@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.manki.yml
+++ b/.manki.yml
@@ -1,0 +1,18 @@
+# Manki — AI Code Review Configuration
+# https://github.com/xdustinface/manki
+
+auto_review: true
+auto_approve: true
+
+exclude_paths:
+  - "*.lock"
+  - "fuzz/**"
+
+instructions: |
+  This is a Rust implementation of the Dash cryptocurrency protocol.
+  Pay special attention to:
+  - Consensus-critical code paths — changes here can cause chain splits
+  - FFI safety for C/Swift bindings in dash-spv-* crates
+  - Proper error handling — prefer Result over unwrap/expect in library code
+  - DIP (Dash Improvement Proposal) compliance for protocol changes
+  - Memory safety in hash/crypto implementations

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -168,6 +168,10 @@ impl WalletTransactionChecker for ManagedWalletInfo {
             }
             self.increment_transactions();
 
+            if !context.confirmed() {
+                self.unconfirmed_transactions.insert(txid, tx.clone());
+            }
+
             let wallet_net = result.total_received as i64 - result.total_sent as i64;
             tracing::info!(
                 txid = %tx.txid(),
@@ -177,6 +181,8 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                 sent = result.total_sent,
                 "New wallet transaction detected"
             );
+        } else if context.confirmed() {
+            self.unconfirmed_transactions.remove(&txid);
         }
 
         if update_balance {
@@ -1069,5 +1075,144 @@ mod tests {
         assert!(record.is_confirmed());
         assert_eq!(record.height(), Some(700));
         assert_eq!(record.block_info().unwrap().block_hash, block_hash);
+    }
+
+    #[tokio::test]
+    async fn test_unconfirmed_store_mempool_adds_transaction() {
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address,
+            ..
+        } = TestWalletContext::new_random();
+
+        let tx = Transaction::dummy(&receive_address, 0..1, &[100_000]);
+        let txid = tx.txid();
+
+        let result = managed_wallet
+            .check_core_transaction(&tx, TransactionContext::Mempool, &mut wallet, true, true)
+            .await;
+        assert!(result.is_relevant);
+        assert!(result.is_new_transaction);
+        assert!(managed_wallet.unconfirmed_transactions().contains_key(&txid));
+        assert_eq!(managed_wallet.get_unconfirmed_transaction(&txid).unwrap().txid(), txid);
+    }
+
+    #[tokio::test]
+    async fn test_unconfirmed_store_instantsend_adds_transaction() {
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address,
+            ..
+        } = TestWalletContext::new_random();
+
+        let tx = Transaction::dummy(&receive_address, 0..1, &[100_000]);
+        let txid = tx.txid();
+
+        let result = managed_wallet
+            .check_core_transaction(&tx, TransactionContext::InstantSend, &mut wallet, true, true)
+            .await;
+        assert!(result.is_relevant);
+        assert!(result.is_new_transaction);
+        assert!(managed_wallet.unconfirmed_transactions().contains_key(&txid));
+    }
+
+    #[tokio::test]
+    async fn test_unconfirmed_store_inblock_skips_store() {
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address,
+            ..
+        } = TestWalletContext::new_random();
+
+        let tx = Transaction::dummy(&receive_address, 0..1, &[100_000]);
+        let txid = tx.txid();
+
+        let block_ctx = TransactionContext::InBlock(BlockInfo::new(
+            100,
+            BlockHash::from_slice(&[0u8; 32]).expect("block hash"),
+            1234567890,
+        ));
+
+        let result =
+            managed_wallet.check_core_transaction(&tx, block_ctx, &mut wallet, true, true).await;
+        assert!(result.is_relevant);
+        assert!(result.is_new_transaction);
+        assert!(!managed_wallet.unconfirmed_transactions().contains_key(&txid));
+    }
+
+    #[tokio::test]
+    async fn test_unconfirmed_store_removed_on_confirmation() {
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address,
+            ..
+        } = TestWalletContext::new_random();
+
+        let tx = Transaction::dummy(&receive_address, 0..1, &[100_000]);
+        let txid = tx.txid();
+
+        // First, record as mempool
+        managed_wallet
+            .check_core_transaction(&tx, TransactionContext::Mempool, &mut wallet, true, true)
+            .await;
+        assert!(managed_wallet.unconfirmed_transactions().contains_key(&txid));
+
+        // Confirm in a block
+        let block_ctx = TransactionContext::InBlock(BlockInfo::new(
+            200,
+            BlockHash::from_slice(&[1u8; 32]).expect("block hash"),
+            1234567891,
+        ));
+        managed_wallet.check_core_transaction(&tx, block_ctx, &mut wallet, true, true).await;
+        assert!(!managed_wallet.unconfirmed_transactions().contains_key(&txid));
+    }
+
+    #[tokio::test]
+    async fn test_unconfirmed_store_serde_roundtrip() {
+        use std::collections::HashMap;
+
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address,
+            ..
+        } = TestWalletContext::new_random();
+
+        let tx = Transaction::dummy(&receive_address, 0..1, &[100_000]);
+        let txid = tx.txid();
+
+        managed_wallet
+            .check_core_transaction(&tx, TransactionContext::Mempool, &mut wallet, true, true)
+            .await;
+        assert!(managed_wallet.unconfirmed_transactions().contains_key(&txid));
+
+        // Roundtrip just the unconfirmed map via JSON (using a Vec encoding)
+        let map = managed_wallet.unconfirmed_transactions();
+        let entries: Vec<_> = map.iter().collect();
+        let serialized = serde_json::to_string(&entries).expect("serialize");
+        let deserialized: Vec<(Txid, Transaction)> =
+            serde_json::from_str(&serialized).expect("deserialize");
+        let restored: HashMap<Txid, Transaction> = deserialized.into_iter().collect();
+
+        assert!(restored.contains_key(&txid));
+        assert_eq!(restored.get(&txid).unwrap().txid(), txid);
+    }
+
+    #[test]
+    fn test_unconfirmed_store_serde_default_backward_compat() {
+        // Deserializing a ManagedWalletInfo that was serialized without the
+        // `unconfirmed_transactions` field should produce an empty map.
+        let info = ManagedWalletInfo::new(Network::Testnet, [0u8; 32]);
+        let mut json = serde_json::to_value(&info).expect("serialize");
+
+        // Remove the field to simulate old data
+        json.as_object_mut().unwrap().remove("unconfirmed_transactions");
+
+        let restored: ManagedWalletInfo = serde_json::from_value(json).expect("deserialize");
+        assert!(restored.unconfirmed_transactions().is_empty());
     }
 }

--- a/key-wallet/src/wallet/managed_wallet_info/mod.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/mod.rs
@@ -20,10 +20,10 @@ use crate::account::ManagedAccountCollection;
 use crate::Network;
 use alloc::string::String;
 use dashcore::prelude::CoreBlockHeight;
-use dashcore::Txid;
+use dashcore::{Transaction, Txid};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Information about a managed wallet
 ///
@@ -50,6 +50,10 @@ pub struct ManagedWalletInfo {
     /// Transactions that have received an InstantSend lock.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) instant_send_locks: HashSet<Txid>,
+    /// Full transactions retained while unconfirmed, for re-broadcast on restart.
+    /// Keyed by txid, removed when the transaction is confirmed.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub(crate) unconfirmed_transactions: HashMap<Txid, Transaction>,
 }
 
 impl ManagedWalletInfo {
@@ -64,6 +68,7 @@ impl ManagedWalletInfo {
             accounts: ManagedAccountCollection::new(),
             balance: WalletCoreBalance::default(),
             instant_send_locks: HashSet::new(),
+            unconfirmed_transactions: HashMap::new(),
         }
     }
 
@@ -78,6 +83,7 @@ impl ManagedWalletInfo {
             accounts: ManagedAccountCollection::new(),
             balance: WalletCoreBalance::default(),
             instant_send_locks: HashSet::new(),
+            unconfirmed_transactions: HashMap::new(),
         }
     }
 
@@ -92,6 +98,7 @@ impl ManagedWalletInfo {
             accounts: ManagedAccountCollection::from_account_collection(&wallet.accounts),
             balance: WalletCoreBalance::default(),
             instant_send_locks: HashSet::new(),
+            unconfirmed_transactions: HashMap::new(),
         }
     }
 
@@ -121,6 +128,16 @@ impl ManagedWalletInfo {
     /// Increment the transaction count
     pub fn increment_transactions(&mut self) {
         self.metadata.total_transactions += 1;
+    }
+
+    /// Get an unconfirmed transaction by txid.
+    pub fn get_unconfirmed_transaction(&self, txid: &Txid) -> Option<&Transaction> {
+        self.unconfirmed_transactions.get(txid)
+    }
+
+    /// Get all unconfirmed transactions for re-broadcast.
+    pub fn unconfirmed_transactions(&self) -> &HashMap<Txid, Transaction> {
+        &self.unconfirmed_transactions
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `unconfirmed_transactions: HashMap<Txid, Transaction>` to `ManagedWalletInfo` for re-broadcast persistence across restarts
- Populated when recording Mempool/InstantSend transactions, cleared on confirmation
- `serde(default)` for backward compatibility with existing serialized wallet state
- 6 new tests: mempool add, IS add, InBlock skip, removal on confirmation, serde roundtrip, backward compat

Closes #70