### PR TITLE
feat: track and persist session peer outcomes

### DIFF
--- a/dash-spv/src/network/addrv2.rs
+++ b/dash-spv/src/network/addrv2.rs
@@ -153,10 +153,10 @@ impl AddrV2Handler {
     }
 
     /// Bump the stored `AddrV2.time` for `addr` to now after directly observing
-    /// the peer (e.g. a successful handshake). A first-hand observation is more
-    /// trustworthy than gossip, so we also refresh the entry if it is missing.
-    /// Existing services on a known entry are preserved. For a new entry the
-    /// provided `services` are used.
+    /// the peer (e.g. a successful handshake) and record the handshake-verified
+    /// `services`. A first-hand observation is authoritative, so both `time` and
+    /// `services` are overwritten on existing entries. If the entry is missing it
+    /// is created with the provided values.
     pub async fn mark_seen(&self, addr: SocketAddr, services: ServiceFlags) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -168,7 +168,10 @@ impl AddrV2Handler {
 
         let mut known_peers = self.known_peers.write().await;
         match known_peers.get_mut(&addr) {
-            Some(existing) => existing.time = now,
+            Some(existing) => {
+                existing.time = now;
+                existing.services = services;
+            }
             None => {
                 known_peers.insert(addr, make_addr_message(addr, services, now));
                 evict_if_needed(&mut known_peers);
@@ -213,12 +216,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mark_seen_bumps_time_and_preserves_services() {
+    async fn test_mark_seen_bumps_time_and_updates_services() {
         let handler = AddrV2Handler::new();
         let addr: SocketAddr = "10.0.0.5:9999".parse().unwrap();
 
         // Seed via AddrV2 gossip with a stale-but-valid timestamp and richer services.
-        let services = ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS;
+        let gossip_services = ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS;
         let ipv4_addr = match addr.ip() {
             IpAddr::V4(v4) => v4,
             _ => panic!("test expects IPv4"),
@@ -229,20 +232,21 @@ mod tests {
         handler
             .handle_addrv2(vec![AddrV2Message {
                 time: stale_time,
-                services,
+                services: gossip_services,
                 addr: AddrV2::Ipv4(ipv4_addr),
                 port: addr.port(),
             }])
             .await;
 
-        // Observe the peer directly with a different (narrower) service set.
-        handler.mark_seen(addr, ServiceFlags::NETWORK).await;
+        // Observe the peer directly — handshake-verified services are authoritative.
+        let handshake_services = ServiceFlags::NETWORK;
+        handler.mark_seen(addr, handshake_services).await;
 
         let known = handler.get_known_addresses().await;
         let entry = known.iter().find(|m| m.socket_addr().ok() == Some(addr)).expect("entry");
         assert!(entry.time >= now);
         assert!(entry.time > stale_time);
-        assert_eq!(entry.services, services);
+        assert_eq!(entry.services, handshake_services);
     }
 
     #[tokio::test]

--- a/dash-spv/src/network/addrv2.rs
+++ b/dash-spv/src/network/addrv2.rs
@@ -264,10 +264,20 @@ mod tests {
     async fn test_mark_seen_evicts_when_at_capacity() {
         let handler = AddrV2Handler::new();
 
-        for i in 0..MAX_ADDR_TO_STORE {
-            let addr: SocketAddr = format!("10.{}.{}.1:9999", i / 256, i % 256).parse().unwrap();
-            handler.add_known_address(addr, ServiceFlags::NETWORK).await;
-        }
+        // Use staggered timestamps strictly older than the mark_seen call below so
+        // the new entry is definitively the freshest and survives eviction.
+        let base_time =
+            (SystemTime::now().duration_since(UNIX_EPOCH).expect("system time").as_secs() as u32)
+                .saturating_sub(ONE_WEEK / 2);
+
+        let msgs: Vec<AddrV2Message> = (0..MAX_ADDR_TO_STORE)
+            .map(|i| {
+                let addr: SocketAddr =
+                    format!("10.{}.{}.1:9999", i / 256, i % 256).parse().unwrap();
+                make_addr_message(addr, ServiceFlags::NETWORK, base_time - i as u32)
+            })
+            .collect();
+        handler.handle_addrv2(msgs).await;
 
         assert_eq!(handler.get_known_addresses().await.len(), MAX_ADDR_TO_STORE);
 
@@ -275,7 +285,7 @@ mod tests {
         handler.mark_seen(new_addr, ServiceFlags::NETWORK).await;
 
         let known = handler.get_known_addresses().await;
-        assert!(known.len() <= MAX_ADDR_TO_STORE);
+        assert_eq!(known.len(), MAX_ADDR_TO_STORE);
         assert!(known.iter().any(|m| m.socket_addr().ok() == Some(new_addr)));
     }
 

--- a/dash-spv/src/network/addrv2.rs
+++ b/dash-spv/src/network/addrv2.rs
@@ -261,6 +261,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mark_seen_evicts_when_at_capacity() {
+        let handler = AddrV2Handler::new();
+
+        for i in 0..MAX_ADDR_TO_STORE {
+            let addr: SocketAddr = format!("10.{}.{}.1:9999", i / 256, i % 256).parse().unwrap();
+            handler.add_known_address(addr, ServiceFlags::NETWORK).await;
+        }
+
+        assert_eq!(handler.get_known_addresses().await.len(), MAX_ADDR_TO_STORE);
+
+        let new_addr: SocketAddr = "192.168.99.99:9999".parse().unwrap();
+        handler.mark_seen(new_addr, ServiceFlags::NETWORK).await;
+
+        let known = handler.get_known_addresses().await;
+        assert!(known.len() <= MAX_ADDR_TO_STORE);
+        assert!(known.iter().any(|m| m.socket_addr().ok() == Some(new_addr)));
+    }
+
+    #[tokio::test]
     async fn test_addrv2_timestamp_validation() {
         let handler = AddrV2Handler::new();
         let now = SystemTime::now()

--- a/dash-spv/src/network/addrv2.rs
+++ b/dash-spv/src/network/addrv2.rs
@@ -2,7 +2,7 @@
 
 use rand::prelude::*;
 use std::collections::{HashMap, HashSet};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
@@ -24,6 +24,14 @@ fn evict_if_needed(peers: &mut HashMap<SocketAddr, AddrV2Message>) {
         entries.truncate(MAX_ADDR_TO_STORE);
         peers.extend(entries);
     }
+}
+
+fn make_addr_message(addr: SocketAddr, services: ServiceFlags, time: u32) -> AddrV2Message {
+    let addr_v2 = match addr.ip() {
+        IpAddr::V4(ipv4) => AddrV2::Ipv4(ipv4),
+        IpAddr::V6(ipv6) => AddrV2::Ipv6(ipv6),
+    };
+    AddrV2Message { time, services, addr: addr_v2, port: addr.port() }
 }
 
 /// Handler for AddrV2 peer exchange protocol
@@ -134,20 +142,8 @@ impl AddrV2Handler {
             })
             .as_secs() as u32;
 
-        let addr_v2 = match addr.ip() {
-            std::net::IpAddr::V4(ipv4) => AddrV2::Ipv4(ipv4),
-            std::net::IpAddr::V6(ipv6) => AddrV2::Ipv6(ipv6),
-        };
-
-        let addr_msg = AddrV2Message {
-            time: now,
-            services,
-            addr: addr_v2,
-            port: addr.port(),
-        };
-
         let mut known_peers = self.known_peers.write().await;
-        known_peers.insert(addr, addr_msg);
+        known_peers.insert(addr, make_addr_message(addr, services, now));
         evict_if_needed(&mut known_peers);
     }
 
@@ -169,19 +165,7 @@ impl AddrV2Handler {
         match known_peers.get_mut(&addr) {
             Some(existing) => existing.time = now,
             None => {
-                let addr_v2 = match addr.ip() {
-                    std::net::IpAddr::V4(ipv4) => AddrV2::Ipv4(ipv4),
-                    std::net::IpAddr::V6(ipv6) => AddrV2::Ipv6(ipv6),
-                };
-                known_peers.insert(
-                    addr,
-                    AddrV2Message {
-                        time: now,
-                        services,
-                        addr: addr_v2,
-                        port: addr.port(),
-                    },
-                );
+                known_peers.insert(addr, make_addr_message(addr, services, now));
                 evict_if_needed(&mut known_peers);
             }
         }
@@ -231,7 +215,7 @@ mod tests {
         // Seed via AddrV2 gossip with a stale-but-valid timestamp and richer services.
         let services = ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS;
         let ipv4_addr = match addr.ip() {
-            std::net::IpAddr::V4(v4) => v4,
+            IpAddr::V4(v4) => v4,
             _ => panic!("test expects IPv4"),
         };
         let now =
@@ -283,7 +267,7 @@ mod tests {
         let addr: SocketAddr =
             "127.0.0.1:9999".parse().expect("Failed to parse test socket address");
         let ipv4_addr = match addr.ip() {
-            std::net::IpAddr::V4(v4) => v4,
+            IpAddr::V4(v4) => v4,
             _ => panic!("Test expects IPv4 address but got IPv6"),
         };
 

--- a/dash-spv/src/network/addrv2.rs
+++ b/dash-spv/src/network/addrv2.rs
@@ -31,7 +31,12 @@ fn make_addr_message(addr: SocketAddr, services: ServiceFlags, time: u32) -> Add
         IpAddr::V4(ipv4) => AddrV2::Ipv4(ipv4),
         IpAddr::V6(ipv6) => AddrV2::Ipv6(ipv6),
     };
-    AddrV2Message { time, services, addr: addr_v2, port: addr.port() }
+    AddrV2Message {
+        time,
+        services,
+        addr: addr_v2,
+        port: addr.port(),
+    }
 }
 
 /// Handler for AddrV2 peer exchange protocol

--- a/dash-spv/src/network/addrv2.rs
+++ b/dash-spv/src/network/addrv2.rs
@@ -151,6 +151,42 @@ impl AddrV2Handler {
         evict_if_needed(&mut known_peers);
     }
 
+    /// Bump the stored `AddrV2.time` for `addr` to now after directly observing
+    /// the peer (e.g. a successful handshake). A first-hand observation is more
+    /// trustworthy than gossip, so we also refresh the entry if it is missing.
+    /// Existing services on a known entry are preserved. For a new entry the
+    /// provided `services` are used.
+    pub async fn mark_seen(&self, addr: SocketAddr, services: ServiceFlags) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|e| {
+                tracing::error!("System time error in mark_seen: {}", e);
+                Duration::from_secs(0)
+            })
+            .as_secs() as u32;
+
+        let mut known_peers = self.known_peers.write().await;
+        match known_peers.get_mut(&addr) {
+            Some(existing) => existing.time = now,
+            None => {
+                let addr_v2 = match addr.ip() {
+                    std::net::IpAddr::V4(ipv4) => AddrV2::Ipv4(ipv4),
+                    std::net::IpAddr::V6(ipv6) => AddrV2::Ipv6(ipv6),
+                };
+                known_peers.insert(
+                    addr,
+                    AddrV2Message {
+                        time: now,
+                        services,
+                        addr: addr_v2,
+                        port: addr.port(),
+                    },
+                );
+                evict_if_needed(&mut known_peers);
+            }
+        }
+    }
+
     /// Build a GetAddr response message
     pub async fn build_addr_response(&self) -> NetworkMessage {
         let addresses = self.get_addresses_for_peer(23).await; // Bitcoin typically sends ~23 addresses
@@ -185,6 +221,54 @@ mod tests {
         let known = handler.get_known_addresses().await;
         assert_eq!(known.len(), 1);
         assert_eq!(known[0].socket_addr().unwrap(), addr);
+    }
+
+    #[tokio::test]
+    async fn test_mark_seen_bumps_time_and_preserves_services() {
+        let handler = AddrV2Handler::new();
+        let addr: SocketAddr = "10.0.0.5:9999".parse().unwrap();
+
+        // Seed via AddrV2 gossip with a stale-but-valid timestamp and richer services.
+        let services = ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS;
+        let ipv4_addr = match addr.ip() {
+            std::net::IpAddr::V4(v4) => v4,
+            _ => panic!("test expects IPv4"),
+        };
+        let now =
+            SystemTime::now().duration_since(UNIX_EPOCH).expect("system time").as_secs() as u32;
+        let stale_time = now.saturating_sub(3600);
+        handler
+            .handle_addrv2(vec![AddrV2Message {
+                time: stale_time,
+                services,
+                addr: AddrV2::Ipv4(ipv4_addr),
+                port: addr.port(),
+            }])
+            .await;
+
+        // Observe the peer directly with a different (narrower) service set.
+        handler.mark_seen(addr, ServiceFlags::NETWORK).await;
+
+        let known = handler.get_known_addresses().await;
+        let entry = known.iter().find(|m| m.socket_addr().ok() == Some(addr)).expect("entry");
+        assert!(entry.time >= now);
+        assert!(entry.time > stale_time);
+        assert_eq!(entry.services, services);
+    }
+
+    #[tokio::test]
+    async fn test_mark_seen_inserts_new_entry() {
+        let handler = AddrV2Handler::new();
+        let addr: SocketAddr = "10.0.0.6:9999".parse().unwrap();
+
+        assert!(handler.get_known_addresses().await.is_empty());
+
+        handler.mark_seen(addr, ServiceFlags::NETWORK).await;
+
+        let known = handler.get_known_addresses().await;
+        assert_eq!(known.len(), 1);
+        assert_eq!(known[0].socket_addr().unwrap(), addr);
+        assert_eq!(known[0].services, ServiceFlags::NETWORK);
     }
 
     #[tokio::test]

--- a/dash-spv/src/network/handshake.rs
+++ b/dash-spv/src/network/handshake.rs
@@ -301,6 +301,11 @@ impl HandshakeManager {
         self.peer_version
     }
 
+    /// Get the service flags advertised by the peer in its version message.
+    pub fn peer_services(&self) -> Option<ServiceFlags> {
+        self.peer_services
+    }
+
     /// Check if peer supports headers2 compression.
     pub fn peer_supports_headers2(&self) -> bool {
         self.peer_services.map(|services| services.has(NODE_HEADERS_COMPRESSED)).unwrap_or(false)

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -311,6 +311,7 @@ impl PeerNetworkManager {
                             tracing::warn!("Handshake failed with {}: {}", addr, e);
                             // Only clears connecting set. Peer was never added, so no count/event needed.
                             pool.remove_peer(&addr).await;
+                            reputation_manager.record_connection_failure(addr).await;
                             // Update reputation for handshake failure
                             reputation_manager
                                 .update_reputation(
@@ -328,6 +329,7 @@ impl PeerNetworkManager {
                     tracing::debug!("Failed to connect to {}: {}", addr, e);
                     // Only clears connecting set. Peer was never added, so no count/event needed.
                     pool.remove_peer(&addr).await;
+                    reputation_manager.record_connection_failure(addr).await;
                     // Minor reputation penalty for connection failure
                     reputation_manager
                         .update_reputation(

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -266,9 +266,8 @@ impl PeerNetworkManager {
                             }
 
                             // Capture peer-advertised services before the peer is moved into the pool.
-                            let peer_services = handshake_manager
-                                .peer_services()
-                                .unwrap_or(ServiceFlags::NETWORK);
+                            let peer_services =
+                                handshake_manager.peer_services().unwrap_or(ServiceFlags::NETWORK);
 
                             // Record successful connection
                             reputation_manager.record_successful_connection(addr).await;

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -317,10 +317,8 @@ impl PeerNetworkManager {
                             tracing::warn!("Handshake failed with {}: {}", addr, e);
                             // Only clears connecting set. Peer was never added, so no count/event needed.
                             pool.remove_peer(&addr).await;
-                            reputation_manager.record_connection_failure(addr).await;
-                            // Update reputation for handshake failure
                             reputation_manager
-                                .update_reputation(
+                                .record_failure_with_penalty(
                                     addr,
                                     misbehavior_scores::INVALID_MESSAGE,
                                     "Handshake failed",
@@ -335,10 +333,8 @@ impl PeerNetworkManager {
                     tracing::debug!("Failed to connect to {}: {}", addr, e);
                     // Only clears connecting set. Peer was never added, so no count/event needed.
                     pool.remove_peer(&addr).await;
-                    reputation_manager.record_connection_failure(addr).await;
-                    // Minor reputation penalty for connection failure
                     reputation_manager
-                        .update_reputation(
+                        .record_failure_with_penalty(
                             addr,
                             misbehavior_scores::TIMEOUT / 2,
                             "Connection failed",

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -290,8 +290,8 @@ impl PeerNetworkManager {
                                 best_height,
                             });
 
-                            // Add to known addresses
-                            addrv2_handler.add_known_address(addr, ServiceFlags::NETWORK).await;
+                            // Bump the AddrV2 time on direct observation
+                            addrv2_handler.mark_seen(addr, ServiceFlags::NETWORK).await;
 
                             // // Start message reader for this peer
                             Self::start_peer_reader(

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -265,6 +265,11 @@ impl PeerNetworkManager {
                                 tracing::warn!("Failed to send GetAddr to {}: {}", addr, e);
                             }
 
+                            // Capture peer-advertised services before the peer is moved into the pool.
+                            let peer_services = handshake_manager
+                                .peer_services()
+                                .unwrap_or(ServiceFlags::NETWORK);
+
                             // Record successful connection
                             reputation_manager.record_successful_connection(addr).await;
 
@@ -290,8 +295,9 @@ impl PeerNetworkManager {
                                 best_height,
                             });
 
-                            // Bump the AddrV2 time on direct observation
-                            addrv2_handler.mark_seen(addr, ServiceFlags::NETWORK).await;
+                            // Bump the AddrV2 time on direct observation, using the peer's
+                            // actual advertised services from the version message.
+                            addrv2_handler.mark_seen(addr, peer_services).await;
 
                             // // Start message reader for this peer
                             Self::start_peer_reader(

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -417,6 +417,9 @@ impl PeerReputationManager {
     pub async fn record_connection_failure(&self, peer: SocketAddr) {
         let mut reputations = self.reputations.write().await;
         let reputation = reputations.entry(peer).or_default();
+        if reputation.last_tried.is_none() {
+            reputation.last_tried = Some(SystemTime::now());
+        }
         reputation.consecutive_failures = reputation.consecutive_failures.saturating_add(1);
     }
 

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -445,8 +445,8 @@ impl PeerReputationManager {
             reputation.apply_decay();
 
             let old_score = reputation.score;
-            reputation.score =
-                (reputation.score + score_change).clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
+            reputation.score = (reputation.score + score_change)
+                .clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
 
             if score_change > 0 {
                 reputation.negative_actions += 1;

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -435,14 +435,21 @@ impl PeerReputationManager {
         reputation.consecutive_failures = 0;
     }
 
+    /// Apply the common fields updated on every failure: refresh `last_tried` and
+    /// increment `consecutive_failures`, clamped to `MAX_CONSECUTIVE_FAILURES`.
+    fn record_failure_fields(reputation: &mut PeerReputation) {
+        reputation.last_tried = Some(SystemTime::now());
+        reputation.consecutive_failures =
+            reputation.consecutive_failures.saturating_add(1).min(MAX_CONSECUTIVE_FAILURES);
+    }
+
     /// Record a connection or handshake failure. Increments the streak of
     /// consecutive failures without touching `last_success`, so callers can
     /// drive cooldown/backoff from the streak length.
     pub async fn record_connection_failure(&self, peer: SocketAddr) {
         let mut reputations = self.reputations.write().await;
         let reputation = reputations.entry(peer).or_default();
-        reputation.last_tried = Some(SystemTime::now());
-        reputation.consecutive_failures = reputation.consecutive_failures.saturating_add(1);
+        Self::record_failure_fields(reputation);
     }
 
     /// Record a connection failure and apply a reputation penalty in a single write-lock
@@ -459,8 +466,7 @@ impl PeerReputationManager {
             let mut reputations = self.reputations.write().await;
             let reputation = reputations.entry(peer).or_default();
 
-            reputation.last_tried = Some(SystemTime::now());
-            reputation.consecutive_failures = reputation.consecutive_failures.saturating_add(1);
+            Self::record_failure_fields(reputation);
 
             reputation.apply_decay();
             Self::apply_score_change(reputation, score_change, peer, reason)

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -147,6 +147,18 @@ where
     Ok(v)
 }
 
+/// Clock-drift tolerance for future timestamps: up to 10 seconds ahead is accepted.
+const FUTURE_TIMESTAMP_TOLERANCE: Duration = Duration::from_secs(10);
+
+fn clamp_future_system_time<'de, D>(d: D) -> Result<Option<SystemTime>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<SystemTime>::deserialize(d)?;
+    let deadline = SystemTime::now() + FUTURE_TIMESTAMP_TOLERANCE;
+    Ok(opt.filter(|t| *t <= deadline))
+}
+
 /// Peer reputation entry
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeerReputation {
@@ -186,11 +198,13 @@ pub struct PeerReputation {
     pub last_connection: Option<Instant>,
 
     /// Wall-clock time of the last successful handshake with this peer.
+    #[serde(default, deserialize_with = "clamp_future_system_time")]
     pub last_success: Option<SystemTime>,
 
     /// Wall-clock time of the last attempted connection to this peer (persisted across
     /// restarts). The canonical source for cooldown and backoff decisions that must
     /// survive process restarts. Distinct from `last_connection`, which is session-only.
+    #[serde(default, deserialize_with = "clamp_future_system_time")]
     pub last_tried: Option<SystemTime>,
 
     /// Failures since the last success. Resets to 0 on a successful handshake.
@@ -445,12 +459,18 @@ impl PeerReputationManager {
 
     /// Record a connection failure and apply a reputation penalty in a single write-lock
     /// acquisition. Returns `true` if the peer was banned by this call.
+    ///
+    /// `score_change` must be non-negative. Failure paths apply penalties (positive delta), not rewards.
     pub async fn record_failure_with_penalty(
         &self,
         peer: SocketAddr,
         score_change: i32,
         reason: &str,
     ) -> bool {
+        debug_assert!(
+            score_change >= 0,
+            "record_failure_with_penalty expects non-negative score change"
+        );
         let should_ban = {
             let mut reputations = self.reputations.write().await;
             let reputation = reputations.entry(peer).or_default();

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::RwLock;
 
 /// Misbehavior score thresholds for different violations
@@ -164,6 +164,18 @@ pub struct PeerReputation {
     /// Last connection time
     #[serde(skip)]
     pub last_connection: Option<Instant>,
+
+    /// Wall-clock time of the last successful handshake with this peer.
+    #[serde(default)]
+    pub last_success: Option<SystemTime>,
+
+    /// Wall-clock time of the last attempted connection to this peer.
+    #[serde(default)]
+    pub last_tried: Option<SystemTime>,
+
+    /// Failures since the last success. Resets to 0 on a successful handshake.
+    #[serde(default)]
+    pub consecutive_failures: u32,
 }
 
 impl Default for PeerReputation {
@@ -178,6 +190,9 @@ impl Default for PeerReputation {
             connection_attempts: 0,
             successful_connections: 0,
             last_connection: None,
+            last_success: None,
+            last_tried: None,
+            consecutive_failures: 0,
         }
     }
 }
@@ -383,6 +398,7 @@ impl PeerReputationManager {
         let reputation = reputations.entry(peer).or_default();
         reputation.connection_attempts += 1;
         reputation.last_connection = Some(Instant::now());
+        reputation.last_tried = Some(SystemTime::now());
     }
 
     /// Record a successful connection
@@ -390,6 +406,17 @@ impl PeerReputationManager {
         let mut reputations = self.reputations.write().await;
         let reputation = reputations.entry(peer).or_default();
         reputation.successful_connections += 1;
+        reputation.last_success = Some(SystemTime::now());
+        reputation.consecutive_failures = 0;
+    }
+
+    /// Record a connection or handshake failure. Increments the streak of
+    /// consecutive failures without touching `last_success`, so callers can
+    /// drive cooldown/backoff from the streak length.
+    pub async fn record_connection_failure(&self, peer: SocketAddr) {
+        let mut reputations = self.reputations.write().await;
+        let reputation = reputations.entry(peer).or_default();
+        reputation.consecutive_failures = reputation.consecutive_failures.saturating_add(1);
     }
 
     /// Get all peer reputations

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -268,6 +268,46 @@ impl PeerReputation {
             self.consecutive_failures.saturating_add(1).min(MAX_CONSECUTIVE_FAILURES);
     }
 
+    /// Apply a score change. Assumes decay has already been applied.
+    /// Returns `true` if the peer was banned by this call.
+    fn apply_score_change(&mut self, score_change: i32, peer: SocketAddr, reason: &str) -> bool {
+        let old_score = self.score;
+        self.score =
+            (self.score + score_change).clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
+
+        if score_change > 0 {
+            self.negative_actions += 1;
+        } else if score_change < 0 {
+            self.positive_actions += 1;
+        }
+
+        let should_ban = self.score >= MAX_MISBEHAVIOR_SCORE && !self.is_banned();
+        if should_ban {
+            self.banned_until = Some(Instant::now() + BAN_DURATION);
+            self.ban_count += 1;
+            tracing::warn!(
+                "Peer {} banned for misbehavior (score: {}, ban #{}, reason: {})",
+                peer,
+                self.score,
+                self.ban_count,
+                reason
+            );
+        }
+
+        if score_change.abs() >= 10 || should_ban {
+            tracing::info!(
+                "Peer {} reputation changed: {} -> {} (change: {}, reason: {})",
+                peer,
+                old_score,
+                self.score,
+                score_change,
+                reason
+            );
+        }
+
+        should_ban
+    }
+
     /// Apply reputation decay
     pub fn apply_decay(&mut self) {
         let now = Instant::now();
@@ -328,50 +368,6 @@ impl PeerReputationManager {
         }
     }
 
-    /// Apply a score change to a reputation entry. Assumes decay has already been applied.
-    /// Returns `true` if the peer was banned by this call.
-    fn apply_score_change(
-        rep: &mut PeerReputation,
-        score_change: i32,
-        peer: SocketAddr,
-        reason: &str,
-    ) -> bool {
-        let old_score = rep.score;
-        rep.score = (rep.score + score_change).clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
-
-        if score_change > 0 {
-            rep.negative_actions += 1;
-        } else if score_change < 0 {
-            rep.positive_actions += 1;
-        }
-
-        let should_ban = rep.score >= MAX_MISBEHAVIOR_SCORE && !rep.is_banned();
-        if should_ban {
-            rep.banned_until = Some(Instant::now() + BAN_DURATION);
-            rep.ban_count += 1;
-            tracing::warn!(
-                "Peer {} banned for misbehavior (score: {}, ban #{}, reason: {})",
-                peer,
-                rep.score,
-                rep.ban_count,
-                reason
-            );
-        }
-
-        if score_change.abs() >= 10 || should_ban {
-            tracing::info!(
-                "Peer {} reputation changed: {} -> {} (change: {}, reason: {})",
-                peer,
-                old_score,
-                rep.score,
-                score_change,
-                reason
-            );
-        }
-
-        should_ban
-    }
-
     /// Update peer reputation
     pub async fn update_reputation(
         &self,
@@ -383,7 +379,7 @@ impl PeerReputationManager {
         let reputation = reputations.entry(peer).or_default();
 
         reputation.apply_decay();
-        let should_ban = Self::apply_score_change(reputation, score_change, peer, reason);
+        let should_ban = reputation.apply_score_change(score_change, peer, reason);
 
         let event = ReputationEvent {
             peer,
@@ -493,7 +489,7 @@ impl PeerReputationManager {
             reputation.record_failure_fields();
 
             reputation.apply_decay();
-            Self::apply_score_change(reputation, score_change, peer, reason)
+            reputation.apply_score_change(score_change, peer, reason)
         };
 
         let event = ReputationEvent {

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -150,13 +150,18 @@ where
 /// Clock-drift tolerance for future timestamps: up to 10 seconds ahead is accepted.
 const FUTURE_TIMESTAMP_TOLERANCE: Duration = Duration::from_secs(10);
 
+/// Timestamps older than this are considered stale and discarded on load.
+const TIMESTAMP_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
 fn clamp_future_system_time<'de, D>(d: D) -> Result<Option<SystemTime>, D::Error>
 where
     D: Deserializer<'de>,
 {
     let opt = Option::<SystemTime>::deserialize(d)?;
-    let deadline = SystemTime::now() + FUTURE_TIMESTAMP_TOLERANCE;
-    Ok(opt.filter(|t| *t <= deadline))
+    let now = SystemTime::now();
+    let deadline = now + FUTURE_TIMESTAMP_TOLERANCE;
+    let floor = now - TIMESTAMP_MAX_AGE;
+    Ok(opt.filter(|t| *t >= floor && *t <= deadline))
 }
 
 /// Peer reputation entry
@@ -232,6 +237,16 @@ impl Default for PeerReputation {
 }
 
 impl PeerReputation {
+    /// Enforce internal consistency after loading from persistent storage. If
+    /// `last_tried` was discarded (e.g., because it was a future or stale
+    /// timestamp), `consecutive_failures` has no temporal anchor and must be
+    /// reset to 0 to avoid incorrect backoff behaviour.
+    fn normalize_after_load(&mut self) {
+        if self.last_tried.is_none() && self.consecutive_failures > 0 {
+            self.consecutive_failures = 0;
+        }
+    }
+
     /// Check if the peer is currently banned
     pub fn is_banned(&self) -> bool {
         self.banned_until.is_some_and(|until| Instant::now() < until)
@@ -567,6 +582,8 @@ impl PeerReputationManager {
             // Validate successful connections don't exceed attempts
             reputation.successful_connections =
                 reputation.successful_connections.min(reputation.connection_attempts);
+
+            reputation.normalize_after_load();
 
             // Skip entry if data appears corrupted
             if reputation.positive_actions > MAX_ACTION_COUNT

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -150,9 +150,6 @@ where
 /// Clock-drift tolerance for future timestamps: up to 10 seconds ahead is accepted.
 const FUTURE_TIMESTAMP_TOLERANCE: Duration = Duration::from_secs(10);
 
-/// Timestamps older than this are considered stale and discarded on load.
-const TIMESTAMP_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
-
 fn clamp_future_system_time<'de, D>(d: D) -> Result<Option<SystemTime>, D::Error>
 where
     D: Deserializer<'de>,
@@ -160,8 +157,7 @@ where
     let opt = Option::<SystemTime>::deserialize(d)?;
     let now = SystemTime::now();
     let deadline = now.checked_add(FUTURE_TIMESTAMP_TOLERANCE).unwrap_or(now);
-    let floor = now.checked_sub(TIMESTAMP_MAX_AGE).unwrap_or(SystemTime::UNIX_EPOCH);
-    Ok(opt.filter(|t| *t >= floor && *t <= deadline))
+    Ok(opt.filter(|t| *t <= deadline))
 }
 
 /// Peer reputation entry
@@ -238,9 +234,9 @@ impl Default for PeerReputation {
 
 impl PeerReputation {
     /// Enforce internal consistency after loading from persistent storage. If
-    /// `last_tried` was discarded (e.g., because it was a future or stale
-    /// timestamp), `consecutive_failures` has no temporal anchor and must be
-    /// reset to 0 to avoid incorrect backoff behaviour.
+    /// `last_tried` was discarded (e.g., because it was a future timestamp),
+    /// `consecutive_failures` has no temporal anchor and must be reset to 0 to
+    /// avoid incorrect backoff behaviour.
     fn normalize_after_load(&mut self) {
         if self.last_tried.is_none() && self.consecutive_failures > 0 {
             self.consecutive_failures = 0;

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -260,6 +260,14 @@ impl PeerReputation {
         })
     }
 
+    /// Apply the common fields updated on every failure: refresh `last_tried` and
+    /// increment `consecutive_failures`, clamped to `MAX_CONSECUTIVE_FAILURES`.
+    fn record_failure_fields(&mut self) {
+        self.last_tried = Some(SystemTime::now());
+        self.consecutive_failures =
+            self.consecutive_failures.saturating_add(1).min(MAX_CONSECUTIVE_FAILURES);
+    }
+
     /// Apply reputation decay
     pub fn apply_decay(&mut self) {
         let now = Instant::now();
@@ -460,14 +468,6 @@ impl PeerReputationManager {
         reputation.consecutive_failures = 0;
     }
 
-    /// Apply the common fields updated on every failure: refresh `last_tried` and
-    /// increment `consecutive_failures`, clamped to `MAX_CONSECUTIVE_FAILURES`.
-    fn record_failure_fields(reputation: &mut PeerReputation) {
-        reputation.last_tried = Some(SystemTime::now());
-        reputation.consecutive_failures =
-            reputation.consecutive_failures.saturating_add(1).min(MAX_CONSECUTIVE_FAILURES);
-    }
-
     /// Record a connection failure and apply a reputation penalty in a single write-lock
     /// acquisition. Returns `true` if the peer was banned by this call.
     ///
@@ -490,7 +490,7 @@ impl PeerReputationManager {
             let mut reputations = self.reputations.write().await;
             let reputation = reputations.entry(peer).or_default();
 
-            Self::record_failure_fields(reputation);
+            reputation.record_failure_fields();
 
             reputation.apply_decay();
             Self::apply_score_change(reputation, score_change, peer, reason)

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -443,19 +443,8 @@ impl PeerReputationManager {
             reputation.consecutive_failures.saturating_add(1).min(MAX_CONSECUTIVE_FAILURES);
     }
 
-    /// Record a connection or handshake failure. Increments the streak of
-    /// consecutive failures without touching `last_success`, so callers can
-    /// drive cooldown/backoff from the streak length.
-    pub async fn record_connection_failure(&self, peer: SocketAddr) {
-        let mut reputations = self.reputations.write().await;
-        let reputation = reputations.entry(peer).or_default();
-        Self::record_failure_fields(reputation);
-    }
-
     /// Record a connection failure and apply a reputation penalty in a single write-lock
-    /// acquisition. Equivalent to calling `record_connection_failure` followed by
-    /// `update_reputation`, but without the race window between two separate locks.
-    /// Returns `true` if the peer was banned by this call.
+    /// acquisition. Returns `true` if the peer was banned by this call.
     pub async fn record_failure_with_penalty(
         &self,
         peer: SocketAddr,

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -166,15 +166,12 @@ pub struct PeerReputation {
     pub last_connection: Option<Instant>,
 
     /// Wall-clock time of the last successful handshake with this peer.
-    #[serde(default)]
     pub last_success: Option<SystemTime>,
 
     /// Wall-clock time of the last attempted connection to this peer.
-    #[serde(default)]
     pub last_tried: Option<SystemTime>,
 
     /// Failures since the last success. Resets to 0 on a successful handshake.
-    #[serde(default)]
     pub consecutive_failures: u32,
 }
 

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -460,7 +460,8 @@ impl PeerReputationManager {
     /// Record a connection failure and apply a reputation penalty in a single write-lock
     /// acquisition. Returns `true` if the peer was banned by this call.
     ///
-    /// `score_change` must be non-negative. Failure paths apply penalties (positive delta), not rewards.
+    /// Any negative `score_change` is clamped to 0 (panics in debug). Failure paths must not
+    /// reward peers.
     pub async fn record_failure_with_penalty(
         &self,
         peer: SocketAddr,
@@ -471,6 +472,7 @@ impl PeerReputationManager {
             score_change >= 0,
             "record_failure_with_penalty expects non-negative score change"
         );
+        let score_change = score_change.max(0);
         let should_ban = {
             let mut reputations = self.reputations.write().await;
             let reputation = reputations.entry(peer).or_default();

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -161,14 +161,18 @@ pub struct PeerReputation {
     /// Successful connection count
     pub successful_connections: u64,
 
-    /// Last connection time
+    /// Monotonic instant of the last connection attempt within the current process session.
+    /// Resets to `None` on restart. Used for runtime decisions such as immediate
+    /// reconnect throttling. For persistent cooldown/backoff logic use `last_tried`.
     #[serde(skip)]
     pub last_connection: Option<Instant>,
 
     /// Wall-clock time of the last successful handshake with this peer.
     pub last_success: Option<SystemTime>,
 
-    /// Wall-clock time of the last attempted connection to this peer.
+    /// Wall-clock time of the last attempted connection to this peer (persisted across
+    /// restarts). The canonical source for cooldown and backoff decisions that must
+    /// survive process restarts. Distinct from `last_connection`, which is session-only.
     pub last_tried: Option<SystemTime>,
 
     /// Failures since the last success. Resets to 0 on a successful handshake.

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -160,7 +160,7 @@ where
     let opt = Option::<SystemTime>::deserialize(d)?;
     let now = SystemTime::now();
     let deadline = now + FUTURE_TIMESTAMP_TOLERANCE;
-    let floor = now - TIMESTAMP_MAX_AGE;
+    let floor = now.checked_sub(TIMESTAMP_MAX_AGE).unwrap_or(SystemTime::UNIX_EPOCH);
     Ok(opt.filter(|t| *t >= floor && *t <= deadline))
 }
 

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -295,6 +295,50 @@ impl PeerReputationManager {
         }
     }
 
+    /// Apply a score change to a reputation entry. Assumes decay has already been applied.
+    /// Returns `true` if the peer was banned by this call.
+    fn apply_score_change(
+        rep: &mut PeerReputation,
+        score_change: i32,
+        peer: SocketAddr,
+        reason: &str,
+    ) -> bool {
+        let old_score = rep.score;
+        rep.score = (rep.score + score_change).clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
+
+        if score_change > 0 {
+            rep.negative_actions += 1;
+        } else if score_change < 0 {
+            rep.positive_actions += 1;
+        }
+
+        let should_ban = rep.score >= MAX_MISBEHAVIOR_SCORE && !rep.is_banned();
+        if should_ban {
+            rep.banned_until = Some(Instant::now() + BAN_DURATION);
+            rep.ban_count += 1;
+            tracing::warn!(
+                "Peer {} banned for misbehavior (score: {}, ban #{}, reason: {})",
+                peer,
+                rep.score,
+                rep.ban_count,
+                reason
+            );
+        }
+
+        if score_change.abs() >= 10 || should_ban {
+            tracing::info!(
+                "Peer {} reputation changed: {} -> {} (change: {}, reason: {})",
+                peer,
+                old_score,
+                rep.score,
+                score_change,
+                reason
+            );
+        }
+
+        should_ban
+    }
+
     /// Update peer reputation
     pub async fn update_reputation(
         &self,
@@ -305,48 +349,9 @@ impl PeerReputationManager {
         let mut reputations = self.reputations.write().await;
         let reputation = reputations.entry(peer).or_default();
 
-        // Apply decay first
         reputation.apply_decay();
+        let should_ban = Self::apply_score_change(reputation, score_change, peer, reason);
 
-        // Update score
-        let old_score = reputation.score;
-        reputation.score =
-            (reputation.score + score_change).clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
-
-        // Track positive/negative actions
-        if score_change > 0 {
-            reputation.negative_actions += 1;
-        } else if score_change < 0 {
-            reputation.positive_actions += 1;
-        }
-
-        // Check if peer should be banned
-        let should_ban = reputation.score >= MAX_MISBEHAVIOR_SCORE && !reputation.is_banned();
-        if should_ban {
-            reputation.banned_until = Some(Instant::now() + BAN_DURATION);
-            reputation.ban_count += 1;
-            tracing::warn!(
-                "Peer {} banned for misbehavior (score: {}, ban #{}, reason: {})",
-                peer,
-                reputation.score,
-                reputation.ban_count,
-                reason
-            );
-        }
-
-        // Log significant changes
-        if score_change.abs() >= 10 || should_ban {
-            tracing::info!(
-                "Peer {} reputation changed: {} -> {} (change: {}, reason: {})",
-                peer,
-                old_score,
-                reputation.score,
-                score_change,
-                reason
-            );
-        }
-
-        // Record event
         let event = ReputationEvent {
             peer,
             change: score_change,
@@ -436,9 +441,7 @@ impl PeerReputationManager {
     pub async fn record_connection_failure(&self, peer: SocketAddr) {
         let mut reputations = self.reputations.write().await;
         let reputation = reputations.entry(peer).or_default();
-        if reputation.last_tried.is_none() {
-            reputation.last_tried = Some(SystemTime::now());
-        }
+        reputation.last_tried = Some(SystemTime::now());
         reputation.consecutive_failures = reputation.consecutive_failures.saturating_add(1);
     }
 
@@ -456,48 +459,11 @@ impl PeerReputationManager {
             let mut reputations = self.reputations.write().await;
             let reputation = reputations.entry(peer).or_default();
 
-            if reputation.last_tried.is_none() {
-                reputation.last_tried = Some(SystemTime::now());
-            }
+            reputation.last_tried = Some(SystemTime::now());
             reputation.consecutive_failures = reputation.consecutive_failures.saturating_add(1);
 
             reputation.apply_decay();
-
-            let old_score = reputation.score;
-            reputation.score = (reputation.score + score_change)
-                .clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
-
-            if score_change > 0 {
-                reputation.negative_actions += 1;
-            } else if score_change < 0 {
-                reputation.positive_actions += 1;
-            }
-
-            let should_ban = reputation.score >= MAX_MISBEHAVIOR_SCORE && !reputation.is_banned();
-            if should_ban {
-                reputation.banned_until = Some(Instant::now() + BAN_DURATION);
-                reputation.ban_count += 1;
-                tracing::warn!(
-                    "Peer {} banned for misbehavior (score: {}, ban #{}, reason: {})",
-                    peer,
-                    reputation.score,
-                    reputation.ban_count,
-                    reason
-                );
-            }
-
-            if score_change.abs() >= 10 || should_ban {
-                tracing::info!(
-                    "Peer {} reputation changed: {} -> {} (change: {}, reason: {})",
-                    peer,
-                    old_score,
-                    reputation.score,
-                    score_change,
-                    reason
-                );
-            }
-
-            should_ban
+            Self::apply_score_change(reputation, score_change, peer, reason)
         };
 
         let event = ReputationEvent {

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -423,6 +423,75 @@ impl PeerReputationManager {
         reputation.consecutive_failures = reputation.consecutive_failures.saturating_add(1);
     }
 
+    /// Record a connection failure and apply a reputation penalty in a single write-lock
+    /// acquisition. Equivalent to calling `record_connection_failure` followed by
+    /// `update_reputation`, but without the race window between two separate locks.
+    /// Returns `true` if the peer was banned by this call.
+    pub async fn record_failure_with_penalty(
+        &self,
+        peer: SocketAddr,
+        score_change: i32,
+        reason: &str,
+    ) -> bool {
+        let should_ban = {
+            let mut reputations = self.reputations.write().await;
+            let reputation = reputations.entry(peer).or_default();
+
+            if reputation.last_tried.is_none() {
+                reputation.last_tried = Some(SystemTime::now());
+            }
+            reputation.consecutive_failures = reputation.consecutive_failures.saturating_add(1);
+
+            reputation.apply_decay();
+
+            let old_score = reputation.score;
+            reputation.score =
+                (reputation.score + score_change).clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
+
+            if score_change > 0 {
+                reputation.negative_actions += 1;
+            } else if score_change < 0 {
+                reputation.positive_actions += 1;
+            }
+
+            let should_ban = reputation.score >= MAX_MISBEHAVIOR_SCORE && !reputation.is_banned();
+            if should_ban {
+                reputation.banned_until = Some(Instant::now() + BAN_DURATION);
+                reputation.ban_count += 1;
+                tracing::warn!(
+                    "Peer {} banned for misbehavior (score: {}, ban #{}, reason: {})",
+                    peer,
+                    reputation.score,
+                    reputation.ban_count,
+                    reason
+                );
+            }
+
+            if score_change.abs() >= 10 || should_ban {
+                tracing::info!(
+                    "Peer {} reputation changed: {} -> {} (change: {}, reason: {})",
+                    peer,
+                    old_score,
+                    reputation.score,
+                    score_change,
+                    reason
+                );
+            }
+
+            should_ban
+        };
+
+        let event = ReputationEvent {
+            peer,
+            change: score_change,
+            reason: reason.to_string(),
+            timestamp: Instant::now(),
+        };
+        self.record_event(event).await;
+
+        should_ban
+    }
+
     /// Get all peer reputations
     pub async fn get_all_reputations(&self) -> HashMap<SocketAddr, PeerReputation> {
         let mut reputations = self.reputations.write().await;

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -475,8 +475,10 @@ impl PeerReputationManager {
     /// Record a connection failure and apply a reputation penalty in a single write-lock
     /// acquisition. Returns `true` if the peer was banned by this call.
     ///
-    /// Any negative `score_change` is clamped to 0 (panics in debug). Failure paths must not
-    /// reward peers.
+    /// `score_change` must be non-negative. A value of `0` records the failure (increments
+    /// `consecutive_failures`, updates `last_tried`) without applying a reputation penalty,
+    /// which is useful for tracking failures whose root cause doesn't warrant a ban contribution.
+    /// Any negative `score_change` is clamped to 0 (panics in debug).
     pub async fn record_failure_with_penalty(
         &self,
         peer: SocketAddr,

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -159,7 +159,7 @@ where
 {
     let opt = Option::<SystemTime>::deserialize(d)?;
     let now = SystemTime::now();
-    let deadline = now + FUTURE_TIMESTAMP_TOLERANCE;
+    let deadline = now.checked_add(FUTURE_TIMESTAMP_TOLERANCE).unwrap_or(now);
     let floor = now.checked_sub(TIMESTAMP_MAX_AGE).unwrap_or(SystemTime::UNIX_EPOCH);
     Ok(opt.filter(|t| *t >= floor && *t <= deadline))
 }

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -129,6 +129,24 @@ where
     Ok(v)
 }
 
+const MAX_CONSECUTIVE_FAILURES: u32 = 1_000;
+
+fn clamp_peer_consecutive_failures<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut v = u32::deserialize(deserializer)?;
+
+    if v > MAX_CONSECUTIVE_FAILURES {
+        tracing::warn!(
+            "Peer has excessive consecutive failures {v}, clamping to {MAX_CONSECUTIVE_FAILURES}"
+        );
+        v = MAX_CONSECUTIVE_FAILURES
+    }
+
+    Ok(v)
+}
+
 /// Peer reputation entry
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeerReputation {
@@ -176,6 +194,7 @@ pub struct PeerReputation {
     pub last_tried: Option<SystemTime>,
 
     /// Failures since the last success. Resets to 0 on a successful handshake.
+    #[serde(deserialize_with = "clamp_peer_consecutive_failures")]
     pub consecutive_failures: u32,
 }
 

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -329,25 +329,18 @@ mod tests {
     }
 
     #[test]
-    fn test_clamp_future_system_time_rejects_future() {
-        let future_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 3600;
+    fn test_clamp_future_system_time() {
+        let now_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+
+        // Future timestamps (1 hour ahead) must be discarded.
+        let future_secs = now_secs + 3600;
         let json = make_reputation_json(Some(future_secs), Some(future_secs));
         let rep: PeerReputation = serde_json::from_str(&json).expect("deserialize");
         assert!(rep.last_tried.is_none(), "future last_tried must be nulled");
         assert!(rep.last_success.is_none(), "future last_success must be nulled");
-    }
 
-    #[test]
-    fn test_clamp_future_system_time_rejects_epoch_zero() {
-        let json = make_reputation_json(Some(0), Some(0));
-        let rep: PeerReputation = serde_json::from_str(&json).expect("deserialize");
-        assert!(rep.last_tried.is_none(), "epoch-zero last_tried must be nulled");
-        assert!(rep.last_success.is_none(), "epoch-zero last_success must be nulled");
-    }
-
-    #[test]
-    fn test_clamp_future_system_time_accepts_recent_past() {
-        let recent_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() - 10;
+        // Recent past (10 seconds ago) must be preserved.
+        let recent_secs = now_secs - 10;
         let json = make_reputation_json(Some(recent_secs), Some(recent_secs));
         let rep: PeerReputation = serde_json::from_str(&json).expect("deserialize");
         assert!(rep.last_tried.is_some(), "recent last_tried must be preserved");
@@ -409,35 +402,6 @@ mod tests {
         let rep = reputations.get(&peer).expect("peer must be present after load");
 
         assert!(rep.last_tried.is_none(), "future last_tried must be discarded by clamp");
-        assert_eq!(
-            rep.consecutive_failures, 0,
-            "normalize_after_load must reset streak when last_tried is absent"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_normalize_after_load_via_storage_round_trip_stale() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
-
-        let peers_dir = temp_dir.path().join("peers");
-        std::fs::create_dir_all(&peers_dir).unwrap();
-        let reputation_file = peers_dir.join("reputations.json");
-
-        let json = r#"{"127.0.0.1:9203":{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":3,"successful_connections":2,"last_success":null,"last_tried":{"secs_since_epoch":0,"nanos_since_epoch":0},"consecutive_failures":5}}"#;
-        std::fs::write(&reputation_file, json).unwrap();
-
-        let peer_storage = PersistentPeerStorage::open(temp_dir.path())
-            .await
-            .expect("Failed to open PersistentPeerStorage");
-
-        let manager = PeerReputationManager::new();
-        manager.load_from_storage(&peer_storage).await.unwrap();
-
-        let peer: SocketAddr = "127.0.0.1:9203".parse().unwrap();
-        let reputations = manager.get_all_reputations().await;
-        let rep = reputations.get(&peer).expect("peer must be present after load");
-
-        assert!(rep.last_tried.is_none(), "stale last_tried must be discarded by clamp");
         assert_eq!(
             rep.consecutive_failures, 0,
             "normalize_after_load must reset streak when last_tried is absent"

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -407,4 +407,36 @@ mod tests {
             "normalize_after_load must reset streak when last_tried is absent"
         );
     }
+
+    #[tokio::test]
+    async fn test_normalize_after_load_preserves_failures_when_last_tried_valid() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        let peers_dir = temp_dir.path().join("peers");
+        std::fs::create_dir_all(&peers_dir).unwrap();
+        let reputation_file = peers_dir.join("reputations.json");
+
+        let recent_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() - 300;
+        let json = format!(
+            r#"{{"127.0.0.1:9203":{{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":5,"successful_connections":2,"last_success":null,"last_tried":{{"secs_since_epoch":{recent_secs},"nanos_since_epoch":0}},"consecutive_failures":3}}}}"#
+        );
+        std::fs::write(&reputation_file, json).unwrap();
+
+        let peer_storage = PersistentPeerStorage::open(temp_dir.path())
+            .await
+            .expect("Failed to open PersistentPeerStorage");
+
+        let manager = PeerReputationManager::new();
+        manager.load_from_storage(&peer_storage).await.unwrap();
+
+        let peer: SocketAddr = "127.0.0.1:9203".parse().unwrap();
+        let reputations = manager.get_all_reputations().await;
+        let rep = reputations.get(&peer).expect("peer must be present after load");
+
+        assert!(rep.last_tried.is_some(), "valid last_tried must be preserved");
+        assert_eq!(
+            rep.consecutive_failures, 3,
+            "non-zero streak must be preserved when last_tried is valid"
+        );
+    }
 }

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -154,10 +154,11 @@ mod tests {
         manager.record_failure_with_penalty(peer, 1, "seed").await;
         manager.record_failure_with_penalty(peer, 1, "seed").await;
         manager.record_failure_with_penalty(peer, 1, "seed").await;
-        {
+        let last_tried_before_success = {
             let reputations = manager.get_all_reputations().await;
             assert_eq!(reputations[&peer].consecutive_failures, 3);
-        }
+            reputations[&peer].last_tried.expect("last_tried set by failure seeds")
+        };
 
         let before = SystemTime::now();
         manager.record_successful_connection(peer).await;
@@ -171,6 +172,11 @@ mod tests {
         assert!(last_success <= after);
         assert_eq!(rep.consecutive_failures, 0);
         assert_eq!(rep.successful_connections, 1);
+        assert_eq!(
+            rep.last_tried,
+            Some(last_tried_before_success),
+            "record_successful_connection must not clear last_tried"
+        );
     }
 
     #[tokio::test]
@@ -283,5 +289,25 @@ mod tests {
 
         let reputations = manager.get_all_reputations().await;
         assert_eq!(reputations[&peer].consecutive_failures, MAX_CONSECUTIVE_FAILURES);
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_updates_last_tried_after_attempt() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:9100".parse().unwrap();
+
+        manager.record_connection_attempt(peer).await;
+        let attempt_time = manager.get_all_reputations().await[&peer]
+            .last_tried
+            .expect("last_tried set by attempt");
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_MESSAGE, "test")
+            .await;
+        let after_failure = manager.get_all_reputations().await[&peer]
+            .last_tried
+            .expect("last_tried still set after failure");
+
+        assert!(after_failure > attempt_time, "failure should update last_tried");
     }
 }

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -310,4 +310,27 @@ mod tests {
 
         assert!(after_failure > attempt_time, "failure should update last_tried");
     }
+
+    #[tokio::test]
+    async fn test_connection_attempt_then_success_preserves_last_tried() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:9101".parse().unwrap();
+
+        manager.record_connection_attempt(peer).await;
+        let tried_after_attempt =
+            manager.get_all_reputations().await[&peer].last_tried.expect("attempt sets last_tried");
+        assert!(manager.get_all_reputations().await[&peer].last_success.is_none());
+
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        manager.record_successful_connection(peer).await;
+
+        let rep = &manager.get_all_reputations().await[&peer];
+        assert_eq!(
+            rep.last_tried,
+            Some(tried_after_attempt),
+            "success must preserve last_tried from the preceding attempt"
+        );
+        assert!(rep.last_success.is_some(), "success sets last_success");
+        assert_eq!(rep.consecutive_failures, 0);
+    }
 }

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -201,4 +201,116 @@ mod tests {
         let reputations = manager.get_all_reputations().await;
         assert_eq!(reputations[&peer].consecutive_failures, 0);
     }
+
+    #[tokio::test]
+    async fn test_record_connection_failure_always_updates_last_tried() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:4444".parse().unwrap();
+
+        let before_first = SystemTime::now();
+        manager.record_connection_failure(peer).await;
+        let after_first = SystemTime::now();
+
+        let first_tried = manager
+            .get_all_reputations()
+            .await
+            .get(&peer)
+            .expect("peer exists")
+            .last_tried
+            .expect("last_tried should be set after first failure");
+        assert!(first_tried >= before_first);
+        assert!(first_tried <= after_first);
+
+        let before_second = SystemTime::now();
+        manager.record_connection_failure(peer).await;
+        let after_second = SystemTime::now();
+
+        let second_tried = manager
+            .get_all_reputations()
+            .await
+            .get(&peer)
+            .expect("peer exists")
+            .last_tried
+            .expect("last_tried should still be set");
+        assert!(second_tried >= before_second);
+        assert!(second_tried <= after_second);
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_increments_streak_and_applies_score() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:5555".parse().unwrap();
+
+        let banned = manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_MESSAGE, "test")
+            .await;
+        assert!(!banned);
+
+        let reputations = manager.get_all_reputations().await;
+        let rep = &reputations[&peer];
+        assert_eq!(rep.consecutive_failures, 1);
+        assert_eq!(rep.score, misbehavior_scores::INVALID_MESSAGE);
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_always_sets_last_tried() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:6666".parse().unwrap();
+
+        let before = SystemTime::now();
+        manager.record_failure_with_penalty(peer, 5, "test").await;
+        let after = SystemTime::now();
+
+        let reputations = manager.get_all_reputations().await;
+        let last_tried = reputations[&peer].last_tried.expect("last_tried should be set");
+        assert!(last_tried >= before);
+        assert!(last_tried <= after);
+
+        let before_second = SystemTime::now();
+        manager.record_failure_with_penalty(peer, 5, "test again").await;
+        let after_second = SystemTime::now();
+
+        let second_tried = manager
+            .get_all_reputations()
+            .await
+            .get(&peer)
+            .unwrap()
+            .last_tried
+            .expect("last_tried should be updated");
+        assert!(second_tried >= before_second);
+        assert!(second_tried <= after_second);
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_triggers_ban() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:7777".parse().unwrap();
+
+        // Apply enough score to bring the peer to the ban threshold.
+        // INVALID_HEADER = 50, so two calls reach 100 = MAX_MISBEHAVIOR_SCORE.
+        let first = manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_HEADER, "bad header 1")
+            .await;
+        assert!(!first);
+
+        let second = manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_HEADER, "bad header 2")
+            .await;
+        assert!(second, "second call should trigger a ban");
+        assert!(manager.is_banned(&peer).await);
+        assert_eq!(manager.get_all_reputations().await[&peer].consecutive_failures, 2);
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_streak_keeps_incrementing() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:8888".parse().unwrap();
+
+        // Each call should increment the streak independently, never resetting.
+        for expected in 1u32..=5 {
+            manager.record_failure_with_penalty(peer, 1, "extra failure").await;
+            let reputations = manager.get_all_reputations().await;
+            assert_eq!(reputations[&peer].consecutive_failures, expected);
+        }
+    }
 }

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -6,7 +6,7 @@ mod tests {
 
     use super::super::*;
     use std::net::SocketAddr;
-    use std::time::SystemTime;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[tokio::test]
     async fn test_basic_reputation_operations() {
@@ -309,6 +309,52 @@ mod tests {
             .expect("last_tried still set after failure");
 
         assert!(after_failure > attempt_time, "failure should update last_tried");
+    }
+
+    fn make_reputation_json(
+        last_tried_secs: Option<u64>,
+        last_success_secs: Option<u64>,
+    ) -> String {
+        let last_tried = match last_tried_secs {
+            Some(s) => format!(r#"{{"secs_since_epoch":{s},"nanos_since_epoch":0}}"#),
+            None => "null".to_string(),
+        };
+        let last_success = match last_success_secs {
+            Some(s) => format!(r#"{{"secs_since_epoch":{s},"nanos_since_epoch":0}}"#),
+            None => "null".to_string(),
+        };
+        format!(
+            r#"{{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":0,"successful_connections":0,"last_success":{last_success},"last_tried":{last_tried},"consecutive_failures":0}}"#
+        )
+    }
+
+    #[test]
+    fn test_clamp_future_system_time_rejects_future() {
+        let future_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 3600;
+        let json = make_reputation_json(Some(future_secs), Some(future_secs));
+        let rep: PeerReputation = serde_json::from_str(&json).expect("deserialize");
+        assert!(rep.last_tried.is_none(), "future last_tried must be nulled");
+        assert!(rep.last_success.is_none(), "future last_success must be nulled");
+    }
+
+    #[test]
+    fn test_clamp_future_system_time_rejects_epoch_zero() {
+        let json = make_reputation_json(Some(0), Some(0));
+        let rep: PeerReputation = serde_json::from_str(&json).expect("deserialize");
+        assert!(rep.last_tried.is_none(), "epoch-zero last_tried must be nulled");
+        assert!(rep.last_success.is_none(), "epoch-zero last_success must be nulled");
+    }
+
+    #[test]
+    fn test_clamp_future_system_time_accepts_recent_past() {
+        let recent_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() - 10;
+        let json = make_reputation_json(Some(recent_secs), Some(recent_secs));
+        let rep: PeerReputation = serde_json::from_str(&json).expect("deserialize");
+        assert!(rep.last_tried.is_some(), "recent last_tried must be preserved");
+        assert!(rep.last_success.is_some(), "recent last_success must be preserved");
+        let expected = UNIX_EPOCH + Duration::from_secs(recent_secs);
+        assert_eq!(rep.last_tried.unwrap(), expected);
+        assert_eq!(rep.last_success.unwrap(), expected);
     }
 
     #[tokio::test]

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -241,6 +241,15 @@ mod tests {
         let manager = PeerReputationManager::new();
         let peer: SocketAddr = "127.0.0.1:5555".parse().unwrap();
 
+        manager.record_successful_connection(peer).await;
+        let success_ts = manager
+            .get_all_reputations()
+            .await
+            .get(&peer)
+            .expect("peer exists")
+            .last_success
+            .expect("last_success should be set after successful connection");
+
         let banned = manager
             .record_failure_with_penalty(peer, misbehavior_scores::INVALID_MESSAGE, "test")
             .await;
@@ -250,6 +259,11 @@ mod tests {
         let rep = &reputations[&peer];
         assert_eq!(rep.consecutive_failures, 1);
         assert_eq!(rep.score, misbehavior_scores::INVALID_MESSAGE);
+        assert_eq!(
+            rep.last_success,
+            Some(success_ts),
+            "record_failure_with_penalty must not clear last_success"
+        );
     }
 
     #[tokio::test]
@@ -299,6 +313,13 @@ mod tests {
         assert!(second, "second call should trigger a ban");
         assert!(manager.is_banned(&peer).await);
         assert_eq!(manager.get_all_reputations().await[&peer].consecutive_failures, 2);
+    }
+
+    #[test]
+    fn test_consecutive_failures_clamped_on_deserialize() {
+        let json = r#"{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":0,"successful_connections":0,"last_success":null,"last_tried":null,"consecutive_failures":99999}"#;
+        let rep: PeerReputation = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(rep.consecutive_failures, MAX_CONSECUTIVE_FAILURES);
     }
 
     #[tokio::test]

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -151,9 +151,9 @@ mod tests {
         let peer: SocketAddr = "127.0.0.1:2222".parse().unwrap();
 
         // Seed a non-zero failure streak first to verify the reset behaviour.
-        manager.record_connection_failure(peer).await;
-        manager.record_connection_failure(peer).await;
-        manager.record_connection_failure(peer).await;
+        manager.record_failure_with_penalty(peer, 1, "seed").await;
+        manager.record_failure_with_penalty(peer, 1, "seed").await;
+        manager.record_failure_with_penalty(peer, 1, "seed").await;
         {
             let reputations = manager.get_all_reputations().await;
             assert_eq!(reputations[&peer].consecutive_failures, 3);
@@ -171,69 +171,6 @@ mod tests {
         assert!(last_success <= after);
         assert_eq!(rep.consecutive_failures, 0);
         assert_eq!(rep.successful_connections, 1);
-    }
-
-    #[tokio::test]
-    async fn test_record_connection_failure_increments_without_clearing_last_success() {
-        let manager = PeerReputationManager::new();
-        let peer: SocketAddr = "127.0.0.1:3333".parse().unwrap();
-
-        manager.record_successful_connection(peer).await;
-        let last_success_before = manager
-            .get_all_reputations()
-            .await
-            .get(&peer)
-            .expect("peer exists")
-            .last_success
-            .expect("last_success should be set");
-
-        manager.record_connection_failure(peer).await;
-        manager.record_connection_failure(peer).await;
-
-        let reputations = manager.get_all_reputations().await;
-        let rep = &reputations[&peer];
-
-        assert_eq!(rep.consecutive_failures, 2);
-        assert_eq!(rep.last_success, Some(last_success_before));
-
-        // A subsequent success clears the streak.
-        manager.record_successful_connection(peer).await;
-        let reputations = manager.get_all_reputations().await;
-        assert_eq!(reputations[&peer].consecutive_failures, 0);
-    }
-
-    #[tokio::test]
-    async fn test_record_connection_failure_always_updates_last_tried() {
-        let manager = PeerReputationManager::new();
-        let peer: SocketAddr = "127.0.0.1:4444".parse().unwrap();
-
-        let before_first = SystemTime::now();
-        manager.record_connection_failure(peer).await;
-        let after_first = SystemTime::now();
-
-        let first_tried = manager
-            .get_all_reputations()
-            .await
-            .get(&peer)
-            .expect("peer exists")
-            .last_tried
-            .expect("last_tried should be set after first failure");
-        assert!(first_tried >= before_first);
-        assert!(first_tried <= after_first);
-
-        let before_second = SystemTime::now();
-        manager.record_connection_failure(peer).await;
-        let after_second = SystemTime::now();
-
-        let second_tried = manager
-            .get_all_reputations()
-            .await
-            .get(&peer)
-            .expect("peer exists")
-            .last_tried
-            .expect("last_tried should still be set");
-        assert!(second_tried >= before_second);
-        assert!(second_tried <= after_second);
     }
 
     #[tokio::test]
@@ -333,5 +270,18 @@ mod tests {
             let reputations = manager.get_all_reputations().await;
             assert_eq!(reputations[&peer].consecutive_failures, expected);
         }
+    }
+
+    #[tokio::test]
+    async fn test_consecutive_failures_saturates_at_runtime() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:9191".parse().unwrap();
+
+        for _ in 0..=MAX_CONSECUTIVE_FAILURES {
+            manager.record_failure_with_penalty(peer, 1, "flood").await;
+        }
+
+        let reputations = manager.get_all_reputations().await;
+        assert_eq!(reputations[&peer].consecutive_failures, MAX_CONSECUTIVE_FAILURES);
     }
 }

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -379,4 +379,39 @@ mod tests {
         assert!(rep.last_success.is_some(), "success sets last_success");
         assert_eq!(rep.consecutive_failures, 0);
     }
+
+    #[tokio::test]
+    async fn test_normalize_after_load_via_storage_round_trip() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        // Write a reputations.json directly so we can embed a future `last_tried`
+        // that `clamp_future_system_time` will discard on load, and a non-zero
+        // `consecutive_failures` that `normalize_after_load` must then reset to 0.
+        let peers_dir = temp_dir.path().join("peers");
+        std::fs::create_dir_all(&peers_dir).unwrap();
+        let reputation_file = peers_dir.join("reputations.json");
+
+        let future_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 3_600;
+        let json = format!(
+            r#"{{"127.0.0.1:9202":{{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":3,"successful_connections":2,"last_success":null,"last_tried":{{"secs_since_epoch":{future_secs},"nanos_since_epoch":0}},"consecutive_failures":5}}}}"#
+        );
+        std::fs::write(&reputation_file, json).unwrap();
+
+        let peer_storage = PersistentPeerStorage::open(temp_dir.path())
+            .await
+            .expect("Failed to open PersistentPeerStorage");
+
+        let manager = PeerReputationManager::new();
+        manager.load_from_storage(&peer_storage).await.unwrap();
+
+        let peer: SocketAddr = "127.0.0.1:9202".parse().unwrap();
+        let reputations = manager.get_all_reputations().await;
+        let rep = reputations.get(&peer).expect("peer must be present after load");
+
+        assert!(rep.last_tried.is_none(), "future last_tried must be discarded by clamp");
+        assert_eq!(
+            rep.consecutive_failures, 0,
+            "normalize_after_load must reset streak when last_tried is absent"
+        );
+    }
 }

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -201,29 +201,4 @@ mod tests {
         let reputations = manager.get_all_reputations().await;
         assert_eq!(reputations[&peer].consecutive_failures, 0);
     }
-
-    #[test]
-    fn test_legacy_reputations_json_loads_with_defaults() {
-        // Older persisted records lack the new session outcome fields.
-        let legacy = r#"{
-            "score": 15,
-            "ban_count": 1,
-            "positive_actions": 4,
-            "negative_actions": 2,
-            "connection_attempts": 7,
-            "successful_connections": 6
-        }"#;
-
-        let rep: PeerReputation = serde_json::from_str(legacy).expect("legacy JSON must parse");
-
-        assert_eq!(rep.score, 15);
-        assert_eq!(rep.ban_count, 1);
-        assert_eq!(rep.positive_actions, 4);
-        assert_eq!(rep.negative_actions, 2);
-        assert_eq!(rep.connection_attempts, 7);
-        assert_eq!(rep.successful_connections, 6);
-        assert!(rep.last_success.is_none());
-        assert!(rep.last_tried.is_none());
-        assert_eq!(rep.consecutive_failures, 0);
-    }
 }

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -414,4 +414,33 @@ mod tests {
             "normalize_after_load must reset streak when last_tried is absent"
         );
     }
+
+    #[tokio::test]
+    async fn test_normalize_after_load_via_storage_round_trip_stale() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        let peers_dir = temp_dir.path().join("peers");
+        std::fs::create_dir_all(&peers_dir).unwrap();
+        let reputation_file = peers_dir.join("reputations.json");
+
+        let json = r#"{"127.0.0.1:9203":{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":3,"successful_connections":2,"last_success":null,"last_tried":{"secs_since_epoch":0,"nanos_since_epoch":0},"consecutive_failures":5}}"#;
+        std::fs::write(&reputation_file, json).unwrap();
+
+        let peer_storage = PersistentPeerStorage::open(temp_dir.path())
+            .await
+            .expect("Failed to open PersistentPeerStorage");
+
+        let manager = PeerReputationManager::new();
+        manager.load_from_storage(&peer_storage).await.unwrap();
+
+        let peer: SocketAddr = "127.0.0.1:9203".parse().unwrap();
+        let reputations = manager.get_all_reputations().await;
+        let rep = reputations.get(&peer).expect("peer must be present after load");
+
+        assert!(rep.last_tried.is_none(), "stale last_tried must be discarded by clamp");
+        assert_eq!(
+            rep.consecutive_failures, 0,
+            "normalize_after_load must reset streak when last_tried is absent"
+        );
+    }
 }

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -6,6 +6,7 @@ mod tests {
 
     use super::super::*;
     use std::net::SocketAddr;
+    use std::time::SystemTime;
 
     #[tokio::test]
     async fn test_basic_reputation_operations() {
@@ -114,5 +115,115 @@ mod tests {
 
         assert_eq!(rep.connection_attempts, 2);
         assert_eq!(rep.successful_connections, 1);
+    }
+
+    #[test]
+    fn test_default_session_outcomes_are_empty() {
+        let rep = PeerReputation::default();
+
+        assert!(rep.last_success.is_none());
+        assert!(rep.last_tried.is_none());
+        assert_eq!(rep.consecutive_failures, 0);
+    }
+
+    #[tokio::test]
+    async fn test_record_connection_attempt_sets_last_tried() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:1111".parse().unwrap();
+
+        let before = SystemTime::now();
+        manager.record_connection_attempt(peer).await;
+        let after = SystemTime::now();
+
+        let reputations = manager.get_all_reputations().await;
+        let rep = &reputations[&peer];
+
+        let last_tried = rep.last_tried.expect("last_tried should be set");
+        assert!(last_tried >= before);
+        assert!(last_tried <= after);
+        assert!(rep.last_success.is_none());
+        assert_eq!(rep.consecutive_failures, 0);
+    }
+
+    #[tokio::test]
+    async fn test_record_successful_connection_sets_last_success_and_resets_failures() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:2222".parse().unwrap();
+
+        // Seed a non-zero failure streak first to verify the reset behaviour.
+        manager.record_connection_failure(peer).await;
+        manager.record_connection_failure(peer).await;
+        manager.record_connection_failure(peer).await;
+        {
+            let reputations = manager.get_all_reputations().await;
+            assert_eq!(reputations[&peer].consecutive_failures, 3);
+        }
+
+        let before = SystemTime::now();
+        manager.record_successful_connection(peer).await;
+        let after = SystemTime::now();
+
+        let reputations = manager.get_all_reputations().await;
+        let rep = &reputations[&peer];
+
+        let last_success = rep.last_success.expect("last_success should be set");
+        assert!(last_success >= before);
+        assert!(last_success <= after);
+        assert_eq!(rep.consecutive_failures, 0);
+        assert_eq!(rep.successful_connections, 1);
+    }
+
+    #[tokio::test]
+    async fn test_record_connection_failure_increments_without_clearing_last_success() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:3333".parse().unwrap();
+
+        manager.record_successful_connection(peer).await;
+        let last_success_before = manager
+            .get_all_reputations()
+            .await
+            .get(&peer)
+            .expect("peer exists")
+            .last_success
+            .expect("last_success should be set");
+
+        manager.record_connection_failure(peer).await;
+        manager.record_connection_failure(peer).await;
+
+        let reputations = manager.get_all_reputations().await;
+        let rep = &reputations[&peer];
+
+        assert_eq!(rep.consecutive_failures, 2);
+        assert_eq!(rep.last_success, Some(last_success_before));
+
+        // A subsequent success clears the streak.
+        manager.record_successful_connection(peer).await;
+        let reputations = manager.get_all_reputations().await;
+        assert_eq!(reputations[&peer].consecutive_failures, 0);
+    }
+
+    #[test]
+    fn test_legacy_reputations_json_loads_with_defaults() {
+        // Older persisted records lack the new session outcome fields.
+        let legacy = r#"{
+            "score": 15,
+            "ban_count": 1,
+            "positive_actions": 4,
+            "negative_actions": 2,
+            "connection_attempts": 7,
+            "successful_connections": 6
+        }"#;
+
+        let rep: PeerReputation = serde_json::from_str(legacy).expect("legacy JSON must parse");
+
+        assert_eq!(rep.score, 15);
+        assert_eq!(rep.ban_count, 1);
+        assert_eq!(rep.positive_actions, 4);
+        assert_eq!(rep.negative_actions, 2);
+        assert_eq!(rep.connection_attempts, 7);
+        assert_eq!(rep.successful_connections, 6);
+        assert!(rep.last_success.is_none());
+        assert!(rep.last_tried.is_none());
+        assert_eq!(rep.consecutive_failures, 0);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `last_success`, `last_tried`, and `consecutive_failures` to `PeerReputation`, wired into the connect/handshake lifecycle: attempts bump `last_tried`, successful handshakes set `last_success` and reset `consecutive_failures`, and both handshake and connect failures increment `consecutive_failures`.
- Bumps `AddrV2.time` on successful handshake via `AddrV2Handler::mark_seen`, which preserves richer gossip services on known entries and uses the peer's actual handshake-negotiated services for first observations.
- Consolidates the two-lock failure recording into an atomic `record_failure_with_penalty`, used from both the handshake-failure and connect-failure paths.
- Unit tests cover every field transition, `mark_seen` behavior, and the atomic failure helper.

Backward compatibility with older `reputations.json` files is explicitly out of scope per #102. Stale local state can be discarded on upgrade.

Foundational work for #104 (capability-aware selection scoring) and #105 (capability-driven churn).

Closes #103

Part of #102