### PR TITLE
feat: capability-aware peer selection with exponential-backoff cooldown

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: xdustinface/manki@v4
+      - uses: manki-review/manki@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -1,0 +1,29 @@
+name: Manki Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+concurrency:
+  group: manki-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: xdustinface/manki@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.manki.yml
+++ b/.manki.yml
@@ -1,0 +1,18 @@
+# Manki — AI Code Review Configuration
+# https://github.com/xdustinface/manki
+
+auto_review: true
+auto_approve: true
+
+exclude_paths:
+  - "*.lock"
+  - "fuzz/**"
+
+instructions: |
+  This is a Rust implementation of the Dash cryptocurrency protocol.
+  Pay special attention to:
+  - Consensus-critical code paths — changes here can cause chain splits
+  - FFI safety for C/Swift bindings in dash-spv-* crates
+  - Proper error handling — prefer Result over unwrap/expect in library code
+  - DIP (Dash Improvement Proposal) compliance for protocol changes
+  - Memory safety in hash/crypto implementations

--- a/.manki.yml
+++ b/.manki.yml
@@ -1,5 +1,5 @@
 # Manki — AI Code Review Configuration
-# https://github.com/xdustinface/manki
+# https://github.com/manki-review/manki
 
 auto_review: true
 auto_approve: true

--- a/dash-spv/src/network/addrv2.rs
+++ b/dash-spv/src/network/addrv2.rs
@@ -2,7 +2,7 @@
 
 use rand::prelude::*;
 use std::collections::{HashMap, HashSet};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
@@ -23,6 +23,19 @@ fn evict_if_needed(peers: &mut HashMap<SocketAddr, AddrV2Message>) {
         entries.sort_by_key(|(_, msg)| std::cmp::Reverse(msg.time));
         entries.truncate(MAX_ADDR_TO_STORE);
         peers.extend(entries);
+    }
+}
+
+fn make_addr_message(addr: SocketAddr, services: ServiceFlags, time: u32) -> AddrV2Message {
+    let addr_v2 = match addr.ip() {
+        IpAddr::V4(ipv4) => AddrV2::Ipv4(ipv4),
+        IpAddr::V6(ipv6) => AddrV2::Ipv6(ipv6),
+    };
+    AddrV2Message {
+        time,
+        services,
+        addr: addr_v2,
+        port: addr.port(),
     }
 }
 
@@ -134,21 +147,36 @@ impl AddrV2Handler {
             })
             .as_secs() as u32;
 
-        let addr_v2 = match addr.ip() {
-            std::net::IpAddr::V4(ipv4) => AddrV2::Ipv4(ipv4),
-            std::net::IpAddr::V6(ipv6) => AddrV2::Ipv6(ipv6),
-        };
+        let mut known_peers = self.known_peers.write().await;
+        known_peers.insert(addr, make_addr_message(addr, services, now));
+        evict_if_needed(&mut known_peers);
+    }
 
-        let addr_msg = AddrV2Message {
-            time: now,
-            services,
-            addr: addr_v2,
-            port: addr.port(),
-        };
+    /// Bump the stored `AddrV2.time` for `addr` to now after directly observing
+    /// the peer (e.g. a successful handshake) and record the handshake-verified
+    /// `services`. A first-hand observation is authoritative, so both `time` and
+    /// `services` are overwritten on existing entries. If the entry is missing it
+    /// is created with the provided values.
+    pub async fn mark_seen(&self, addr: SocketAddr, services: ServiceFlags) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|e| {
+                tracing::error!("System time error in mark_seen: {}", e);
+                Duration::from_secs(0)
+            })
+            .as_secs() as u32;
 
         let mut known_peers = self.known_peers.write().await;
-        known_peers.insert(addr, addr_msg);
-        evict_if_needed(&mut known_peers);
+        match known_peers.get_mut(&addr) {
+            Some(existing) => {
+                existing.time = now;
+                existing.services = services;
+            }
+            None => {
+                known_peers.insert(addr, make_addr_message(addr, services, now));
+                evict_if_needed(&mut known_peers);
+            }
+        }
     }
 
     /// Build a GetAddr response message
@@ -188,6 +216,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mark_seen_bumps_time_and_updates_services() {
+        let handler = AddrV2Handler::new();
+        let addr: SocketAddr = "10.0.0.5:9999".parse().unwrap();
+
+        // Seed via AddrV2 gossip with a stale-but-valid timestamp and richer services.
+        let gossip_services = ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS;
+        let ipv4_addr = match addr.ip() {
+            IpAddr::V4(v4) => v4,
+            _ => panic!("test expects IPv4"),
+        };
+        let now =
+            SystemTime::now().duration_since(UNIX_EPOCH).expect("system time").as_secs() as u32;
+        let stale_time = now.saturating_sub(3600);
+        handler
+            .handle_addrv2(vec![AddrV2Message {
+                time: stale_time,
+                services: gossip_services,
+                addr: AddrV2::Ipv4(ipv4_addr),
+                port: addr.port(),
+            }])
+            .await;
+
+        // Observe the peer directly — handshake-verified services are authoritative.
+        let handshake_services = ServiceFlags::NETWORK;
+        handler.mark_seen(addr, handshake_services).await;
+
+        let known = handler.get_known_addresses().await;
+        let entry = known.iter().find(|m| m.socket_addr().ok() == Some(addr)).expect("entry");
+        assert!(entry.time >= now);
+        assert!(entry.time > stale_time);
+        assert_eq!(entry.services, handshake_services);
+    }
+
+    #[tokio::test]
+    async fn test_mark_seen_inserts_new_entry() {
+        let handler = AddrV2Handler::new();
+        let addr: SocketAddr = "10.0.0.6:9999".parse().unwrap();
+
+        assert!(handler.get_known_addresses().await.is_empty());
+
+        handler.mark_seen(addr, ServiceFlags::NETWORK).await;
+
+        let known = handler.get_known_addresses().await;
+        assert_eq!(known.len(), 1);
+        assert_eq!(known[0].socket_addr().unwrap(), addr);
+        assert_eq!(known[0].services, ServiceFlags::NETWORK);
+    }
+
+    #[tokio::test]
+    async fn test_mark_seen_evicts_when_at_capacity() {
+        let handler = AddrV2Handler::new();
+
+        // Use staggered timestamps strictly older than the mark_seen call below so
+        // the new entry is definitively the freshest and survives eviction.
+        let base_time =
+            (SystemTime::now().duration_since(UNIX_EPOCH).expect("system time").as_secs() as u32)
+                .saturating_sub(ONE_WEEK / 2);
+
+        let msgs: Vec<AddrV2Message> = (0..MAX_ADDR_TO_STORE)
+            .map(|i| {
+                let addr: SocketAddr =
+                    format!("10.{}.{}.1:9999", i / 256, i % 256).parse().unwrap();
+                make_addr_message(addr, ServiceFlags::NETWORK, base_time - i as u32)
+            })
+            .collect();
+        handler.handle_addrv2(msgs).await;
+
+        assert_eq!(handler.get_known_addresses().await.len(), MAX_ADDR_TO_STORE);
+
+        let new_addr: SocketAddr = "192.168.99.99:9999".parse().unwrap();
+        handler.mark_seen(new_addr, ServiceFlags::NETWORK).await;
+
+        let known = handler.get_known_addresses().await;
+        assert_eq!(known.len(), MAX_ADDR_TO_STORE);
+        assert!(known.iter().any(|m| m.socket_addr().ok() == Some(new_addr)));
+    }
+
+    #[tokio::test]
     async fn test_addrv2_timestamp_validation() {
         let handler = AddrV2Handler::new();
         let now = SystemTime::now()
@@ -199,7 +305,7 @@ mod tests {
         let addr: SocketAddr =
             "127.0.0.1:9999".parse().expect("Failed to parse test socket address");
         let ipv4_addr = match addr.ip() {
-            std::net::IpAddr::V4(v4) => v4,
+            IpAddr::V4(v4) => v4,
             _ => panic!("Test expects IPv4 address but got IPv6"),
         };
 

--- a/dash-spv/src/network/handshake.rs
+++ b/dash-spv/src/network/handshake.rs
@@ -301,6 +301,11 @@ impl HandshakeManager {
         self.peer_version
     }
 
+    /// Get the service flags advertised by the peer in its version message.
+    pub fn peer_services(&self) -> Option<ServiceFlags> {
+        self.peer_services
+    }
+
     /// Check if peer supports headers2 compression.
     pub fn peer_supports_headers2(&self) -> bool {
         self.peer_services.map(|services| services.has(NODE_HEADERS_COMPRESSED)).unwrap_or(false)

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -65,6 +65,10 @@ pub struct PeerNetworkManager {
     exclusive_mode: bool,
     /// Services peers must advertise to be eligible for selection.
     required_services: RequiredServices,
+    /// Set of explicit peer addresses from `ClientConfig.peers`. These bypass the
+    /// `required_services` hard-filter because their real services are not known until
+    /// after handshake.
+    explicit_peers: HashSet<SocketAddr>,
     /// Cached count of currently connected peers for fast, non-blocking queries
     connected_peer_count: Arc<AtomicUsize>,
     /// Disable headers2 after decompression failure
@@ -115,6 +119,7 @@ impl PeerNetworkManager {
             user_agent: config.user_agent.clone(),
             exclusive_mode,
             required_services: RequiredServices::from_config(config),
+            explicit_peers: config.peers.iter().copied().collect(),
             connected_peer_count: Arc::new(AtomicUsize::new(0)),
             headers2_disabled: Arc::new(Mutex::new(HashSet::new())),
             message_dispatcher: Arc::new(Mutex::new(MessageDispatcher::default())),
@@ -897,7 +902,12 @@ impl PeerNetworkManager {
                 // replenish known addresses on a subsequent cycle.
                 let best_peers = self
                     .reputation_manager
-                    .select_best_peers(self.required_services, known, needed * 2)
+                    .select_best_peers(
+                        self.required_services,
+                        known,
+                        needed * 2,
+                        &self.explicit_peers,
+                    )
                     .await;
                 let mut attempted = 0;
 
@@ -1293,6 +1303,7 @@ impl Clone for PeerNetworkManager {
             user_agent: self.user_agent.clone(),
             exclusive_mode: self.exclusive_mode,
             required_services: self.required_services,
+            explicit_peers: self.explicit_peers.clone(),
             connected_peer_count: self.connected_peer_count.clone(),
             headers2_disabled: self.headers2_disabled.clone(),
             message_dispatcher: self.message_dispatcher.clone(),

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -265,6 +265,10 @@ impl PeerNetworkManager {
                                 tracing::warn!("Failed to send GetAddr to {}: {}", addr, e);
                             }
 
+                            // Capture peer-advertised services before the peer is moved into the pool.
+                            let peer_services =
+                                handshake_manager.peer_services().unwrap_or(ServiceFlags::NETWORK);
+
                             // Record successful connection
                             reputation_manager.record_successful_connection(addr).await;
 
@@ -290,8 +294,9 @@ impl PeerNetworkManager {
                                 best_height,
                             });
 
-                            // Add to known addresses
-                            addrv2_handler.add_known_address(addr, ServiceFlags::NETWORK).await;
+                            // Bump the AddrV2 time on direct observation, using the peer's
+                            // actual advertised services from the version message.
+                            addrv2_handler.mark_seen(addr, peer_services).await;
 
                             // // Start message reader for this peer
                             Self::start_peer_reader(
@@ -311,9 +316,8 @@ impl PeerNetworkManager {
                             tracing::warn!("Handshake failed with {}: {}", addr, e);
                             // Only clears connecting set. Peer was never added, so no count/event needed.
                             pool.remove_peer(&addr).await;
-                            // Update reputation for handshake failure
                             reputation_manager
-                                .update_reputation(
+                                .record_failure_with_penalty(
                                     addr,
                                     misbehavior_scores::INVALID_MESSAGE,
                                     "Handshake failed",
@@ -328,9 +332,8 @@ impl PeerNetworkManager {
                     tracing::debug!("Failed to connect to {}: {}", addr, e);
                     // Only clears connecting set. Peer was never added, so no count/event needed.
                     pool.remove_peer(&addr).await;
-                    // Minor reputation penalty for connection failure
                     reputation_manager
-                        .update_reputation(
+                        .record_failure_with_penalty(
                             addr,
                             misbehavior_scores::TIMEOUT / 2,
                             "Connection failed",

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -19,6 +19,7 @@ use crate::network::pool::PeerPool;
 use crate::network::reputation::{
     misbehavior_scores, positive_scores, PeerReputationManager, ReputationAware,
 };
+use crate::network::required_services::RequiredServices;
 use crate::network::{
     HandshakeManager, Message, MessageDispatcher, MessageType, NetworkEvent, NetworkManager,
     NetworkRequest, Peer, RequestSender,
@@ -62,6 +63,8 @@ pub struct PeerNetworkManager {
     user_agent: Option<String>,
     /// Exclusive mode: restrict to configured peers only (no DNS or peer store)
     exclusive_mode: bool,
+    /// Services peers must advertise to be eligible for selection.
+    required_services: RequiredServices,
     /// Cached count of currently connected peers for fast, non-blocking queries
     connected_peer_count: Arc<AtomicUsize>,
     /// Disable headers2 after decompression failure
@@ -111,6 +114,7 @@ impl PeerNetworkManager {
             data_dir,
             user_agent: config.user_agent.clone(),
             exclusive_mode,
+            required_services: RequiredServices::from_config(config),
             connected_peer_count: Arc::new(AtomicUsize::new(0)),
             headers2_disabled: Arc::new(Mutex::new(HashSet::new())),
             message_dispatcher: Arc::new(Mutex::new(MessageDispatcher::default())),
@@ -888,8 +892,13 @@ impl PeerNetworkManager {
                 // Try known addresses first, sorted by reputation
                 let known = self.addrv2_handler.get_known_addresses().await;
                 let needed = TARGET_PEERS.saturating_sub(count);
-                // Select best peers based on reputation
-                let best_peers = self.reputation_manager.select_best_peers(known, needed * 2).await;
+                // Capability-aware reputation-ranked selection. If no peers survive the
+                // hard filters, the maintenance tick ends empty-handed so DNS discovery can
+                // replenish known addresses on a subsequent cycle.
+                let best_peers = self
+                    .reputation_manager
+                    .select_best_peers(self.required_services, known, needed * 2)
+                    .await;
                 let mut attempted = 0;
 
                 for addr in best_peers {
@@ -1283,6 +1292,7 @@ impl Clone for PeerNetworkManager {
             data_dir: self.data_dir.clone(),
             user_agent: self.user_agent.clone(),
             exclusive_mode: self.exclusive_mode,
+            required_services: self.required_services,
             connected_peer_count: self.connected_peer_count.clone(),
             headers2_disabled: self.headers2_disabled.clone(),
             message_dispatcher: self.message_dispatcher.clone(),

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -10,6 +10,7 @@ mod message_dispatcher;
 pub mod peer;
 pub mod pool;
 pub mod reputation;
+pub(crate) mod required_services;
 
 mod message_type;
 #[cfg(test)]

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::RwLock;
 
 /// Misbehavior score thresholds for different violations
@@ -129,6 +129,37 @@ where
     Ok(v)
 }
 
+const MAX_CONSECUTIVE_FAILURES: u32 = 1_000;
+
+fn clamp_peer_consecutive_failures<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut v = u32::deserialize(deserializer)?;
+
+    if v > MAX_CONSECUTIVE_FAILURES {
+        tracing::warn!(
+            "Peer has excessive consecutive failures {v}, clamping to {MAX_CONSECUTIVE_FAILURES}"
+        );
+        v = MAX_CONSECUTIVE_FAILURES
+    }
+
+    Ok(v)
+}
+
+/// Clock-drift tolerance for future timestamps: up to 10 seconds ahead is accepted.
+const FUTURE_TIMESTAMP_TOLERANCE: Duration = Duration::from_secs(10);
+
+fn clamp_future_system_time<'de, D>(d: D) -> Result<Option<SystemTime>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<SystemTime>::deserialize(d)?;
+    let now = SystemTime::now();
+    let deadline = now.checked_add(FUTURE_TIMESTAMP_TOLERANCE).unwrap_or(now);
+    Ok(opt.filter(|t| *t <= deadline))
+}
+
 /// Peer reputation entry
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeerReputation {
@@ -161,9 +192,25 @@ pub struct PeerReputation {
     /// Successful connection count
     pub successful_connections: u64,
 
-    /// Last connection time
+    /// Monotonic instant of the last connection attempt within the current process session.
+    /// Resets to `None` on restart. Used for runtime decisions such as immediate
+    /// reconnect throttling. For persistent cooldown/backoff logic use `last_tried`.
     #[serde(skip)]
     pub last_connection: Option<Instant>,
+
+    /// Wall-clock time of the last successful handshake with this peer.
+    #[serde(default, deserialize_with = "clamp_future_system_time")]
+    pub last_success: Option<SystemTime>,
+
+    /// Wall-clock time of the last attempted connection to this peer (persisted across
+    /// restarts). The canonical source for cooldown and backoff decisions that must
+    /// survive process restarts. Distinct from `last_connection`, which is session-only.
+    #[serde(default, deserialize_with = "clamp_future_system_time")]
+    pub last_tried: Option<SystemTime>,
+
+    /// Failures since the last success. Resets to 0 on a successful handshake.
+    #[serde(deserialize_with = "clamp_peer_consecutive_failures")]
+    pub consecutive_failures: u32,
 }
 
 impl Default for PeerReputation {
@@ -178,11 +225,24 @@ impl Default for PeerReputation {
             connection_attempts: 0,
             successful_connections: 0,
             last_connection: None,
+            last_success: None,
+            last_tried: None,
+            consecutive_failures: 0,
         }
     }
 }
 
 impl PeerReputation {
+    /// Enforce internal consistency after loading from persistent storage. If
+    /// `last_tried` was discarded (e.g., because it was a future timestamp),
+    /// `consecutive_failures` has no temporal anchor and must be reset to 0 to
+    /// avoid incorrect backoff behaviour.
+    fn normalize_after_load(&mut self) {
+        if self.last_tried.is_none() && self.consecutive_failures > 0 {
+            self.consecutive_failures = 0;
+        }
+    }
+
     /// Check if the peer is currently banned
     pub fn is_banned(&self) -> bool {
         self.banned_until.is_some_and(|until| Instant::now() < until)
@@ -198,6 +258,54 @@ impl PeerReputation {
                 None
             }
         })
+    }
+
+    /// Apply the common fields updated on every failure: refresh `last_tried` and
+    /// increment `consecutive_failures`, clamped to `MAX_CONSECUTIVE_FAILURES`.
+    fn record_failure_fields(&mut self) {
+        self.last_tried = Some(SystemTime::now());
+        self.consecutive_failures =
+            self.consecutive_failures.saturating_add(1).min(MAX_CONSECUTIVE_FAILURES);
+    }
+
+    /// Apply a score change. Assumes decay has already been applied.
+    /// Returns `true` if the peer was banned by this call.
+    fn apply_score_change(&mut self, score_change: i32, peer: SocketAddr, reason: &str) -> bool {
+        let old_score = self.score;
+        self.score =
+            (self.score + score_change).clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
+
+        if score_change > 0 {
+            self.negative_actions += 1;
+        } else if score_change < 0 {
+            self.positive_actions += 1;
+        }
+
+        let should_ban = self.score >= MAX_MISBEHAVIOR_SCORE && !self.is_banned();
+        if should_ban {
+            self.banned_until = Some(Instant::now() + BAN_DURATION);
+            self.ban_count += 1;
+            tracing::warn!(
+                "Peer {} banned for misbehavior (score: {}, ban #{}, reason: {})",
+                peer,
+                self.score,
+                self.ban_count,
+                reason
+            );
+        }
+
+        if score_change.abs() >= 10 || should_ban {
+            tracing::info!(
+                "Peer {} reputation changed: {} -> {} (change: {}, reason: {})",
+                peer,
+                old_score,
+                self.score,
+                score_change,
+                reason
+            );
+        }
+
+        should_ban
     }
 
     /// Apply reputation decay
@@ -270,48 +378,9 @@ impl PeerReputationManager {
         let mut reputations = self.reputations.write().await;
         let reputation = reputations.entry(peer).or_default();
 
-        // Apply decay first
         reputation.apply_decay();
+        let should_ban = reputation.apply_score_change(score_change, peer, reason);
 
-        // Update score
-        let old_score = reputation.score;
-        reputation.score =
-            (reputation.score + score_change).clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
-
-        // Track positive/negative actions
-        if score_change > 0 {
-            reputation.negative_actions += 1;
-        } else if score_change < 0 {
-            reputation.positive_actions += 1;
-        }
-
-        // Check if peer should be banned
-        let should_ban = reputation.score >= MAX_MISBEHAVIOR_SCORE && !reputation.is_banned();
-        if should_ban {
-            reputation.banned_until = Some(Instant::now() + BAN_DURATION);
-            reputation.ban_count += 1;
-            tracing::warn!(
-                "Peer {} banned for misbehavior (score: {}, ban #{}, reason: {})",
-                peer,
-                reputation.score,
-                reputation.ban_count,
-                reason
-            );
-        }
-
-        // Log significant changes
-        if score_change.abs() >= 10 || should_ban {
-            tracing::info!(
-                "Peer {} reputation changed: {} -> {} (change: {}, reason: {})",
-                peer,
-                old_score,
-                reputation.score,
-                score_change,
-                reason
-            );
-        }
-
-        // Record event
         let event = ReputationEvent {
             peer,
             change: score_change,
@@ -383,6 +452,7 @@ impl PeerReputationManager {
         let reputation = reputations.entry(peer).or_default();
         reputation.connection_attempts += 1;
         reputation.last_connection = Some(Instant::now());
+        reputation.last_tried = Some(SystemTime::now());
     }
 
     /// Record a successful connection
@@ -390,6 +460,47 @@ impl PeerReputationManager {
         let mut reputations = self.reputations.write().await;
         let reputation = reputations.entry(peer).or_default();
         reputation.successful_connections += 1;
+        reputation.last_success = Some(SystemTime::now());
+        reputation.consecutive_failures = 0;
+    }
+
+    /// Record a connection failure and apply a reputation penalty in a single write-lock
+    /// acquisition. Returns `true` if the peer was banned by this call.
+    ///
+    /// `score_change` must be non-negative. A value of `0` records the failure (increments
+    /// `consecutive_failures`, updates `last_tried`) without applying a reputation penalty,
+    /// which is useful for tracking failures whose root cause doesn't warrant a ban contribution.
+    /// Any negative `score_change` is clamped to 0 (panics in debug).
+    pub async fn record_failure_with_penalty(
+        &self,
+        peer: SocketAddr,
+        score_change: i32,
+        reason: &str,
+    ) -> bool {
+        debug_assert!(
+            score_change >= 0,
+            "record_failure_with_penalty expects non-negative score change"
+        );
+        let score_change = score_change.max(0);
+        let should_ban = {
+            let mut reputations = self.reputations.write().await;
+            let reputation = reputations.entry(peer).or_default();
+
+            reputation.record_failure_fields();
+
+            reputation.apply_decay();
+            reputation.apply_score_change(score_change, peer, reason)
+        };
+
+        let event = ReputationEvent {
+            peer,
+            change: score_change,
+            reason: reason.to_string(),
+            timestamp: Instant::now(),
+        };
+        self.record_event(event).await;
+
+        should_ban
     }
 
     /// Get all peer reputations
@@ -465,6 +576,8 @@ impl PeerReputationManager {
             // Validate successful connections don't exceed attempts
             reputation.successful_connections =
                 reputation.successful_connections.min(reputation.connection_attempts);
+
+            reputation.normalize_after_load();
 
             // Skip entry if data appears corrupted
             if reputation.positive_actions > MAX_ACTION_COUNT

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -10,7 +10,7 @@ use crate::storage::PeerStorage;
 use dashcore::network::address::AddrV2Message;
 use dashcore::network::constants::ServiceFlags;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -669,10 +669,13 @@ fn composite_score(reputation: &PeerReputation, addr: &AddrV2Message, now_epoch_
     let mut score = reputation.score as f64;
 
     let attempts = reputation.connection_attempts.max(1) as f64;
-    let success_ratio = reputation.successful_connections as f64 / attempts;
+    let success_ratio = (reputation.successful_connections as f64 / attempts).clamp(0.0, 1.0);
     score -= success_ratio * scoring_weights::SUCCESS_RATIO_WEIGHT;
 
-    let staleness_secs = now_epoch_secs.saturating_sub(addr.time as u64) as f64;
+    // Clamp addr.time to at most now so a peer-controlled future timestamp cannot
+    // zero out the staleness penalty.
+    let addr_time = (addr.time as u64).min(now_epoch_secs);
+    let staleness_secs = now_epoch_secs.saturating_sub(addr_time) as f64;
     let staleness_penalty = (staleness_secs / scoring_weights::STALENESS_SECS_PER_POINT)
         .min(scoring_weights::STALENESS_CAP);
     score += staleness_penalty;
@@ -687,6 +690,12 @@ fn composite_score(reputation: &PeerReputation, addr: &AddrV2Message, now_epoch_
 /// Helper trait for reputation-aware peer selection
 pub(crate) trait ReputationAware {
     /// Select best peers that satisfy `required` services and are not banned.
+    ///
+    /// Peers whose address appears in `explicit_peers` bypass the `required` services
+    /// hard-filter (they are still subject to ban and cooldown filters). This allows
+    /// user-configured peers to be selected even when their services are not yet known
+    /// (services are learned only after handshake).
+    ///
     /// An empty return value indicates no capable survivors, allowing callers
     /// to fall back to DNS discovery rather than connecting to an incapable peer.
     fn select_best_peers(
@@ -694,6 +703,7 @@ pub(crate) trait ReputationAware {
         required: RequiredServices,
         available_peers: Vec<AddrV2Message>,
         count: usize,
+        explicit_peers: &HashSet<SocketAddr>,
     ) -> impl std::future::Future<Output = Vec<SocketAddr>> + Send;
 
     /// Check if we should connect to a peer based on reputation
@@ -709,6 +719,7 @@ impl ReputationAware for PeerReputationManager {
         required: RequiredServices,
         available_peers: Vec<AddrV2Message>,
         count: usize,
+        explicit_peers: &HashSet<SocketAddr>,
     ) -> Vec<SocketAddr> {
         if count == 0 {
             return Vec::new();
@@ -718,32 +729,51 @@ impl ReputationAware for PeerReputationManager {
         let now_epoch_secs =
             now_system.duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
 
-        let mut reputations = self.reputations.write().await;
-        let mut scored: Vec<(SocketAddr, f64)> = Vec::with_capacity(available_peers.len());
+        // Collect candidates under the write lock: apply decay and clone reputation data.
+        // The lock is held only for this gathering phase, not for the sort that follows.
+        let candidates: Vec<(SocketAddr, PeerReputation, AddrV2Message)> = {
+            let mut reputations = self.reputations.write().await;
+            let mut out = Vec::with_capacity(available_peers.len());
 
-        for peer in available_peers {
-            let Ok(socket_addr) = peer.socket_addr() else {
-                tracing::warn!("Skip invalid peer address: {:?}", peer);
-                continue;
-            };
+            for peer in available_peers {
+                let Ok(socket_addr) = peer.socket_addr() else {
+                    tracing::warn!("Skip invalid peer address: {:?}", peer);
+                    continue;
+                };
 
-            if !required.is_satisfied_by(peer.services) {
-                continue;
+                // Explicit peers bypass the services hard-filter; all others must satisfy it.
+                if !explicit_peers.contains(&socket_addr)
+                    && !required.is_satisfied_by(peer.services)
+                {
+                    continue;
+                }
+
+                // Read reputation without inserting a default entry for unknown peers.
+                let mut rep = reputations.get(&socket_addr).cloned().unwrap_or_default();
+                rep.apply_decay();
+
+                // Persist decay back only for peers that already have an entry.
+                if let Some(stored) = reputations.get_mut(&socket_addr) {
+                    stored.apply_decay();
+                }
+
+                if rep.is_banned() {
+                    continue;
+                }
+
+                if rep.in_cooldown(now_system) {
+                    continue;
+                }
+
+                out.push((socket_addr, rep, peer));
             }
+            out
+        };
 
-            let reputation = reputations.entry(socket_addr).or_default();
-            reputation.apply_decay();
-
-            if reputation.is_banned() {
-                continue;
-            }
-
-            if reputation.in_cooldown(now_system) {
-                continue;
-            }
-
-            scored.push((socket_addr, composite_score(reputation, &peer, now_epoch_secs)));
-        }
+        let mut scored: Vec<(SocketAddr, f64)> = candidates
+            .into_iter()
+            .map(|(addr, rep, peer)| (addr, composite_score(&rep, &peer, now_epoch_secs)))
+            .collect();
 
         scored.sort_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         scored.into_iter().take(count).map(|(peer, _)| peer).collect()

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -8,11 +8,12 @@
 use crate::network::required_services::RequiredServices;
 use crate::storage::PeerStorage;
 use dashcore::network::address::AddrV2Message;
+use dashcore::network::constants::ServiceFlags;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 
 /// Misbehavior score thresholds for different violations
@@ -161,6 +162,24 @@ pub(crate) const COOLDOWN_STEPS: [Duration; 5] = [
     Duration::from_secs(30 * 60),
     Duration::from_secs(2 * 60 * 60),
 ];
+
+/// Tunables for the capability-aware peer-selection score. Lower composite score is
+/// better, matching the existing reputation convention.
+mod scoring_weights {
+    /// Weight applied to the success ratio (successful / attempts). Subtracted from
+    /// the composite score so peers with a high historical success rate rank ahead
+    /// of peers at the same reputation score.
+    pub(super) const SUCCESS_RATIO_WEIGHT: f64 = 30.0;
+
+    /// Seconds of `AddrV2.time` staleness per 1 point of penalty.
+    pub(super) const STALENESS_SECS_PER_POINT: f64 = 600.0;
+
+    /// Cap on the staleness penalty so a very old address cannot dominate the score.
+    pub(super) const STALENESS_CAP: f64 = 50.0;
+
+    /// Bonus subtracted when the peer advertises `NODE_HEADERS_COMPRESSED`.
+    pub(super) const PREFERRED_SERVICES_BONUS: f64 = 15.0;
+}
 
 fn clamp_future_system_time<'de, D>(d: D) -> Result<Option<SystemTime>, D::Error>
 where
@@ -644,6 +663,27 @@ impl PeerReputationManager {
     }
 }
 
+/// Combine reputation score, historical success ratio, gossip staleness and the
+/// preferred-services bonus into a single score. Lower is better.
+fn composite_score(reputation: &PeerReputation, addr: &AddrV2Message, now_epoch_secs: u64) -> f64 {
+    let mut score = reputation.score as f64;
+
+    let attempts = reputation.connection_attempts.max(1) as f64;
+    let success_ratio = reputation.successful_connections as f64 / attempts;
+    score -= success_ratio * scoring_weights::SUCCESS_RATIO_WEIGHT;
+
+    let staleness_secs = now_epoch_secs.saturating_sub(addr.time as u64) as f64;
+    let staleness_penalty = (staleness_secs / scoring_weights::STALENESS_SECS_PER_POINT)
+        .min(scoring_weights::STALENESS_CAP);
+    score += staleness_penalty;
+
+    if addr.services.has(ServiceFlags::NODE_HEADERS_COMPRESSED) {
+        score -= scoring_weights::PREFERRED_SERVICES_BONUS;
+    }
+
+    score
+}
+
 /// Helper trait for reputation-aware peer selection
 pub(crate) trait ReputationAware {
     /// Select best peers that satisfy `required` services and are not banned.
@@ -674,9 +714,12 @@ impl ReputationAware for PeerReputationManager {
             return Vec::new();
         }
 
-        let now = SystemTime::now();
-        let mut peer_scores = Vec::new();
+        let now_system = SystemTime::now();
+        let now_epoch_secs =
+            now_system.duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
+
         let mut reputations = self.reputations.write().await;
+        let mut scored: Vec<(SocketAddr, f64)> = Vec::with_capacity(available_peers.len());
 
         for peer in available_peers {
             let Ok(socket_addr) = peer.socket_addr() else {
@@ -695,18 +738,15 @@ impl ReputationAware for PeerReputationManager {
                 continue;
             }
 
-            if reputation.in_cooldown(now) {
+            if reputation.in_cooldown(now_system) {
                 continue;
             }
 
-            peer_scores.push((socket_addr, reputation.score));
+            scored.push((socket_addr, composite_score(reputation, &peer, now_epoch_secs)));
         }
 
-        // Sort by score (lower is better)
-        peer_scores.sort_by_key(|(_, score)| *score);
-
-        // Return the best peers
-        peer_scores.into_iter().take(count).map(|(peer, _)| peer).collect()
+        scored.sort_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        scored.into_iter().take(count).map(|(peer, _)| peer).collect()
     }
 
     async fn should_connect_to_peer(&self, peer: &SocketAddr) -> bool {

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -151,6 +151,17 @@ where
 /// Clock-drift tolerance for future timestamps: up to 10 seconds ahead is accepted.
 const FUTURE_TIMESTAMP_TOLERANCE: Duration = Duration::from_secs(10);
 
+/// Exponential backoff steps applied after repeated connection failures. Indexed
+/// by `consecutive_failures - 1`, clamped to the last entry once the streak
+/// exceeds the table length.
+pub(crate) const COOLDOWN_STEPS: [Duration; 5] = [
+    Duration::from_secs(30),
+    Duration::from_secs(60),
+    Duration::from_secs(5 * 60),
+    Duration::from_secs(30 * 60),
+    Duration::from_secs(2 * 60 * 60),
+];
+
 fn clamp_future_system_time<'de, D>(d: D) -> Result<Option<SystemTime>, D::Error>
 where
     D: Deserializer<'de>,
@@ -307,6 +318,32 @@ impl PeerReputation {
         }
 
         should_ban
+    }
+
+    /// Return the backoff duration that should apply after `last_tried` given
+    /// the current `consecutive_failures` streak. `None` means no cooldown is
+    /// imposed, either because there are no failures or because there is no
+    /// temporal anchor in `last_tried`.
+    pub(crate) fn cooldown(&self) -> Option<Duration> {
+        if self.consecutive_failures == 0 {
+            return None;
+        }
+        let idx =
+            (self.consecutive_failures as usize).saturating_sub(1).min(COOLDOWN_STEPS.len() - 1);
+        Some(COOLDOWN_STEPS[idx])
+    }
+
+    /// True when `now` still falls inside the cooldown window anchored at
+    /// `last_tried`. Returns false if either the streak is zero or `last_tried`
+    /// is missing (e.g. discarded on load).
+    pub(crate) fn in_cooldown(&self, now: SystemTime) -> bool {
+        match (self.last_tried, self.cooldown()) {
+            (Some(last), Some(cd)) => match last.checked_add(cd) {
+                Some(deadline) => deadline > now,
+                None => false,
+            },
+            _ => false,
+        }
     }
 
     /// Apply reputation decay
@@ -637,6 +674,7 @@ impl ReputationAware for PeerReputationManager {
             return Vec::new();
         }
 
+        let now = SystemTime::now();
         let mut peer_scores = Vec::new();
         let mut reputations = self.reputations.write().await;
 
@@ -653,9 +691,15 @@ impl ReputationAware for PeerReputationManager {
             let reputation = reputations.entry(socket_addr).or_default();
             reputation.apply_decay();
 
-            if !reputation.is_banned() {
-                peer_scores.push((socket_addr, reputation.score));
+            if reputation.is_banned() {
+                continue;
             }
+
+            if reputation.in_cooldown(now) {
+                continue;
+            }
+
+            peer_scores.push((socket_addr, reputation.score));
         }
 
         // Sort by score (lower is better)

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -5,6 +5,7 @@
 //! implements automatic banning for excessive misbehavior, and provides reputation
 //! decay over time for recovery.
 
+use crate::network::required_services::RequiredServices;
 use crate::storage::PeerStorage;
 use dashcore::network::address::AddrV2Message;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -607,10 +608,13 @@ impl PeerReputationManager {
 }
 
 /// Helper trait for reputation-aware peer selection
-pub trait ReputationAware {
-    /// Select best peers based on reputation
+pub(crate) trait ReputationAware {
+    /// Select best peers that satisfy `required` services and are not banned.
+    /// An empty return value indicates no capable survivors, allowing callers
+    /// to fall back to DNS discovery rather than connecting to an incapable peer.
     fn select_best_peers(
         &self,
+        required: RequiredServices,
         available_peers: Vec<AddrV2Message>,
         count: usize,
     ) -> impl std::future::Future<Output = Vec<SocketAddr>> + Send;
@@ -625,9 +629,14 @@ pub trait ReputationAware {
 impl ReputationAware for PeerReputationManager {
     async fn select_best_peers(
         &self,
+        required: RequiredServices,
         available_peers: Vec<AddrV2Message>,
         count: usize,
     ) -> Vec<SocketAddr> {
+        if count == 0 {
+            return Vec::new();
+        }
+
         let mut peer_scores = Vec::new();
         let mut reputations = self.reputations.write().await;
 
@@ -636,6 +645,10 @@ impl ReputationAware for PeerReputationManager {
                 tracing::warn!("Skip invalid peer address: {:?}", peer);
                 continue;
             };
+
+            if !required.is_satisfied_by(peer.services) {
+                continue;
+            }
 
             let reputation = reputations.entry(socket_addr).or_default();
             reputation.apply_decay();

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -417,6 +417,62 @@ mod tests {
         );
     }
 
+    fn rep_with_streak(failures: u32, last_tried: Option<SystemTime>) -> PeerReputation {
+        PeerReputation {
+            consecutive_failures: failures,
+            last_tried,
+            ..PeerReputation::default()
+        }
+    }
+
+    #[test]
+    fn test_cooldown_none_when_no_failures() {
+        let rep = PeerReputation::default();
+        assert!(rep.cooldown().is_none());
+        assert!(!rep.in_cooldown(SystemTime::now()));
+    }
+
+    #[test]
+    fn test_cooldown_steps_match_exponential_backoff() {
+        let expected = [
+            (1, Duration::from_secs(30)),
+            (2, Duration::from_secs(60)),
+            (3, Duration::from_secs(5 * 60)),
+            (4, Duration::from_secs(30 * 60)),
+            (5, Duration::from_secs(2 * 60 * 60)),
+        ];
+        for (failures, duration) in expected {
+            let rep = rep_with_streak(failures, Some(SystemTime::now()));
+            assert_eq!(rep.cooldown(), Some(duration));
+        }
+    }
+
+    #[test]
+    fn test_cooldown_saturates_past_table_length() {
+        let rep = rep_with_streak(50, Some(SystemTime::now()));
+        assert_eq!(rep.cooldown(), Some(Duration::from_secs(2 * 60 * 60)));
+    }
+
+    #[test]
+    fn test_in_cooldown_true_within_window() {
+        let now = SystemTime::now();
+        let rep = rep_with_streak(1, Some(now - Duration::from_secs(10)));
+        assert!(rep.in_cooldown(now));
+    }
+
+    #[test]
+    fn test_in_cooldown_false_after_window() {
+        let now = SystemTime::now();
+        let rep = rep_with_streak(1, Some(now - Duration::from_secs(31)));
+        assert!(!rep.in_cooldown(now));
+    }
+
+    #[test]
+    fn test_in_cooldown_false_without_last_tried() {
+        let rep = rep_with_streak(3, None);
+        assert!(!rep.in_cooldown(SystemTime::now()));
+    }
+
     #[tokio::test]
     async fn test_normalize_after_load_preserves_failures_when_last_tried_valid() {
         let temp_dir = tempfile::TempDir::new().unwrap();

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -8,8 +8,13 @@ mod tests {
     use super::super::*;
     use dashcore::network::address::AddrV2;
     use dashcore::network::constants::ServiceFlags;
+    use std::collections::HashSet;
     use std::net::{Ipv4Addr, SocketAddr};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    fn no_explicit() -> HashSet<SocketAddr> {
+        HashSet::new()
+    }
 
     fn now_epoch_secs() -> u32 {
         SystemTime::now().duration_since(UNIX_EPOCH).expect("system time").as_secs() as u32
@@ -116,7 +121,8 @@ mod tests {
         // neutral_peer has default score of 0
 
         let all_peers = vec![good_peer.clone(), neutral_peer.clone(), bad_peer.clone()];
-        let selected = manager.select_best_peers(network_required(), all_peers, 2).await;
+        let selected =
+            manager.select_best_peers(network_required(), all_peers, 2, &no_explicit()).await;
 
         // Should select good_peer first, then neutral_peer
         assert_eq!(selected.len(), 2);
@@ -445,7 +451,12 @@ mod tests {
         let required =
             RequiredServices::from_flags(ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS);
         let selected = manager
-            .select_best_peers(required, vec![capable.clone(), missing_filters, no_services], 10)
+            .select_best_peers(
+                required,
+                vec![capable.clone(), missing_filters, no_services],
+                10,
+                &no_explicit(),
+            )
             .await;
 
         assert_eq!(selected, vec![capable.socket_addr().unwrap()]);
@@ -478,8 +489,9 @@ mod tests {
             }
         }
 
-        let selected =
-            manager.select_best_peers(network_required(), msgs.clone(), addrs.len()).await;
+        let selected = manager
+            .select_best_peers(network_required(), msgs.clone(), addrs.len(), &no_explicit())
+            .await;
         assert!(selected.is_empty(), "every peer should be in cooldown");
 
         // Confirm streaks match expectations by probing cooldown() via reputations.
@@ -512,7 +524,8 @@ mod tests {
             r.last_tried = Some(SystemTime::now() - Duration::from_secs(120));
         }
 
-        let selected = manager.select_best_peers(network_required(), vec![msg], 1).await;
+        let selected =
+            manager.select_best_peers(network_required(), vec![msg], 1, &no_explicit()).await;
         assert_eq!(selected, vec![addr]);
     }
 
@@ -536,7 +549,7 @@ mod tests {
             addr_msg("10.1.1.1", 9999, ServiceFlags::NETWORK, now),
             addr_msg("10.1.1.2", 9999, ServiceFlags::NETWORK, now),
         ];
-        let selected = manager.select_best_peers(network_required(), msgs, 2).await;
+        let selected = manager.select_best_peers(network_required(), msgs, 2, &no_explicit()).await;
         assert_eq!(selected, vec![high, low]);
     }
 
@@ -554,7 +567,7 @@ mod tests {
             addr_msg("10.2.2.1", 9999, ServiceFlags::NETWORK, now),
             addr_msg("10.2.2.2", 9999, ServiceFlags::NETWORK, now),
         ];
-        let selected = manager.select_best_peers(network_required(), msgs, 2).await;
+        let selected = manager.select_best_peers(network_required(), msgs, 2, &no_explicit()).await;
         assert_eq!(selected, vec![better, worse]);
     }
 
@@ -569,7 +582,12 @@ mod tests {
         let stale = addr_msg("10.3.3.2", 9999, ServiceFlags::NETWORK, now.saturating_sub(7200));
 
         let selected = manager
-            .select_best_peers(network_required(), vec![stale.clone(), fresh.clone()], 2)
+            .select_best_peers(
+                network_required(),
+                vec![stale.clone(), fresh.clone()],
+                2,
+                &no_explicit(),
+            )
             .await;
         assert_eq!(selected, vec![fresh_addr, stale_addr]);
     }
@@ -590,7 +608,12 @@ mod tests {
         let plain = addr_msg("10.4.4.2", 9999, ServiceFlags::NETWORK, now);
 
         let selected = manager
-            .select_best_peers(network_required(), vec![plain.clone(), bonus.clone()], 2)
+            .select_best_peers(
+                network_required(),
+                vec![plain.clone(), bonus.clone()],
+                2,
+                &no_explicit(),
+            )
             .await;
         assert_eq!(selected, vec![bonus_addr, plain_addr]);
     }
@@ -602,8 +625,9 @@ mod tests {
         let a = addr_msg("10.5.5.1", 9999, ServiceFlags::NETWORK, now);
         let b = addr_msg("10.5.5.2", 9999, ServiceFlags::NETWORK, now);
 
-        let selected =
-            manager.select_best_peers(network_required(), vec![a.clone(), b.clone()], 5).await;
+        let selected = manager
+            .select_best_peers(network_required(), vec![a.clone(), b.clone()], 5, &no_explicit())
+            .await;
         let a_sa = a.socket_addr().unwrap();
         let b_sa = b.socket_addr().unwrap();
         assert_eq!(selected.len(), 2);
@@ -619,7 +643,8 @@ mod tests {
         let required =
             RequiredServices::from_flags(ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS);
 
-        let selected = manager.select_best_peers(required, vec![incapable], 5).await;
+        let selected =
+            manager.select_best_peers(required, vec![incapable], 5, &no_explicit()).await;
         assert!(selected.is_empty());
     }
 
@@ -632,7 +657,7 @@ mod tests {
             .map(|i| addr_msg(&format!("10.7.7.{i}"), 9999, ServiceFlags::NETWORK, now))
             .collect();
 
-        let selected = manager.select_best_peers(network_required(), msgs, 3).await;
+        let selected = manager.select_best_peers(network_required(), msgs, 3, &no_explicit()).await;
         assert_eq!(selected.len(), 3);
     }
 
@@ -642,7 +667,7 @@ mod tests {
         let now = now_epoch_secs();
 
         let msgs = vec![addr_msg("10.8.8.1", 9999, ServiceFlags::NETWORK, now)];
-        let selected = manager.select_best_peers(network_required(), msgs, 0).await;
+        let selected = manager.select_best_peers(network_required(), msgs, 0, &no_explicit()).await;
         assert!(selected.is_empty());
     }
 
@@ -663,7 +688,8 @@ mod tests {
             addr_msg("10.9.9.1", 9999, ServiceFlags::NETWORK, now),
             addr_msg("10.9.9.2", 9999, ServiceFlags::NETWORK, now),
         ];
-        let selected = manager.select_best_peers(network_required(), msgs, 10).await;
+        let selected =
+            manager.select_best_peers(network_required(), msgs, 10, &no_explicit()).await;
         assert_eq!(selected, vec![good_addr]);
     }
 
@@ -753,5 +779,84 @@ mod tests {
             rep.consecutive_failures, 3,
             "non-zero streak must be preserved when last_tried is valid"
         );
+    }
+
+    #[tokio::test]
+    async fn test_select_empty_available_peers_returns_empty() {
+        let manager = PeerReputationManager::new();
+        let required =
+            RequiredServices::from_flags(ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS);
+
+        let selected = manager.select_best_peers(required, vec![], 5, &no_explicit()).await;
+        assert!(selected.is_empty());
+
+        // Confirm no entries were inserted into the map as a side-effect of the call.
+        let reputations = manager.get_all_reputations().await;
+        assert!(reputations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_select_future_addr_time_does_not_panic_and_ranks_as_fresh() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+
+        // Peer with a timestamp set one hour in the future (peer-controlled adversarial input).
+        let future_time = now.saturating_add(3600);
+        let future_peer = addr_msg("20.0.0.1", 9999, ServiceFlags::NETWORK, future_time);
+        // Peer with a timestamp one hour in the past.
+        let past_peer = addr_msg("20.0.0.2", 9999, ServiceFlags::NETWORK, now.saturating_sub(3600));
+
+        let selected = manager
+            .select_best_peers(
+                network_required(),
+                vec![past_peer.clone(), future_peer.clone()],
+                2,
+                &no_explicit(),
+            )
+            .await;
+
+        assert_eq!(selected.len(), 2);
+        // The future-timed peer gets staleness_secs = 0 (clamped), same as a peer seen just now.
+        // The past peer has staleness_secs > 0, so the future peer must rank first (lower score).
+        let future_sa = future_peer.socket_addr().unwrap();
+        let past_sa = past_peer.socket_addr().unwrap();
+        assert_eq!(
+            selected[0], future_sa,
+            "future-timed peer should rank first (treated as fresh)"
+        );
+        assert_eq!(selected[1], past_sa);
+    }
+
+    #[tokio::test]
+    async fn test_select_combined_services_and_cooldown_filters() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+
+        let missing_service_addr: SocketAddr = "30.0.0.1:9999".parse().unwrap();
+        let in_cooldown_addr: SocketAddr = "30.0.0.2:9999".parse().unwrap();
+        let good_addr: SocketAddr = "30.0.0.3:9999".parse().unwrap();
+
+        let required =
+            RequiredServices::from_flags(ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS);
+
+        // Peer A: advertises only NETWORK, missing COMPACT_FILTERS.
+        let peer_a = addr_msg("30.0.0.1", 9999, ServiceFlags::NETWORK, now);
+        // Peer B: advertises both required flags but is in active cooldown.
+        let peer_b =
+            addr_msg("30.0.0.2", 9999, ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS, now);
+        // Peer C: advertises both required flags and is not in cooldown.
+        let peer_c =
+            addr_msg("30.0.0.3", 9999, ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS, now);
+
+        // Put peer B into cooldown by recording a failure (streak = 1, cooldown = 30s).
+        manager.record_failure_with_penalty(in_cooldown_addr, 0, "seed").await;
+
+        let selected = manager
+            .select_best_peers(required, vec![peer_a, peer_b, peer_c], 5, &no_explicit())
+            .await;
+
+        assert_eq!(selected, vec![good_addr], "only peer C should survive both filters");
+        assert!(!selected.contains(&missing_service_addr));
+        assert!(!selected.contains(&in_cooldown_addr));
     }
 }

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -2,11 +2,17 @@
 
 #[cfg(test)]
 mod tests {
+    use crate::network::required_services::RequiredServices;
     use crate::storage::{PersistentPeerStorage, PersistentStorage};
 
     use super::super::*;
+    use dashcore::network::constants::ServiceFlags;
     use std::net::SocketAddr;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    fn network_required() -> RequiredServices {
+        RequiredServices::from_flags(ServiceFlags::NETWORK)
+    }
 
     #[tokio::test]
     async fn test_basic_reputation_operations() {
@@ -82,9 +88,12 @@ mod tests {
     async fn test_peer_selection() {
         let manager = PeerReputationManager::new();
 
-        let good_peer = AddrV2Message::dummy(0, "1.1.1.1".parse().unwrap(), 8333);
-        let neutral_peer = AddrV2Message::dummy(0, "2.2.2.2".parse().unwrap(), 8333);
-        let bad_peer = AddrV2Message::dummy(0, "3.3.3.3".parse().unwrap(), 8333);
+        let mut good_peer = AddrV2Message::dummy(0, "1.1.1.1".parse().unwrap(), 8333);
+        good_peer.services = ServiceFlags::NETWORK;
+        let mut neutral_peer = AddrV2Message::dummy(0, "2.2.2.2".parse().unwrap(), 8333);
+        neutral_peer.services = ServiceFlags::NETWORK;
+        let mut bad_peer = AddrV2Message::dummy(0, "3.3.3.3".parse().unwrap(), 8333);
+        bad_peer.services = ServiceFlags::NETWORK;
 
         // Set different reputations
         manager.update_reputation(good_peer.socket_addr().unwrap(), -20, "Very good").await;
@@ -92,7 +101,7 @@ mod tests {
         // neutral_peer has default score of 0
 
         let all_peers = vec![good_peer.clone(), neutral_peer.clone(), bad_peer.clone()];
-        let selected = manager.select_best_peers(all_peers, 2).await;
+        let selected = manager.select_best_peers(network_required(), all_peers, 2).await;
 
         // Should select good_peer first, then neutral_peer
         assert_eq!(selected.len(), 2);

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -6,6 +6,7 @@ mod tests {
 
     use super::super::*;
     use std::net::SocketAddr;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[tokio::test]
     async fn test_basic_reputation_operations() {
@@ -114,5 +115,328 @@ mod tests {
 
         assert_eq!(rep.connection_attempts, 2);
         assert_eq!(rep.successful_connections, 1);
+    }
+
+    #[test]
+    fn test_default_session_outcomes_are_empty() {
+        let rep = PeerReputation::default();
+
+        assert!(rep.last_success.is_none());
+        assert!(rep.last_tried.is_none());
+        assert_eq!(rep.consecutive_failures, 0);
+    }
+
+    #[tokio::test]
+    async fn test_record_connection_attempt_sets_last_tried() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:1111".parse().unwrap();
+
+        let before = SystemTime::now();
+        manager.record_connection_attempt(peer).await;
+        let after = SystemTime::now();
+
+        let reputations = manager.get_all_reputations().await;
+        let rep = &reputations[&peer];
+
+        let last_tried = rep.last_tried.expect("last_tried should be set");
+        assert!(last_tried >= before);
+        assert!(last_tried <= after);
+        assert!(rep.last_success.is_none());
+        assert_eq!(rep.consecutive_failures, 0);
+    }
+
+    #[tokio::test]
+    async fn test_record_successful_connection_sets_last_success_and_resets_failures() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:2222".parse().unwrap();
+
+        // Seed a non-zero failure streak first to verify the reset behaviour.
+        manager.record_failure_with_penalty(peer, 1, "seed").await;
+        manager.record_failure_with_penalty(peer, 1, "seed").await;
+        manager.record_failure_with_penalty(peer, 1, "seed").await;
+        let last_tried_before_success = {
+            let reputations = manager.get_all_reputations().await;
+            assert_eq!(reputations[&peer].consecutive_failures, 3);
+            reputations[&peer].last_tried.expect("last_tried set by failure seeds")
+        };
+
+        let before = SystemTime::now();
+        manager.record_successful_connection(peer).await;
+        let after = SystemTime::now();
+
+        let reputations = manager.get_all_reputations().await;
+        let rep = &reputations[&peer];
+
+        let last_success = rep.last_success.expect("last_success should be set");
+        assert!(last_success >= before);
+        assert!(last_success <= after);
+        assert_eq!(rep.consecutive_failures, 0);
+        assert_eq!(rep.successful_connections, 1);
+        assert_eq!(
+            rep.last_tried,
+            Some(last_tried_before_success),
+            "record_successful_connection must not clear last_tried"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_increments_streak_and_applies_score() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:5555".parse().unwrap();
+
+        manager.record_successful_connection(peer).await;
+        let success_ts = manager
+            .get_all_reputations()
+            .await
+            .get(&peer)
+            .expect("peer exists")
+            .last_success
+            .expect("last_success should be set after successful connection");
+
+        let banned = manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_MESSAGE, "test")
+            .await;
+        assert!(!banned);
+
+        let reputations = manager.get_all_reputations().await;
+        let rep = &reputations[&peer];
+        assert_eq!(rep.consecutive_failures, 1);
+        assert_eq!(rep.score, misbehavior_scores::INVALID_MESSAGE);
+        assert_eq!(
+            rep.last_success,
+            Some(success_ts),
+            "record_failure_with_penalty must not clear last_success"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_always_sets_last_tried() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:6666".parse().unwrap();
+
+        let before = SystemTime::now();
+        manager.record_failure_with_penalty(peer, 5, "test").await;
+        let after = SystemTime::now();
+
+        let reputations = manager.get_all_reputations().await;
+        let last_tried = reputations[&peer].last_tried.expect("last_tried should be set");
+        assert!(last_tried >= before);
+        assert!(last_tried <= after);
+
+        let before_second = SystemTime::now();
+        manager.record_failure_with_penalty(peer, 5, "test again").await;
+        let after_second = SystemTime::now();
+
+        let second_tried = manager
+            .get_all_reputations()
+            .await
+            .get(&peer)
+            .unwrap()
+            .last_tried
+            .expect("last_tried should be updated");
+        assert!(second_tried >= before_second);
+        assert!(second_tried <= after_second);
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_triggers_ban() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:7777".parse().unwrap();
+
+        // Apply enough score to bring the peer to the ban threshold.
+        // INVALID_HEADER = 50, so two calls reach 100 = MAX_MISBEHAVIOR_SCORE.
+        let first = manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_HEADER, "bad header 1")
+            .await;
+        assert!(!first);
+
+        let second = manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_HEADER, "bad header 2")
+            .await;
+        assert!(second, "second call should trigger a ban");
+        assert!(manager.is_banned(&peer).await);
+        assert_eq!(manager.get_all_reputations().await[&peer].consecutive_failures, 2);
+    }
+
+    #[test]
+    fn test_consecutive_failures_clamped_on_deserialize() {
+        let json = r#"{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":0,"successful_connections":0,"last_success":null,"last_tried":null,"consecutive_failures":99999}"#;
+        let rep: PeerReputation = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(rep.consecutive_failures, MAX_CONSECUTIVE_FAILURES);
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_streak_keeps_incrementing() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:8888".parse().unwrap();
+
+        // Each call should increment the streak independently, never resetting.
+        for expected in 1u32..=5 {
+            manager.record_failure_with_penalty(peer, 1, "extra failure").await;
+            let reputations = manager.get_all_reputations().await;
+            assert_eq!(reputations[&peer].consecutive_failures, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_consecutive_failures_saturates_at_runtime() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:9191".parse().unwrap();
+
+        for _ in 0..=MAX_CONSECUTIVE_FAILURES {
+            manager.record_failure_with_penalty(peer, 1, "flood").await;
+        }
+
+        let reputations = manager.get_all_reputations().await;
+        assert_eq!(reputations[&peer].consecutive_failures, MAX_CONSECUTIVE_FAILURES);
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_updates_last_tried_after_attempt() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:9100".parse().unwrap();
+
+        manager.record_connection_attempt(peer).await;
+        let attempt_time = manager.get_all_reputations().await[&peer]
+            .last_tried
+            .expect("last_tried set by attempt");
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_MESSAGE, "test")
+            .await;
+        let after_failure = manager.get_all_reputations().await[&peer]
+            .last_tried
+            .expect("last_tried still set after failure");
+
+        assert!(after_failure > attempt_time, "failure should update last_tried");
+    }
+
+    fn make_reputation_json(
+        last_tried_secs: Option<u64>,
+        last_success_secs: Option<u64>,
+    ) -> String {
+        let last_tried = match last_tried_secs {
+            Some(s) => format!(r#"{{"secs_since_epoch":{s},"nanos_since_epoch":0}}"#),
+            None => "null".to_string(),
+        };
+        let last_success = match last_success_secs {
+            Some(s) => format!(r#"{{"secs_since_epoch":{s},"nanos_since_epoch":0}}"#),
+            None => "null".to_string(),
+        };
+        format!(
+            r#"{{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":0,"successful_connections":0,"last_success":{last_success},"last_tried":{last_tried},"consecutive_failures":0}}"#
+        )
+    }
+
+    #[test]
+    fn test_clamp_future_system_time() {
+        let now_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+
+        // Future timestamps (1 hour ahead) must be discarded.
+        let future_secs = now_secs + 3600;
+        let json = make_reputation_json(Some(future_secs), Some(future_secs));
+        let rep: PeerReputation = serde_json::from_str(&json).expect("deserialize");
+        assert!(rep.last_tried.is_none(), "future last_tried must be nulled");
+        assert!(rep.last_success.is_none(), "future last_success must be nulled");
+
+        // Recent past (10 seconds ago) must be preserved.
+        let recent_secs = now_secs - 10;
+        let json = make_reputation_json(Some(recent_secs), Some(recent_secs));
+        let rep: PeerReputation = serde_json::from_str(&json).expect("deserialize");
+        assert!(rep.last_tried.is_some(), "recent last_tried must be preserved");
+        assert!(rep.last_success.is_some(), "recent last_success must be preserved");
+        let expected = UNIX_EPOCH + Duration::from_secs(recent_secs);
+        assert_eq!(rep.last_tried.unwrap(), expected);
+        assert_eq!(rep.last_success.unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_connection_attempt_then_success_preserves_last_tried() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:9101".parse().unwrap();
+
+        manager.record_connection_attempt(peer).await;
+        let tried_after_attempt =
+            manager.get_all_reputations().await[&peer].last_tried.expect("attempt sets last_tried");
+        assert!(manager.get_all_reputations().await[&peer].last_success.is_none());
+
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        manager.record_successful_connection(peer).await;
+
+        let rep = &manager.get_all_reputations().await[&peer];
+        assert_eq!(
+            rep.last_tried,
+            Some(tried_after_attempt),
+            "success must preserve last_tried from the preceding attempt"
+        );
+        assert!(rep.last_success.is_some(), "success sets last_success");
+        assert_eq!(rep.consecutive_failures, 0);
+    }
+
+    #[tokio::test]
+    async fn test_normalize_after_load_via_storage_round_trip() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        // Write a reputations.json directly so we can embed a future `last_tried`
+        // that `clamp_future_system_time` will discard on load, and a non-zero
+        // `consecutive_failures` that `normalize_after_load` must then reset to 0.
+        let peers_dir = temp_dir.path().join("peers");
+        std::fs::create_dir_all(&peers_dir).unwrap();
+        let reputation_file = peers_dir.join("reputations.json");
+
+        let future_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 3_600;
+        let json = format!(
+            r#"{{"127.0.0.1:9202":{{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":3,"successful_connections":2,"last_success":null,"last_tried":{{"secs_since_epoch":{future_secs},"nanos_since_epoch":0}},"consecutive_failures":5}}}}"#
+        );
+        std::fs::write(&reputation_file, json).unwrap();
+
+        let peer_storage = PersistentPeerStorage::open(temp_dir.path())
+            .await
+            .expect("Failed to open PersistentPeerStorage");
+
+        let manager = PeerReputationManager::new();
+        manager.load_from_storage(&peer_storage).await.unwrap();
+
+        let peer: SocketAddr = "127.0.0.1:9202".parse().unwrap();
+        let reputations = manager.get_all_reputations().await;
+        let rep = reputations.get(&peer).expect("peer must be present after load");
+
+        assert!(rep.last_tried.is_none(), "future last_tried must be discarded by clamp");
+        assert_eq!(
+            rep.consecutive_failures, 0,
+            "normalize_after_load must reset streak when last_tried is absent"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_normalize_after_load_preserves_failures_when_last_tried_valid() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        let peers_dir = temp_dir.path().join("peers");
+        std::fs::create_dir_all(&peers_dir).unwrap();
+        let reputation_file = peers_dir.join("reputations.json");
+
+        let recent_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() - 300;
+        let json = format!(
+            r#"{{"127.0.0.1:9203":{{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":5,"successful_connections":2,"last_success":null,"last_tried":{{"secs_since_epoch":{recent_secs},"nanos_since_epoch":0}},"consecutive_failures":3}}}}"#
+        );
+        std::fs::write(&reputation_file, json).unwrap();
+
+        let peer_storage = PersistentPeerStorage::open(temp_dir.path())
+            .await
+            .expect("Failed to open PersistentPeerStorage");
+
+        let manager = PeerReputationManager::new();
+        manager.load_from_storage(&peer_storage).await.unwrap();
+
+        let peer: SocketAddr = "127.0.0.1:9203".parse().unwrap();
+        let reputations = manager.get_all_reputations().await;
+        let rep = reputations.get(&peer).expect("peer must be present after load");
+
+        assert!(rep.last_tried.is_some(), "valid last_tried must be preserved");
+        assert_eq!(
+            rep.consecutive_failures, 3,
+            "non-zero streak must be preserved when last_tried is valid"
+        );
     }
 }

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -6,9 +6,24 @@ mod tests {
     use crate::storage::{PersistentPeerStorage, PersistentStorage};
 
     use super::super::*;
+    use dashcore::network::address::AddrV2;
     use dashcore::network::constants::ServiceFlags;
-    use std::net::SocketAddr;
+    use std::net::{Ipv4Addr, SocketAddr};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    fn now_epoch_secs() -> u32 {
+        SystemTime::now().duration_since(UNIX_EPOCH).expect("system time").as_secs() as u32
+    }
+
+    fn addr_msg(ip: &str, port: u16, services: ServiceFlags, time: u32) -> AddrV2Message {
+        let ipv4: Ipv4Addr = ip.parse().expect("ipv4");
+        AddrV2Message {
+            time,
+            services,
+            addr: AddrV2::Ipv4(ipv4),
+            port,
+        }
+    }
 
     fn network_required() -> RequiredServices {
         RequiredServices::from_flags(ServiceFlags::NETWORK)
@@ -415,6 +430,241 @@ mod tests {
             rep.consecutive_failures, 0,
             "normalize_after_load must reset streak when last_tried is absent"
         );
+    }
+
+    #[tokio::test]
+    async fn test_select_filters_out_peers_missing_required_services() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+
+        let capable =
+            addr_msg("1.2.3.4", 9999, ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS, now);
+        let missing_filters = addr_msg("5.6.7.8", 9999, ServiceFlags::NETWORK, now);
+        let no_services = addr_msg("9.9.9.9", 9999, ServiceFlags::NONE, now);
+
+        let required =
+            RequiredServices::from_flags(ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS);
+        let selected = manager
+            .select_best_peers(required, vec![capable.clone(), missing_filters, no_services], 10)
+            .await;
+
+        assert_eq!(selected, vec![capable.socket_addr().unwrap()]);
+    }
+
+    #[tokio::test]
+    async fn test_select_filters_out_peers_in_cooldown() {
+        let manager = PeerReputationManager::new();
+        let now_secs = now_epoch_secs();
+
+        let addrs: Vec<SocketAddr> =
+            (1..=5).map(|i| format!("10.0.0.{i}:9999").parse::<SocketAddr>().unwrap()).collect();
+        let msgs: Vec<AddrV2Message> = addrs
+            .iter()
+            .map(|sa| match sa {
+                SocketAddr::V4(v4) => AddrV2Message {
+                    time: now_secs,
+                    services: ServiceFlags::NETWORK,
+                    addr: AddrV2::Ipv4(*v4.ip()),
+                    port: v4.port(),
+                },
+                _ => unreachable!("IPv4 only"),
+            })
+            .collect();
+
+        // Assign streaks 1..=5 with a fresh last_tried so every peer is in cooldown.
+        for (i, addr) in addrs.iter().enumerate() {
+            for _ in 0..=i {
+                manager.record_failure_with_penalty(*addr, 0, "seed").await;
+            }
+        }
+
+        let selected =
+            manager.select_best_peers(network_required(), msgs.clone(), addrs.len()).await;
+        assert!(selected.is_empty(), "every peer should be in cooldown");
+
+        // Confirm streaks match expectations by probing cooldown() via reputations.
+        let reps = manager.get_all_reputations().await;
+        let expected = [
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+            Duration::from_secs(5 * 60),
+            Duration::from_secs(30 * 60),
+            Duration::from_secs(2 * 60 * 60),
+        ];
+        for (i, addr) in addrs.iter().enumerate() {
+            assert_eq!(reps[addr].cooldown(), Some(expected[i]));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_select_includes_peer_whose_cooldown_expired() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+        let addr: SocketAddr = "192.168.10.10:9999".parse().unwrap();
+        let msg = addr_msg("192.168.10.10", 9999, ServiceFlags::NETWORK, now);
+
+        // One failure gives a 30s cooldown. Rewind last_tried past that window so
+        // the peer is no longer in cooldown.
+        manager.record_failure_with_penalty(addr, 0, "seed").await;
+        {
+            let mut reps = manager.reputations.write().await;
+            let r = reps.get_mut(&addr).unwrap();
+            r.last_tried = Some(SystemTime::now() - Duration::from_secs(120));
+        }
+
+        let selected = manager.select_best_peers(network_required(), vec![msg], 1).await;
+        assert_eq!(selected, vec![addr]);
+    }
+
+    #[tokio::test]
+    async fn test_select_ranking_prefers_higher_success_ratio() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+        let low: SocketAddr = "10.1.1.1:9999".parse().unwrap();
+        let high: SocketAddr = "10.1.1.2:9999".parse().unwrap();
+
+        // Equal reputation scores, differing success histories.
+        for _ in 0..10 {
+            manager.record_connection_attempt(low).await;
+            manager.record_connection_attempt(high).await;
+        }
+        for _ in 0..9 {
+            manager.record_successful_connection(high).await;
+        }
+
+        let msgs = vec![
+            addr_msg("10.1.1.1", 9999, ServiceFlags::NETWORK, now),
+            addr_msg("10.1.1.2", 9999, ServiceFlags::NETWORK, now),
+        ];
+        let selected = manager.select_best_peers(network_required(), msgs, 2).await;
+        assert_eq!(selected, vec![high, low]);
+    }
+
+    #[tokio::test]
+    async fn test_select_ranking_prefers_lower_reputation_score() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+        let better: SocketAddr = "10.2.2.1:9999".parse().unwrap();
+        let worse: SocketAddr = "10.2.2.2:9999".parse().unwrap();
+
+        manager.update_reputation(better, -10, "good").await;
+        manager.update_reputation(worse, 20, "bad").await;
+
+        let msgs = vec![
+            addr_msg("10.2.2.1", 9999, ServiceFlags::NETWORK, now),
+            addr_msg("10.2.2.2", 9999, ServiceFlags::NETWORK, now),
+        ];
+        let selected = manager.select_best_peers(network_required(), msgs, 2).await;
+        assert_eq!(selected, vec![better, worse]);
+    }
+
+    #[tokio::test]
+    async fn test_select_ranking_prefers_fresher_addrv2_time() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+
+        let fresh_addr: SocketAddr = "10.3.3.1:9999".parse().unwrap();
+        let stale_addr: SocketAddr = "10.3.3.2:9999".parse().unwrap();
+        let fresh = addr_msg("10.3.3.1", 9999, ServiceFlags::NETWORK, now);
+        let stale = addr_msg("10.3.3.2", 9999, ServiceFlags::NETWORK, now.saturating_sub(7200));
+
+        let selected = manager
+            .select_best_peers(network_required(), vec![stale.clone(), fresh.clone()], 2)
+            .await;
+        assert_eq!(selected, vec![fresh_addr, stale_addr]);
+    }
+
+    #[tokio::test]
+    async fn test_select_ranking_prefers_compressed_headers_bonus() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+
+        let bonus_addr: SocketAddr = "10.4.4.1:9999".parse().unwrap();
+        let plain_addr: SocketAddr = "10.4.4.2:9999".parse().unwrap();
+        let bonus = addr_msg(
+            "10.4.4.1",
+            9999,
+            ServiceFlags::NETWORK | ServiceFlags::NODE_HEADERS_COMPRESSED,
+            now,
+        );
+        let plain = addr_msg("10.4.4.2", 9999, ServiceFlags::NETWORK, now);
+
+        let selected = manager
+            .select_best_peers(network_required(), vec![plain.clone(), bonus.clone()], 2)
+            .await;
+        assert_eq!(selected, vec![bonus_addr, plain_addr]);
+    }
+
+    #[tokio::test]
+    async fn test_select_ties_preserve_all_survivors() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+        let a = addr_msg("10.5.5.1", 9999, ServiceFlags::NETWORK, now);
+        let b = addr_msg("10.5.5.2", 9999, ServiceFlags::NETWORK, now);
+
+        let selected =
+            manager.select_best_peers(network_required(), vec![a.clone(), b.clone()], 5).await;
+        let a_sa = a.socket_addr().unwrap();
+        let b_sa = b.socket_addr().unwrap();
+        assert_eq!(selected.len(), 2);
+        assert!(selected.contains(&a_sa) && selected.contains(&b_sa));
+    }
+
+    #[tokio::test]
+    async fn test_select_returns_empty_when_all_filtered() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+
+        let incapable = addr_msg("10.6.6.1", 9999, ServiceFlags::NETWORK, now);
+        let required =
+            RequiredServices::from_flags(ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS);
+
+        let selected = manager.select_best_peers(required, vec![incapable], 5).await;
+        assert!(selected.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_select_does_not_exceed_requested_count() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+
+        let msgs: Vec<AddrV2Message> = (0..10)
+            .map(|i| addr_msg(&format!("10.7.7.{i}"), 9999, ServiceFlags::NETWORK, now))
+            .collect();
+
+        let selected = manager.select_best_peers(network_required(), msgs, 3).await;
+        assert_eq!(selected.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_select_zero_count_returns_empty() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+
+        let msgs = vec![addr_msg("10.8.8.1", 9999, ServiceFlags::NETWORK, now)];
+        let selected = manager.select_best_peers(network_required(), msgs, 0).await;
+        assert!(selected.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_select_filters_out_banned_peers() {
+        let manager = PeerReputationManager::new();
+        let now = now_epoch_secs();
+        let banned_addr: SocketAddr = "10.9.9.1:9999".parse().unwrap();
+        let good_addr: SocketAddr = "10.9.9.2:9999".parse().unwrap();
+
+        // Push score past ban threshold.
+        manager
+            .update_reputation(banned_addr, misbehavior_scores::INVALID_MESSAGE * 10, "bad")
+            .await;
+        assert!(manager.is_banned(&banned_addr).await);
+
+        let msgs = vec![
+            addr_msg("10.9.9.1", 9999, ServiceFlags::NETWORK, now),
+            addr_msg("10.9.9.2", 9999, ServiceFlags::NETWORK, now),
+        ];
+        let selected = manager.select_best_peers(network_required(), msgs, 10).await;
+        assert_eq!(selected, vec![good_addr]);
     }
 
     fn rep_with_streak(failures: u32, last_tried: Option<SystemTime>) -> PeerReputation {

--- a/dash-spv/src/network/required_services.rs
+++ b/dash-spv/src/network/required_services.rs
@@ -1,0 +1,128 @@
+//! Capability requirements derived from the client configuration.
+//!
+//! `RequiredServices` captures the minimum set of peer service flags that the
+//! client needs in order to make progress with its configured sync mode. It is
+//! built once from `ClientConfig` at startup and consulted by peer selection to
+//! hard-filter incapable peers.
+
+use dashcore::network::constants::ServiceFlags;
+
+use crate::client::config::{ClientConfig, MempoolStrategy};
+
+/// Capabilities a peer must advertise to be usable for this client's sync mode.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) struct RequiredServices(ServiceFlags);
+
+impl RequiredServices {
+    /// Derive the required service flags from the client's configuration.
+    ///
+    /// `NETWORK` is always required. `COMPACT_FILTERS` is required when
+    /// filter sync is enabled. `BLOOM` is required when mempool tracking uses
+    /// the BIP37 bloom-filter strategy.
+    pub(crate) fn from_config(config: &ClientConfig) -> Self {
+        let mut flags = ServiceFlags::NETWORK;
+        if config.enable_filters {
+            flags |= ServiceFlags::COMPACT_FILTERS;
+        }
+        if config.enable_mempool_tracking
+            && matches!(config.mempool_strategy, MempoolStrategy::BloomFilter)
+        {
+            flags |= ServiceFlags::BLOOM;
+        }
+        Self(flags)
+    }
+
+    /// Construct directly from raw service flags. Intended for tests.
+    #[cfg(test)]
+    pub(crate) fn from_flags(flags: ServiceFlags) -> Self {
+        Self(flags)
+    }
+
+    /// True if `peer_services` covers every required flag.
+    pub(crate) fn is_satisfied_by(self, peer_services: ServiceFlags) -> bool {
+        peer_services.has(self.0)
+    }
+
+    /// Return the underlying flags. Intended for tests.
+    #[cfg(test)]
+    pub(crate) fn flags(self) -> ServiceFlags {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_config_always_includes_network() {
+        let mut config = ClientConfig::mainnet();
+        config.enable_filters = false;
+        config.enable_mempool_tracking = false;
+
+        let required = RequiredServices::from_config(&config);
+        assert!(required.is_satisfied_by(ServiceFlags::NETWORK));
+        assert!(!required.is_satisfied_by(ServiceFlags::NONE));
+    }
+
+    #[test]
+    fn from_config_adds_compact_filters_when_filters_enabled() {
+        let mut config = ClientConfig::mainnet();
+        config.enable_filters = true;
+        config.enable_mempool_tracking = false;
+
+        let required = RequiredServices::from_config(&config);
+        assert!(!required.is_satisfied_by(ServiceFlags::NETWORK));
+        assert!(required.is_satisfied_by(ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS));
+    }
+
+    #[test]
+    fn from_config_adds_bloom_only_for_bloom_mempool_strategy() {
+        let mut config = ClientConfig::mainnet();
+        config.enable_filters = false;
+
+        config.enable_mempool_tracking = true;
+        config.mempool_strategy = MempoolStrategy::FetchAll;
+        let fetch_all = RequiredServices::from_config(&config);
+        assert!(fetch_all.is_satisfied_by(ServiceFlags::NETWORK));
+        assert!(!fetch_all.flags().has(ServiceFlags::BLOOM));
+
+        config.mempool_strategy = MempoolStrategy::BloomFilter;
+        let bloom = RequiredServices::from_config(&config);
+        assert!(!bloom.is_satisfied_by(ServiceFlags::NETWORK));
+        assert!(bloom.is_satisfied_by(ServiceFlags::NETWORK | ServiceFlags::BLOOM));
+    }
+
+    #[test]
+    fn from_config_skips_bloom_when_mempool_tracking_disabled() {
+        let mut config = ClientConfig::mainnet();
+        config.enable_filters = false;
+        config.enable_mempool_tracking = false;
+        config.mempool_strategy = MempoolStrategy::BloomFilter;
+
+        let required = RequiredServices::from_config(&config);
+        assert!(!required.flags().has(ServiceFlags::BLOOM));
+    }
+
+    #[test]
+    fn from_config_combines_all_requirements() {
+        let mut config = ClientConfig::mainnet();
+        config.enable_filters = true;
+        config.enable_mempool_tracking = true;
+        config.mempool_strategy = MempoolStrategy::BloomFilter;
+
+        let required = RequiredServices::from_config(&config);
+        let full = ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS | ServiceFlags::BLOOM;
+        assert!(required.is_satisfied_by(full));
+        assert!(!required.is_satisfied_by(ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS));
+        assert!(!required.is_satisfied_by(ServiceFlags::NETWORK | ServiceFlags::BLOOM));
+    }
+
+    #[test]
+    fn preferred_bonus_is_not_required() {
+        let config = ClientConfig::mainnet();
+        let required = RequiredServices::from_config(&config);
+        // NODE_HEADERS_COMPRESSED is a preferred bonus, never in the required set.
+        assert!(!required.flags().has(ServiceFlags::NODE_HEADERS_COMPRESSED));
+    }
+}

--- a/dash-spv/tests/dashd_sync/setup.rs
+++ b/dash-spv/tests/dashd_sync/setup.rs
@@ -396,11 +396,18 @@ pub(super) async fn create_non_exclusive_test_config(
     peer_addr: std::net::SocketAddr,
 ) -> ClientConfig {
     let config = ClientConfig::regtest().with_storage_path(storage_path).without_masternodes();
-    // Seed the peer store so the client can discover our dashd node
+    // Seed the peer store so the client can discover our dashd node. Use the
+    // full regtest service flags so the peer survives the `RequiredServices`
+    // hard-filter in `select_best_peers`. Real services are re-learned via
+    // `addrv2_handler.mark_seen` after handshake; the seed only needs to be
+    // good enough to pass selection.
     let peer_store = PersistentPeerStorage::open(config.storage_path.clone())
         .await
         .expect("Failed to open peer storage");
-    let msg = AddrV2Message::new(peer_addr, ServiceFlags::NETWORK);
+    let msg = AddrV2Message::new(
+        peer_addr,
+        ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS,
+    );
     peer_store.save_peers(&[msg]).await.expect("Failed to seed peer store");
     config
 }

--- a/dash-spv/tests/dashd_sync/setup.rs
+++ b/dash-spv/tests/dashd_sync/setup.rs
@@ -404,10 +404,7 @@ pub(super) async fn create_non_exclusive_test_config(
     let peer_store = PersistentPeerStorage::open(config.storage_path.clone())
         .await
         .expect("Failed to open peer storage");
-    let msg = AddrV2Message::new(
-        peer_addr,
-        ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS,
-    );
+    let msg = AddrV2Message::new(peer_addr, ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS);
     peer_store.save_peers(&[msg]).await.expect("Failed to seed peer store");
     config
 }


### PR DESCRIPTION
## Summary

- Adds `RequiredServices` derived from `ClientConfig` at client startup (always `NETWORK`, plus `COMPACT_FILTERS` when filter sync is enabled, plus `BLOOM` when bloom-filter sync is enabled). Threaded into `PeerNetworkManager`.
- Replaces misbehavior-score-only `select_best_peers` with a tiered, capability-aware selector: hard-filters stored peers by required services, by exponential-backoff cooldown (30s → 1m → 5m → 30m → 2h keyed on `consecutive_failures` and `last_tried`), and by ban status. Remaining candidates are ranked by a single composite score combining reputation, success ratio, `AddrV2.time` staleness, and a `NODE_HEADERS_COMPRESSED` preferred-services bonus. When nothing survives the filters, the selection returns empty so DNS discovery can take over on the next tick.
- 24 new unit tests covering each filter, each ranking factor, ties, empty-after-filter, zero-count, and the cooldown steps.

Foundational work for #105 (capability-driven churn in the maintenance loop) which will also consume `RequiredServices`.

Closes #104

Part of #102