### PR TITLE
refactor: make wallet events atomic

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: xdustinface/manki@v4
+      - uses: manki-review/manki@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -1,0 +1,29 @@
+name: Manki Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+concurrency:
+  group: manki-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: xdustinface/manki@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.manki.yml
+++ b/.manki.yml
@@ -1,0 +1,18 @@
+# Manki — AI Code Review Configuration
+# https://github.com/xdustinface/manki
+
+auto_review: true
+auto_approve: true
+
+exclude_paths:
+  - "*.lock"
+  - "fuzz/**"
+
+instructions: |
+  This is a Rust implementation of the Dash cryptocurrency protocol.
+  Pay special attention to:
+  - Consensus-critical code paths — changes here can cause chain splits
+  - FFI safety for C/Swift bindings in dash-spv-* crates
+  - Proper error handling — prefer Result over unwrap/expect in library code
+  - DIP (Dash Improvement Proposal) compliance for protocol changes
+  - Memory safety in hash/crypto implementations

--- a/.manki.yml
+++ b/.manki.yml
@@ -1,5 +1,5 @@
 # Manki — AI Code Review Configuration
-# https://github.com/xdustinface/manki
+# https://github.com/manki-review/manki
 
 auto_review: true
 auto_approve: true

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -167,10 +167,10 @@ fn short_wallet(wallet_id: *const c_char) -> String {
 
 fn read_balance(balance: *const FFIBalance) -> FFIBalance {
     if balance.is_null() {
-        FFIBalance::default()
-    } else {
-        unsafe { *balance }
+        tracing::warn!("read_balance: null pointer, returning zero balance");
+        return FFIBalance::default();
     }
+    unsafe { *balance }
 }
 
 extern "C" fn on_mempool_transaction_received(

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -6,7 +6,7 @@ use clap::{Arg, ArgAction, Command};
 use dash_network::ffi::FFINetwork;
 use dash_spv_ffi::*;
 use key_wallet_ffi::managed_account::FFITransactionRecord;
-use key_wallet_ffi::types::FFITransactionContext;
+use key_wallet_ffi::types::FFIBalance;
 use key_wallet_ffi::wallet_manager::wallet_manager_add_wallet_from_mnemonic;
 use key_wallet_ffi::FFIError;
 
@@ -156,61 +156,88 @@ extern "C" fn on_peers_updated(connected_count: u32, best_height: u32, _user_dat
 // Wallet Event Callbacks
 // ============================================================================
 
-extern "C" fn on_transaction_received(
+fn short_wallet(wallet_id: *const c_char) -> String {
+    let s = ffi_string_to_rust(wallet_id);
+    if s.len() > 8 {
+        s[..8].to_string()
+    } else {
+        s
+    }
+}
+
+fn read_balance(balance: *const FFIBalance) -> FFIBalance {
+    if balance.is_null() {
+        FFIBalance::default()
+    } else {
+        unsafe { *balance }
+    }
+}
+
+extern "C" fn on_mempool_transaction_received(
     wallet_id: *const c_char,
-    account_index: u32,
+    account_path: *const c_char,
     record: *const FFITransactionRecord,
+    balance: *const FFIBalance,
     _user_data: *mut c_void,
 ) {
-    let wallet_str = ffi_string_to_rust(wallet_id);
-    let wallet_short = if wallet_str.len() > 8 {
-        &wallet_str[..8]
-    } else {
-        &wallet_str
-    };
+    let wallet_short = short_wallet(wallet_id);
+    let path_str = ffi_string_to_rust(account_path);
     if record.is_null() {
         println!(
-            "[Wallet] TX received: wallet={}..., account={}, record=null",
-            wallet_short, account_index
+            "[Wallet] Mempool TX received: wallet={}..., account={}, record=null",
+            wallet_short, path_str
         );
         return;
     }
     let r = unsafe { &*record };
+    let b = read_balance(balance);
     let txid_hex = hex::encode(r.txid);
     println!(
-        "[Wallet] TX received: wallet={}..., txid={}, account={}, amount={} duffs, tx_size={}",
-        wallet_short, txid_hex, account_index, r.net_amount, r.tx_len
+        "[Wallet] Mempool TX received: wallet={}..., txid={}, account={}, amount={} duffs, balance[confirmed={}, unconfirmed={}]",
+        wallet_short, txid_hex, path_str, r.net_amount, b.confirmed, b.unconfirmed
     );
 }
 
-extern "C" fn on_transaction_status_changed(
-    _wallet_id: *const c_char,
-    txid: *const [u8; 32],
-    status: FFITransactionContext,
-    _user_data: *mut c_void,
-) {
-    let txid_hex = unsafe { hex::encode(*txid) };
-    println!("[Wallet] TX status changed: txid={}, status={:?}", txid_hex, status);
-}
-
-extern "C" fn on_balance_updated(
+extern "C" fn on_transaction_instant_send_locked(
     wallet_id: *const c_char,
-    spendable: u64,
-    unconfirmed: u64,
-    immature: u64,
-    locked: u64,
+    txid: *const [u8; 32],
+    _islock_data: *const u8,
+    _islock_len: usize,
+    balance: *const FFIBalance,
     _user_data: *mut c_void,
 ) {
-    let wallet_str = ffi_string_to_rust(wallet_id);
-    let wallet_short = if wallet_str.len() > 8 {
-        &wallet_str[..8]
-    } else {
-        &wallet_str
-    };
+    let wallet_short = short_wallet(wallet_id);
+    let txid_hex = unsafe { hex::encode(*txid) };
+    let b = read_balance(balance);
     println!(
-        "[Wallet] Balance updated: wallet={}..., spendable={}, unconfirmed={}, immature={}, locked={}",
-        wallet_short, spendable, unconfirmed, immature, locked
+        "[Wallet] IS lock: wallet={}..., txid={}, balance[confirmed={}]",
+        wallet_short, txid_hex, b.confirmed
     );
+}
+
+extern "C" fn on_block_process_change(
+    wallet_id: *const c_char,
+    height: u32,
+    _updates: *const FFIBlockRecordUpdate,
+    update_count: u32,
+    balance: *const FFIBalance,
+    _user_data: *mut c_void,
+) {
+    let wallet_short = short_wallet(wallet_id);
+    let b = read_balance(balance);
+    println!(
+        "[Wallet] Block processed: wallet={}..., height={}, updates={}, balance[confirmed={}, unconfirmed={}, immature={}, locked={}]",
+        wallet_short, height, update_count, b.confirmed, b.unconfirmed, b.immature, b.locked
+    );
+}
+
+extern "C" fn on_synced_height_updated(
+    wallet_id: *const c_char,
+    height: u32,
+    _user_data: *mut c_void,
+) {
+    let wallet_short = short_wallet(wallet_id);
+    println!("[Wallet] Synced height updated: wallet={}..., height={}", wallet_short, height);
 }
 
 // ============================================================================
@@ -434,9 +461,10 @@ fn main() {
                 user_data: ptr::null_mut(),
             },
             wallet: FFIWalletEventCallbacks {
-                on_transaction_received: Some(on_transaction_received),
-                on_transaction_status_changed: Some(on_transaction_status_changed),
-                on_balance_updated: Some(on_balance_updated),
+                on_mempool_transaction_received: Some(on_mempool_transaction_received),
+                on_transaction_instant_send_locked: Some(on_transaction_instant_send_locked),
+                on_block_process_change: Some(on_block_process_change),
+                on_synced_height_updated: Some(on_synced_height_updated),
                 user_data: ptr::null_mut(),
             },
             error: FFIClientErrorCallback {

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -174,25 +174,25 @@ fn read_balance(balance: *const FFIBalance) -> FFIBalance {
 
 extern "C" fn on_transaction_received(
     wallet_id: *const c_char,
-    change: *const FFIRecordChange,
+    update: *const FFITransactionRecordUpdate,
     balance: *const FFIBalance,
     _user_data: *mut c_void,
 ) {
     let wallet_short = short_wallet(wallet_id);
-    if change.is_null() {
-        println!("[Wallet] TX received: wallet={}..., change=null", wallet_short);
+    if update.is_null() {
+        println!("[Wallet] TX received: wallet={}..., update=null", wallet_short);
         return;
     }
-    let c = unsafe { &*change };
+    let u = unsafe { &*update };
     let b = read_balance(balance);
-    let txid_hex = hex::encode(c.record.txid);
+    let txid_hex = hex::encode(u.record.txid);
     println!(
         "[Wallet] TX received: wallet={}..., txid={}, account_type={:?}, account_index={}, amount={} duffs, balance[confirmed={}, unconfirmed={}]",
         wallet_short,
         txid_hex,
-        c.account_type,
-        c.account_index,
-        c.record.net_amount,
+        u.record.account_type,
+        u.record.account_index,
+        u.record.net_amount,
         b.confirmed,
         b.unconfirmed
     );
@@ -218,16 +218,16 @@ extern "C" fn on_transaction_instant_send_locked(
 extern "C" fn on_wallet_block_processed(
     wallet_id: *const c_char,
     height: u32,
-    _changes: *const FFIRecordChange,
-    change_count: u32,
+    _updates: *const FFITransactionRecordUpdate,
+    update_count: u32,
     balance: *const FFIBalance,
     _user_data: *mut c_void,
 ) {
     let wallet_short = short_wallet(wallet_id);
     let b = read_balance(balance);
     println!(
-        "[Wallet] Block processed: wallet={}..., height={}, changes={}, balance[confirmed={}, unconfirmed={}, immature={}, locked={}]",
-        wallet_short, height, change_count, b.confirmed, b.unconfirmed, b.immature, b.locked
+        "[Wallet] Block processed: wallet={}..., height={}, updates={}, balance[confirmed={}, unconfirmed={}, immature={}, locked={}]",
+        wallet_short, height, update_count, b.confirmed, b.unconfirmed, b.immature, b.locked
     );
 }
 

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -5,7 +5,6 @@ use std::ptr;
 use clap::{Arg, ArgAction, Command};
 use dash_network::ffi::FFINetwork;
 use dash_spv_ffi::*;
-use key_wallet_ffi::managed_account::FFITransactionRecord;
 use key_wallet_ffi::types::FFIBalance;
 use key_wallet_ffi::wallet_manager::wallet_manager_add_wallet_from_mnemonic;
 use key_wallet_ffi::FFIError;
@@ -173,28 +172,29 @@ fn read_balance(balance: *const FFIBalance) -> FFIBalance {
     unsafe { *balance }
 }
 
-extern "C" fn on_mempool_transaction_received(
+extern "C" fn on_transaction_received(
     wallet_id: *const c_char,
-    account_path: *const c_char,
-    record: *const FFITransactionRecord,
+    change: *const FFIRecordChange,
     balance: *const FFIBalance,
     _user_data: *mut c_void,
 ) {
     let wallet_short = short_wallet(wallet_id);
-    let path_str = ffi_string_to_rust(account_path);
-    if record.is_null() {
-        println!(
-            "[Wallet] Mempool TX received: wallet={}..., account={}, record=null",
-            wallet_short, path_str
-        );
+    if change.is_null() {
+        println!("[Wallet] TX received: wallet={}..., change=null", wallet_short);
         return;
     }
-    let r = unsafe { &*record };
+    let c = unsafe { &*change };
     let b = read_balance(balance);
-    let txid_hex = hex::encode(r.txid);
+    let txid_hex = hex::encode(c.record.txid);
     println!(
-        "[Wallet] Mempool TX received: wallet={}..., txid={}, account={}, amount={} duffs, balance[confirmed={}, unconfirmed={}]",
-        wallet_short, txid_hex, path_str, r.net_amount, b.confirmed, b.unconfirmed
+        "[Wallet] TX received: wallet={}..., txid={}, account_type={:?}, account_index={}, amount={} duffs, balance[confirmed={}, unconfirmed={}]",
+        wallet_short,
+        txid_hex,
+        c.account_type,
+        c.account_index,
+        c.record.net_amount,
+        b.confirmed,
+        b.unconfirmed
     );
 }
 
@@ -215,19 +215,19 @@ extern "C" fn on_transaction_instant_send_locked(
     );
 }
 
-extern "C" fn on_block_process_change(
+extern "C" fn on_wallet_block_processed(
     wallet_id: *const c_char,
     height: u32,
-    _updates: *const FFIBlockRecordUpdate,
-    update_count: u32,
+    _changes: *const FFIRecordChange,
+    change_count: u32,
     balance: *const FFIBalance,
     _user_data: *mut c_void,
 ) {
     let wallet_short = short_wallet(wallet_id);
     let b = read_balance(balance);
     println!(
-        "[Wallet] Block processed: wallet={}..., height={}, updates={}, balance[confirmed={}, unconfirmed={}, immature={}, locked={}]",
-        wallet_short, height, update_count, b.confirmed, b.unconfirmed, b.immature, b.locked
+        "[Wallet] Block processed: wallet={}..., height={}, changes={}, balance[confirmed={}, unconfirmed={}, immature={}, locked={}]",
+        wallet_short, height, change_count, b.confirmed, b.unconfirmed, b.immature, b.locked
     );
 }
 
@@ -461,9 +461,9 @@ fn main() {
                 user_data: ptr::null_mut(),
             },
             wallet: FFIWalletEventCallbacks {
-                on_mempool_transaction_received: Some(on_mempool_transaction_received),
+                on_transaction_received: Some(on_transaction_received),
                 on_transaction_instant_send_locked: Some(on_transaction_instant_send_locked),
-                on_block_process_change: Some(on_block_process_change),
+                on_block_processed: Some(on_wallet_block_processed),
                 on_synced_height_updated: Some(on_synced_height_updated),
                 user_data: ptr::null_mut(),
             },

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -11,11 +11,8 @@ use dash_spv::network::NetworkEvent;
 use dash_spv::sync::{SyncEvent, SyncProgress};
 use dash_spv::EventHandler;
 use dashcore::hashes::Hash;
-use key_wallet::account::StandardAccountType;
-use key_wallet::AccountType;
-use key_wallet_ffi::managed_account::FFITransactionRecord;
-use key_wallet_ffi::types::FFIBalance;
-use key_wallet_manager::{RecordAction, TransactionRecordUpdate, WalletEvent};
+use key_wallet_ffi::types::{FFIBalance, FFITransactionRecordUpdate};
+use key_wallet_manager::WalletEvent;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 use std::ptr;
@@ -532,156 +529,6 @@ impl FFINetworkEventCallbacks {
 // FFIWalletEventCallbacks - One callback per WalletEvent variant
 // ============================================================================
 
-/// Whether a record is newly stored or updates a previously stored record.
-#[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FFIRecordAction {
-    /// The record is new (first time stored for this wallet).
-    Inserted = 0,
-    /// The record was already stored and has been updated.
-    Updated = 1,
-}
-
-impl From<RecordAction> for FFIRecordAction {
-    fn from(action: RecordAction) -> Self {
-        match action {
-            RecordAction::Inserted => FFIRecordAction::Inserted,
-            RecordAction::Updated => FFIRecordAction::Updated,
-        }
-    }
-}
-
-/// Discriminant identifying a wallet account. Mirrors `key_wallet::AccountType`
-/// for FFI consumption. Combined with `account_index` it identifies the
-/// account that owns a record without forcing consumers to parse derivation
-/// path strings. The full BIP-32 path is recoverable from
-/// `(account_type, account_index, network)` via `AccountType::derivation_path`.
-///
-/// Variants that carry extra payload in the Rust enum (`DashpayReceivingFunds`
-/// / `DashpayExternalAccount` carry identity IDs, `PlatformPayment` carries a
-/// `key_class`) are reported here as discriminant + primary index only; the
-/// extra fields are not exposed at the FFI boundary.
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FFIAccountType {
-    /// `AccountType::Standard { standard_account_type: BIP44Account, .. }`.
-    /// `account_index` carries the BIP-44 account index.
-    StandardBIP44 = 0,
-    /// `AccountType::Standard { standard_account_type: BIP32Account, .. }`.
-    /// `account_index` carries the BIP-32 account index.
-    StandardBIP32 = 1,
-    /// `AccountType::CoinJoin { index }`. `account_index` carries `index`.
-    CoinJoin = 2,
-    /// `AccountType::IdentityRegistration`. No index.
-    IdentityRegistration = 3,
-    /// `AccountType::IdentityTopUp { registration_index }`.
-    /// `account_index` carries `registration_index`.
-    IdentityTopUp = 4,
-    /// `AccountType::IdentityTopUpNotBoundToIdentity`. No index.
-    IdentityTopUpNotBoundToIdentity = 5,
-    /// `AccountType::IdentityInvitation`. No index.
-    IdentityInvitation = 6,
-    /// `AccountType::AssetLockAddressTopUp`. No index.
-    AssetLockAddressTopUp = 7,
-    /// `AccountType::AssetLockShieldedAddressTopUp`. No index.
-    AssetLockShieldedAddressTopUp = 8,
-    /// `AccountType::ProviderVotingKeys`. No index.
-    ProviderVotingKeys = 9,
-    /// `AccountType::ProviderOwnerKeys`. No index.
-    ProviderOwnerKeys = 10,
-    /// `AccountType::ProviderOperatorKeys`. No index.
-    ProviderOperatorKeys = 11,
-    /// `AccountType::ProviderPlatformKeys`. No index.
-    ProviderPlatformKeys = 12,
-    /// `AccountType::DashpayReceivingFunds { index, .. }`. `account_index`
-    /// carries `index`. Identity IDs are not exposed here.
-    DashpayReceivingFunds = 13,
-    /// `AccountType::DashpayExternalAccount { index, .. }`. `account_index`
-    /// carries `index`. Identity IDs are not exposed here.
-    DashpayExternalAccount = 14,
-    /// `AccountType::PlatformPayment { account, .. }`. `account_index`
-    /// carries `account`; `key_class` is not exposed here.
-    PlatformPayment = 15,
-}
-
-impl FFIAccountType {
-    /// Decompose an `AccountType` into `(discriminant, account_index)`.
-    /// `account_index` is `-1` for variants without a meaningful primary index.
-    fn from_account_type(account_type: &AccountType) -> (Self, i32) {
-        match *account_type {
-            AccountType::Standard {
-                index,
-                standard_account_type: StandardAccountType::BIP44Account,
-            } => (FFIAccountType::StandardBIP44, index as i32),
-            AccountType::Standard {
-                index,
-                standard_account_type: StandardAccountType::BIP32Account,
-            } => (FFIAccountType::StandardBIP32, index as i32),
-            AccountType::CoinJoin {
-                index,
-            } => (FFIAccountType::CoinJoin, index as i32),
-            AccountType::IdentityRegistration => (FFIAccountType::IdentityRegistration, -1),
-            AccountType::IdentityTopUp {
-                registration_index,
-            } => (FFIAccountType::IdentityTopUp, registration_index as i32),
-            AccountType::IdentityTopUpNotBoundToIdentity => {
-                (FFIAccountType::IdentityTopUpNotBoundToIdentity, -1)
-            }
-            AccountType::IdentityInvitation => (FFIAccountType::IdentityInvitation, -1),
-            AccountType::AssetLockAddressTopUp => (FFIAccountType::AssetLockAddressTopUp, -1),
-            AccountType::AssetLockShieldedAddressTopUp => {
-                (FFIAccountType::AssetLockShieldedAddressTopUp, -1)
-            }
-            AccountType::ProviderVotingKeys => (FFIAccountType::ProviderVotingKeys, -1),
-            AccountType::ProviderOwnerKeys => (FFIAccountType::ProviderOwnerKeys, -1),
-            AccountType::ProviderOperatorKeys => (FFIAccountType::ProviderOperatorKeys, -1),
-            AccountType::ProviderPlatformKeys => (FFIAccountType::ProviderPlatformKeys, -1),
-            AccountType::DashpayReceivingFunds {
-                index,
-                ..
-            } => (FFIAccountType::DashpayReceivingFunds, index as i32),
-            AccountType::DashpayExternalAccount {
-                index,
-                ..
-            } => (FFIAccountType::DashpayExternalAccount, index as i32),
-            AccountType::PlatformPayment {
-                account,
-                ..
-            } => (FFIAccountType::PlatformPayment, account as i32),
-        }
-    }
-}
-
-/// FFI-friendly form of `TransactionRecordUpdate`: a `TransactionRecord`
-/// paired with the account it belongs to and whether it is a fresh insertion
-/// or an update to an existing record. Used as a single value by
-/// `on_transaction_received` and as an array element by `on_block_processed`.
-#[repr(C)]
-pub struct FFIRecordChange {
-    /// Discriminant identifying the account variant (see `FFIAccountType`).
-    pub account_type: FFIAccountType,
-    /// Primary account index for this variant, or `-1` for variants without
-    /// one (Identity*, Provider*, AssetLock*).
-    pub account_index: i32,
-    /// Whether the record is new or an update to a previously stored one.
-    pub action: FFIRecordAction,
-    /// The transaction record.
-    pub record: FFITransactionRecord,
-}
-
-impl FFIRecordChange {
-    fn from_record_update(update: &TransactionRecordUpdate) -> Self {
-        let (account_type, account_index) =
-            FFIAccountType::from_account_type(&update.record.account_type);
-        Self {
-            account_type,
-            account_index,
-            action: FFIRecordAction::from(update.action),
-            record: FFITransactionRecord::from(&update.record),
-        }
-    }
-}
-
 /// Callback for `WalletEvent::TransactionReceived`.
 ///
 /// Fires when a wallet-relevant transaction is first seen off-chain — either
@@ -695,7 +542,7 @@ impl FFIRecordChange {
 pub type OnTransactionReceivedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
-        update: *const FFIRecordChange,
+        update: *const FFITransactionRecordUpdate,
         balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
@@ -720,10 +567,10 @@ pub type OnTransactionInstantSendLockedCallback = Option<
 /// Callback for `WalletEvent::BlockProcessed`.
 ///
 /// Fires once per wallet affected by a processed block. `updates` points to
-/// an array of `update_count` `FFIRecordChange` entries covering records
-/// newly recorded or updated by this block. The array may be empty (and
-/// `updates` will be null) when only the wallet's balance shifted (e.g. a
-/// coinbase maturing). `balance` is the wallet's balance *after* the block
+/// an array of `update_count` `FFITransactionRecordUpdate` entries covering
+/// records newly recorded or updated by this block. The array may be empty
+/// (and `updates` will be null) when only the wallet's balance shifted (e.g.
+/// a coinbase maturing). `balance` is the wallet's balance *after* the block
 /// was processed.
 ///
 /// The `updates` array and all its contents are borrowed and only valid for
@@ -732,7 +579,7 @@ pub type OnWalletBlockProcessedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
         height: u32,
-        updates: *const FFIRecordChange,
+        updates: *const FFITransactionRecordUpdate,
         update_count: u32,
         balance: *const FFIBalance,
         user_data: *mut c_void,
@@ -878,12 +725,12 @@ impl FFIWalletEventCallbacks {
                 if let Some(cb) = self.on_transaction_received {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
-                    let ffi_update = FFIRecordChange::from_record_update(update.as_ref());
+                    let ffi_update = FFITransactionRecordUpdate::from(update.as_ref());
                     let ffi_balance = FFIBalance::from(*balance);
 
                     cb(
                         c_wallet_id.as_ptr(),
-                        &ffi_update as *const FFIRecordChange,
+                        &ffi_update as *const FFITransactionRecordUpdate,
                         &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
@@ -921,8 +768,8 @@ impl FFIWalletEventCallbacks {
                 if let Some(cb) = self.on_block_processed {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
-                    let ffi_updates: Vec<FFIRecordChange> =
-                        updates.iter().map(FFIRecordChange::from_record_update).collect();
+                    let ffi_updates: Vec<FFITransactionRecordUpdate> =
+                        updates.iter().map(FFITransactionRecordUpdate::from).collect();
                     let ffi_balance = FFIBalance::from(*balance);
 
                     // Pass a null `updates` pointer when the array is empty so

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -15,7 +15,7 @@ use key_wallet::account::StandardAccountType;
 use key_wallet::AccountType;
 use key_wallet_ffi::managed_account::FFITransactionRecord;
 use key_wallet_ffi::types::FFIBalance;
-use key_wallet_manager::{RecordAction, RecordChange, WalletEvent};
+use key_wallet_manager::{RecordAction, TransactionRecordUpdate, WalletEvent};
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 use std::ptr;
@@ -652,10 +652,10 @@ impl FFIAccountType {
     }
 }
 
-/// FFI-friendly form of `RecordChange`: a `TransactionRecord` paired with the
-/// account it belongs to and whether it is a fresh insertion or an update to
-/// an existing record. Used as a single value by `on_transaction_received`
-/// and as an array element by `on_block_processed`.
+/// FFI-friendly form of `TransactionRecordUpdate`: a `TransactionRecord`
+/// paired with the account it belongs to and whether it is a fresh insertion
+/// or an update to an existing record. Used as a single value by
+/// `on_transaction_received` and as an array element by `on_block_processed`.
 #[repr(C)]
 pub struct FFIRecordChange {
     /// Discriminant identifying the account variant (see `FFIAccountType`).
@@ -670,13 +670,14 @@ pub struct FFIRecordChange {
 }
 
 impl FFIRecordChange {
-    fn from_record_change(change: &RecordChange) -> Self {
-        let (account_type, account_index) = FFIAccountType::from_account_type(&change.account_type);
+    fn from_record_update(update: &TransactionRecordUpdate) -> Self {
+        let (account_type, account_index) =
+            FFIAccountType::from_account_type(&update.record.account_type);
         Self {
             account_type,
             account_index,
-            action: FFIRecordAction::from(change.action),
-            record: FFITransactionRecord::from(&change.record),
+            action: FFIRecordAction::from(update.action),
+            record: FFITransactionRecord::from(&update.record),
         }
     }
 }
@@ -685,7 +686,7 @@ impl FFIRecordChange {
 ///
 /// Fires when a wallet-relevant transaction is first seen off-chain — either
 /// in the mempool, or directly via an InstantSend lock (in that case the
-/// record's `context` is `InstantSend(..)`). `change.action` is always
+/// record's `context` is `InstantSend(..)`). `update.action` is always
 /// `Inserted` for this callback.
 ///
 /// All pointer parameters are borrowed and only valid for the duration of the
@@ -694,7 +695,7 @@ impl FFIRecordChange {
 pub type OnTransactionReceivedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
-        change: *const FFIRecordChange,
+        update: *const FFIRecordChange,
         balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
@@ -718,21 +719,21 @@ pub type OnTransactionInstantSendLockedCallback = Option<
 
 /// Callback for `WalletEvent::BlockProcessed`.
 ///
-/// Fires once per wallet affected by a processed block. `changes` points to
-/// an array of `change_count` `FFIRecordChange` entries covering records
+/// Fires once per wallet affected by a processed block. `updates` points to
+/// an array of `update_count` `FFIRecordChange` entries covering records
 /// newly recorded or updated by this block. The array may be empty (and
-/// `changes` will be null) when only the wallet's balance shifted (e.g. a
+/// `updates` will be null) when only the wallet's balance shifted (e.g. a
 /// coinbase maturing). `balance` is the wallet's balance *after* the block
 /// was processed.
 ///
-/// The `changes` array and all its contents are borrowed and only valid for
+/// The `updates` array and all its contents are borrowed and only valid for
 /// the duration of the callback.
 pub type OnWalletBlockProcessedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
         height: u32,
-        changes: *const FFIRecordChange,
-        change_count: u32,
+        updates: *const FFIRecordChange,
+        update_count: u32,
         balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
@@ -752,7 +753,7 @@ pub type OnSyncedHeightUpdatedCallback =
 /// Set only the callbacks you're interested in; unset callbacks will be ignored.
 ///
 /// All pointer parameters passed to callbacks (wallet IDs, txids, records,
-/// balances, changes) are borrowed and only valid for the duration of the
+/// balances, updates) are borrowed and only valid for the duration of the
 /// callback invocation. Callers must copy any data they need to retain.
 #[repr(C)]
 #[derive(Clone)]
@@ -871,18 +872,18 @@ impl FFIWalletEventCallbacks {
         match event {
             WalletEvent::TransactionReceived {
                 wallet_id,
-                change,
+                update,
                 balance,
             } => {
                 if let Some(cb) = self.on_transaction_received {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
-                    let ffi_change = FFIRecordChange::from_record_change(change.as_ref());
+                    let ffi_update = FFIRecordChange::from_record_update(update.as_ref());
                     let ffi_balance = FFIBalance::from(*balance);
 
                     cb(
                         c_wallet_id.as_ptr(),
-                        &ffi_change as *const FFIRecordChange,
+                        &ffi_update as *const FFIRecordChange,
                         &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
@@ -914,35 +915,35 @@ impl FFIWalletEventCallbacks {
             WalletEvent::BlockProcessed {
                 wallet_id,
                 height,
-                changes,
+                updates,
                 balance,
             } => {
                 if let Some(cb) = self.on_block_processed {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
-                    let ffi_changes: Vec<FFIRecordChange> =
-                        changes.iter().map(FFIRecordChange::from_record_change).collect();
+                    let ffi_updates: Vec<FFIRecordChange> =
+                        updates.iter().map(FFIRecordChange::from_record_update).collect();
                     let ffi_balance = FFIBalance::from(*balance);
 
-                    // Pass a null `changes` pointer when the array is empty so
+                    // Pass a null `updates` pointer when the array is empty so
                     // C/Swift consumers that null-check before reading don't
                     // see a non-null dangling pointer paired with a zero count.
-                    let changes_ptr = if ffi_changes.is_empty() {
+                    let updates_ptr = if ffi_updates.is_empty() {
                         ptr::null()
                     } else {
-                        ffi_changes.as_ptr()
+                        ffi_updates.as_ptr()
                     };
 
                     cb(
                         c_wallet_id.as_ptr(),
                         *height,
-                        changes_ptr,
-                        ffi_changes.len() as u32,
+                        updates_ptr,
+                        ffi_updates.len() as u32,
                         &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
 
-                    drop(ffi_changes);
+                    drop(ffi_updates);
                 }
             }
             WalletEvent::SyncedHeightUpdated {

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -11,9 +11,11 @@ use dash_spv::network::NetworkEvent;
 use dash_spv::sync::{SyncEvent, SyncProgress};
 use dash_spv::EventHandler;
 use dashcore::hashes::Hash;
+use key_wallet::account::StandardAccountType;
+use key_wallet::AccountType;
 use key_wallet_ffi::managed_account::FFITransactionRecord;
 use key_wallet_ffi::types::FFIBalance;
-use key_wallet_manager::{RecordAction, WalletEvent};
+use key_wallet_manager::{RecordAction, RecordChange, WalletEvent};
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 use std::ptr;
@@ -549,34 +551,150 @@ impl From<RecordAction> for FFIRecordAction {
     }
 }
 
-/// FFI-friendly form of `BlockRecordUpdate`: a `TransactionRecord` affected by
-/// a block, with its account derivation path and whether it is a fresh
-/// insertion or an update to an existing record.
+/// Discriminant identifying a wallet account. Mirrors `key_wallet::AccountType`
+/// for FFI consumption. Combined with `account_index` it identifies the
+/// account that owns a record without forcing consumers to parse derivation
+/// path strings. The full BIP-32 path is recoverable from
+/// `(account_type, account_index, network)` via `AccountType::derivation_path`.
+///
+/// Variants that carry extra payload in the Rust enum (`DashpayReceivingFunds`
+/// / `DashpayExternalAccount` carry identity IDs, `PlatformPayment` carries a
+/// `key_class`) are reported here as discriminant + primary index only; the
+/// extra fields are not exposed at the FFI boundary.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FFIAccountType {
+    /// `AccountType::Standard { standard_account_type: BIP44Account, .. }`.
+    /// `account_index` carries the BIP-44 account index.
+    StandardBIP44 = 0,
+    /// `AccountType::Standard { standard_account_type: BIP32Account, .. }`.
+    /// `account_index` carries the BIP-32 account index.
+    StandardBIP32 = 1,
+    /// `AccountType::CoinJoin { index }`. `account_index` carries `index`.
+    CoinJoin = 2,
+    /// `AccountType::IdentityRegistration`. No index.
+    IdentityRegistration = 3,
+    /// `AccountType::IdentityTopUp { registration_index }`.
+    /// `account_index` carries `registration_index`.
+    IdentityTopUp = 4,
+    /// `AccountType::IdentityTopUpNotBoundToIdentity`. No index.
+    IdentityTopUpNotBoundToIdentity = 5,
+    /// `AccountType::IdentityInvitation`. No index.
+    IdentityInvitation = 6,
+    /// `AccountType::AssetLockAddressTopUp`. No index.
+    AssetLockAddressTopUp = 7,
+    /// `AccountType::AssetLockShieldedAddressTopUp`. No index.
+    AssetLockShieldedAddressTopUp = 8,
+    /// `AccountType::ProviderVotingKeys`. No index.
+    ProviderVotingKeys = 9,
+    /// `AccountType::ProviderOwnerKeys`. No index.
+    ProviderOwnerKeys = 10,
+    /// `AccountType::ProviderOperatorKeys`. No index.
+    ProviderOperatorKeys = 11,
+    /// `AccountType::ProviderPlatformKeys`. No index.
+    ProviderPlatformKeys = 12,
+    /// `AccountType::DashpayReceivingFunds { index, .. }`. `account_index`
+    /// carries `index`. Identity IDs are not exposed here.
+    DashpayReceivingFunds = 13,
+    /// `AccountType::DashpayExternalAccount { index, .. }`. `account_index`
+    /// carries `index`. Identity IDs are not exposed here.
+    DashpayExternalAccount = 14,
+    /// `AccountType::PlatformPayment { account, .. }`. `account_index`
+    /// carries `account`; `key_class` is not exposed here.
+    PlatformPayment = 15,
+}
+
+impl FFIAccountType {
+    /// Decompose an `AccountType` into `(discriminant, account_index)`.
+    /// `account_index` is `-1` for variants without a meaningful primary index.
+    fn from_account_type(account_type: &AccountType) -> (Self, i32) {
+        match *account_type {
+            AccountType::Standard {
+                index,
+                standard_account_type: StandardAccountType::BIP44Account,
+            } => (FFIAccountType::StandardBIP44, index as i32),
+            AccountType::Standard {
+                index,
+                standard_account_type: StandardAccountType::BIP32Account,
+            } => (FFIAccountType::StandardBIP32, index as i32),
+            AccountType::CoinJoin {
+                index,
+            } => (FFIAccountType::CoinJoin, index as i32),
+            AccountType::IdentityRegistration => (FFIAccountType::IdentityRegistration, -1),
+            AccountType::IdentityTopUp {
+                registration_index,
+            } => (FFIAccountType::IdentityTopUp, registration_index as i32),
+            AccountType::IdentityTopUpNotBoundToIdentity => {
+                (FFIAccountType::IdentityTopUpNotBoundToIdentity, -1)
+            }
+            AccountType::IdentityInvitation => (FFIAccountType::IdentityInvitation, -1),
+            AccountType::AssetLockAddressTopUp => (FFIAccountType::AssetLockAddressTopUp, -1),
+            AccountType::AssetLockShieldedAddressTopUp => {
+                (FFIAccountType::AssetLockShieldedAddressTopUp, -1)
+            }
+            AccountType::ProviderVotingKeys => (FFIAccountType::ProviderVotingKeys, -1),
+            AccountType::ProviderOwnerKeys => (FFIAccountType::ProviderOwnerKeys, -1),
+            AccountType::ProviderOperatorKeys => (FFIAccountType::ProviderOperatorKeys, -1),
+            AccountType::ProviderPlatformKeys => (FFIAccountType::ProviderPlatformKeys, -1),
+            AccountType::DashpayReceivingFunds {
+                index,
+                ..
+            } => (FFIAccountType::DashpayReceivingFunds, index as i32),
+            AccountType::DashpayExternalAccount {
+                index,
+                ..
+            } => (FFIAccountType::DashpayExternalAccount, index as i32),
+            AccountType::PlatformPayment {
+                account,
+                ..
+            } => (FFIAccountType::PlatformPayment, account as i32),
+        }
+    }
+}
+
+/// FFI-friendly form of `RecordChange`: a `TransactionRecord` paired with the
+/// account it belongs to and whether it is a fresh insertion or an update to
+/// an existing record. Used as a single value by `on_transaction_received`
+/// and as an array element by `on_block_processed`.
 #[repr(C)]
-pub struct FFIBlockRecordUpdate {
-    /// Null-terminated UTF-8 BIP-32 path string identifying the account
-    /// (e.g. `"m/44'/1'/0'"`). Borrowed for the duration of the callback.
-    pub account_path: *const c_char,
+pub struct FFIRecordChange {
+    /// Discriminant identifying the account variant (see `FFIAccountType`).
+    pub account_type: FFIAccountType,
+    /// Primary account index for this variant, or `-1` for variants without
+    /// one (Identity*, Provider*, AssetLock*).
+    pub account_index: i32,
     /// Whether the record is new or an update to a previously stored one.
     pub action: FFIRecordAction,
     /// The transaction record.
     pub record: FFITransactionRecord,
 }
 
-/// Callback for `WalletEvent::MempoolTransactionReceived`.
+impl FFIRecordChange {
+    fn from_record_change(change: &RecordChange) -> Self {
+        let (account_type, account_index) = FFIAccountType::from_account_type(&change.account_type);
+        Self {
+            account_type,
+            account_index,
+            action: FFIRecordAction::from(change.action),
+            record: FFITransactionRecord::from(&change.record),
+        }
+    }
+}
+
+/// Callback for `WalletEvent::TransactionReceived`.
 ///
-/// Fires when a wallet-relevant transaction is first seen in the mempool
-/// (optionally with an InstantSend lock — in that case the record's context
-/// is `InstantSend(..)`).
+/// Fires when a wallet-relevant transaction is first seen off-chain — either
+/// in the mempool, or directly via an InstantSend lock (in that case the
+/// record's `context` is `InstantSend(..)`). `change.action` is always
+/// `Inserted` for this callback.
 ///
 /// All pointer parameters are borrowed and only valid for the duration of the
 /// callback. `balance` is the wallet's balance *after* the transaction was
 /// recorded.
-pub type OnMempoolTransactionReceivedCallback = Option<
+pub type OnTransactionReceivedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
-        account_path: *const c_char,
-        record: *const FFITransactionRecord,
+        change: *const FFIRecordChange,
         balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
@@ -598,22 +716,23 @@ pub type OnTransactionInstantSendLockedCallback = Option<
     ),
 >;
 
-/// Callback for `WalletEvent::BlockProcessChange`.
+/// Callback for `WalletEvent::BlockProcessed`.
 ///
-/// Fires once per wallet affected by a processed block. `updates` points to an
-/// array of `update_count` `FFIBlockRecordUpdate` entries covering records
-/// newly recorded or updated by this block. The array may be empty when only
-/// the wallet's balance shifted (e.g. a coinbase maturing). `balance` is the
-/// wallet's balance *after* the block was processed.
+/// Fires once per wallet affected by a processed block. `changes` points to
+/// an array of `change_count` `FFIRecordChange` entries covering records
+/// newly recorded or updated by this block. The array may be empty (and
+/// `changes` will be null) when only the wallet's balance shifted (e.g. a
+/// coinbase maturing). `balance` is the wallet's balance *after* the block
+/// was processed.
 ///
-/// The `updates` array and all its contents are borrowed and only valid for
+/// The `changes` array and all its contents are borrowed and only valid for
 /// the duration of the callback.
-pub type OnBlockProcessChangeCallback = Option<
+pub type OnWalletBlockProcessedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
         height: u32,
-        updates: *const FFIBlockRecordUpdate,
-        update_count: u32,
+        changes: *const FFIRecordChange,
+        change_count: u32,
         balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
@@ -624,7 +743,7 @@ pub type OnBlockProcessChangeCallback = Option<
 /// Fires once per wallet when the filter pipeline commits a batch — the
 /// wallet has been scanned up to `height`. Consumers can persist this as a
 /// checkpoint atomically with any records/balance already persisted from
-/// prior `BlockProcessChange` events inside the batch.
+/// prior `BlockProcessed` events inside the batch.
 pub type OnSyncedHeightUpdatedCallback =
     Option<extern "C" fn(wallet_id: *const c_char, height: u32, user_data: *mut c_void)>;
 
@@ -633,14 +752,14 @@ pub type OnSyncedHeightUpdatedCallback =
 /// Set only the callbacks you're interested in; unset callbacks will be ignored.
 ///
 /// All pointer parameters passed to callbacks (wallet IDs, txids, records,
-/// balances, updates) are borrowed and only valid for the duration of the
+/// balances, changes) are borrowed and only valid for the duration of the
 /// callback invocation. Callers must copy any data they need to retain.
 #[repr(C)]
 #[derive(Clone)]
 pub struct FFIWalletEventCallbacks {
-    pub on_mempool_transaction_received: OnMempoolTransactionReceivedCallback,
+    pub on_transaction_received: OnTransactionReceivedCallback,
     pub on_transaction_instant_send_locked: OnTransactionInstantSendLockedCallback,
-    pub on_block_process_change: OnBlockProcessChangeCallback,
+    pub on_block_processed: OnWalletBlockProcessedCallback,
     pub on_synced_height_updated: OnSyncedHeightUpdatedCallback,
     pub user_data: *mut c_void,
 }
@@ -652,9 +771,9 @@ unsafe impl Sync for FFIWalletEventCallbacks {}
 impl Default for FFIWalletEventCallbacks {
     fn default() -> Self {
         Self {
-            on_mempool_transaction_received: None,
+            on_transaction_received: None,
             on_transaction_instant_send_locked: None,
-            on_block_process_change: None,
+            on_block_processed: None,
             on_synced_height_updated: None,
             user_data: std::ptr::null_mut(),
         }
@@ -750,23 +869,20 @@ impl FFIWalletEventCallbacks {
     /// Dispatch a WalletEvent to the appropriate callback.
     pub fn dispatch(&self, event: &WalletEvent) {
         match event {
-            WalletEvent::MempoolTransactionReceived {
+            WalletEvent::TransactionReceived {
                 wallet_id,
-                account_path,
-                record,
+                change,
                 balance,
             } => {
-                if let Some(cb) = self.on_mempool_transaction_received {
+                if let Some(cb) = self.on_transaction_received {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
-                    let c_account_path = CString::new(account_path.to_string()).unwrap_or_default();
-                    let ffi_record = FFITransactionRecord::from(record.as_ref());
+                    let ffi_change = FFIRecordChange::from_record_change(change.as_ref());
                     let ffi_balance = FFIBalance::from(*balance);
 
                     cb(
                         c_wallet_id.as_ptr(),
-                        c_account_path.as_ptr(),
-                        &ffi_record as *const FFITransactionRecord,
+                        &ffi_change as *const FFIRecordChange,
                         &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
@@ -795,54 +911,38 @@ impl FFIWalletEventCallbacks {
                     );
                 }
             }
-            WalletEvent::BlockProcessChange {
+            WalletEvent::BlockProcessed {
                 wallet_id,
                 height,
-                updates,
+                changes,
                 balance,
             } => {
-                if let Some(cb) = self.on_block_process_change {
+                if let Some(cb) = self.on_block_processed {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
-                    // Materialize one CString per update *before* building the
-                    // FFI views so the `*const c_char` pointers stored inside
-                    // `FFIBlockRecordUpdate` stay valid for the duration of
-                    // the callback invocation.
-                    let path_cstrs: Vec<CString> = updates
-                        .iter()
-                        .map(|u| CString::new(u.account_path.to_string()).unwrap_or_default())
-                        .collect();
-                    let ffi_updates: Vec<FFIBlockRecordUpdate> = updates
-                        .iter()
-                        .zip(path_cstrs.iter())
-                        .map(|(u, path)| FFIBlockRecordUpdate {
-                            account_path: path.as_ptr(),
-                            action: FFIRecordAction::from(u.action),
-                            record: FFITransactionRecord::from(&u.record),
-                        })
-                        .collect();
+                    let ffi_changes: Vec<FFIRecordChange> =
+                        changes.iter().map(FFIRecordChange::from_record_change).collect();
                     let ffi_balance = FFIBalance::from(*balance);
 
-                    // Pass a null `updates` pointer when the array is empty so
+                    // Pass a null `changes` pointer when the array is empty so
                     // C/Swift consumers that null-check before reading don't
                     // see a non-null dangling pointer paired with a zero count.
-                    let updates_ptr = if ffi_updates.is_empty() {
+                    let changes_ptr = if ffi_changes.is_empty() {
                         ptr::null()
                     } else {
-                        ffi_updates.as_ptr()
+                        ffi_changes.as_ptr()
                     };
 
                     cb(
                         c_wallet_id.as_ptr(),
                         *height,
-                        updates_ptr,
-                        ffi_updates.len() as u32,
+                        changes_ptr,
+                        ffi_changes.len() as u32,
                         &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
 
-                    drop(ffi_updates);
-                    drop(path_cstrs);
+                    drop(ffi_changes);
                 }
             }
             WalletEvent::SyncedHeightUpdated {

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -12,10 +12,9 @@ use dash_spv::sync::{SyncEvent, SyncProgress};
 use dash_spv::EventHandler;
 use dashcore::hashes::Hash;
 use key_wallet_ffi::managed_account::FFITransactionRecord;
-use key_wallet_ffi::types::FFITransactionContext;
-use key_wallet_manager::WalletEvent;
+use key_wallet_ffi::types::FFIBalance;
+use key_wallet_manager::{RecordAction, WalletEvent};
 use std::ffi::CString;
-use std::ops::Deref;
 use std::os::raw::{c_char, c_void};
 
 // ============================================================================
@@ -530,63 +529,118 @@ impl FFINetworkEventCallbacks {
 // FFIWalletEventCallbacks - One callback per WalletEvent variant
 // ============================================================================
 
-/// Callback for WalletEvent::TransactionReceived
+/// Whether a record is newly stored or updates a previously stored record.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FFIRecordAction {
+    /// The record is new (first time stored for this wallet).
+    Inserted = 0,
+    /// The record was already stored and has been updated.
+    Updated = 1,
+}
+
+impl From<RecordAction> for FFIRecordAction {
+    fn from(action: RecordAction) -> Self {
+        match action {
+            RecordAction::Inserted => FFIRecordAction::Inserted,
+            RecordAction::Updated => FFIRecordAction::Updated,
+        }
+    }
+}
+
+/// FFI-friendly form of `BlockRecordUpdate`: a `TransactionRecord` affected by
+/// a block, with its account derivation path and whether it is a fresh
+/// insertion or an update to an existing record.
+#[repr(C)]
+pub struct FFIBlockRecordUpdate {
+    /// Null-terminated UTF-8 BIP-32 path string identifying the account
+    /// (e.g. `"m/44'/1'/0'"`). Borrowed for the duration of the callback.
+    pub account_path: *const c_char,
+    /// Whether the record is new or an update to a previously stored one.
+    pub action: FFIRecordAction,
+    /// The transaction record.
+    pub record: FFITransactionRecord,
+}
+
+/// Callback for `WalletEvent::MempoolTransactionReceived`.
 ///
-/// The `record` pointer is borrowed and only valid for the duration of the
-/// callback. Callers must copy any data they need to retain after the callback
-/// returns. The record contains all transaction details including serialized
-/// transaction bytes, input/output details, and classification metadata.
-pub type OnTransactionReceivedCallback = Option<
+/// Fires when a wallet-relevant transaction is first seen in the mempool
+/// (optionally with an InstantSend lock — in that case the record's context
+/// is `InstantSend(..)`).
+///
+/// All pointer parameters are borrowed and only valid for the duration of the
+/// callback. `balance` is the wallet's balance *after* the transaction was
+/// recorded.
+pub type OnMempoolTransactionReceivedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
-        account_index: u32,
+        account_path: *const c_char,
         record: *const FFITransactionRecord,
+        balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
 >;
 
-/// Callback for WalletEvent::TransactionStatusChanged
+/// Callback for `WalletEvent::TransactionInstantSendLocked`.
 ///
-/// The `wallet_id` string pointer and `txid` hash pointer are borrowed and only
-/// valid for the duration of the callback.
-pub type OnTransactionStatusChangedCallback = Option<
+/// Fires when a previously-seen wallet-relevant transaction is
+/// InstantSend-locked. `islock_data` points to consensus-serialized
+/// `InstantLock` bytes valid only for the duration of the callback.
+pub type OnTransactionInstantSendLockedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
         txid: *const [u8; 32],
-        status: FFITransactionContext,
+        islock_data: *const u8,
+        islock_len: usize,
+        balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
 >;
 
-/// Callback for WalletEvent::BalanceUpdated
+/// Callback for `WalletEvent::BlockProcessChange`.
 ///
-/// The `wallet_id` string pointer is borrowed and only valid for the duration
-/// of the callback. Callers must copy the string if they need to retain it
-/// after the callback returns.
-pub type OnBalanceUpdatedCallback = Option<
+/// Fires once per wallet affected by a processed block. `updates` points to an
+/// array of `update_count` `FFIBlockRecordUpdate` entries covering records
+/// newly recorded or updated by this block. The array may be empty when only
+/// the wallet's balance shifted (e.g. a coinbase maturing). `balance` is the
+/// wallet's balance *after* the block was processed.
+///
+/// The `updates` array and all its contents are borrowed and only valid for
+/// the duration of the callback.
+pub type OnBlockProcessChangeCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
-        confirmed: u64,
-        unconfirmed: u64,
-        immature: u64,
-        locked: u64,
+        height: u32,
+        updates: *const FFIBlockRecordUpdate,
+        update_count: u32,
+        balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
 >;
+
+/// Callback for `WalletEvent::SyncedHeightUpdated`.
+///
+/// Fires once per wallet when the filter pipeline commits a batch — the
+/// wallet has been scanned up to `height`. Consumers can persist this as a
+/// checkpoint atomically with any records/balance already persisted from
+/// prior `BlockProcessChange` events inside the batch.
+pub type OnSyncedHeightUpdatedCallback =
+    Option<extern "C" fn(wallet_id: *const c_char, height: u32, user_data: *mut c_void)>;
 
 /// Wallet event callbacks - one callback per WalletEvent variant.
 ///
 /// Set only the callbacks you're interested in; unset callbacks will be ignored.
 ///
-/// All pointer parameters passed to callbacks (wallet IDs, txids, addresses)
-/// are borrowed and only valid for the duration of the callback invocation.
-/// Callers must copy any data they need to retain.
+/// All pointer parameters passed to callbacks (wallet IDs, txids, records,
+/// balances, updates) are borrowed and only valid for the duration of the
+/// callback invocation. Callers must copy any data they need to retain.
 #[repr(C)]
 #[derive(Clone)]
 pub struct FFIWalletEventCallbacks {
-    pub on_transaction_received: OnTransactionReceivedCallback,
-    pub on_transaction_status_changed: OnTransactionStatusChangedCallback,
-    pub on_balance_updated: OnBalanceUpdatedCallback,
+    pub on_mempool_transaction_received: OnMempoolTransactionReceivedCallback,
+    pub on_transaction_instant_send_locked: OnTransactionInstantSendLockedCallback,
+    pub on_block_process_change: OnBlockProcessChangeCallback,
+    pub on_synced_height_updated: OnSyncedHeightUpdatedCallback,
     pub user_data: *mut c_void,
 }
 
@@ -597,9 +651,10 @@ unsafe impl Sync for FFIWalletEventCallbacks {}
 impl Default for FFIWalletEventCallbacks {
     fn default() -> Self {
         Self {
-            on_transaction_received: None,
-            on_transaction_status_changed: None,
-            on_balance_updated: None,
+            on_mempool_transaction_received: None,
+            on_transaction_instant_send_locked: None,
+            on_block_process_change: None,
+            on_synced_height_updated: None,
             user_data: std::ptr::null_mut(),
         }
     }
@@ -694,62 +749,100 @@ impl FFIWalletEventCallbacks {
     /// Dispatch a WalletEvent to the appropriate callback.
     pub fn dispatch(&self, event: &WalletEvent) {
         match event {
-            WalletEvent::TransactionReceived {
+            WalletEvent::MempoolTransactionReceived {
                 wallet_id,
-                account_index,
+                account_path,
                 record,
+                balance,
             } => {
-                if let Some(cb) = self.on_transaction_received {
+                if let Some(cb) = self.on_mempool_transaction_received {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
-
-                    let ffi_record = FFITransactionRecord::from(record.deref());
+                    let c_account_path = CString::new(account_path.to_string()).unwrap_or_default();
+                    let ffi_record = FFITransactionRecord::from(record.as_ref());
+                    let ffi_balance = FFIBalance::from(*balance);
 
                     cb(
                         c_wallet_id.as_ptr(),
-                        *account_index,
+                        c_account_path.as_ptr(),
                         &ffi_record as *const FFITransactionRecord,
+                        &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
                 }
             }
-            WalletEvent::TransactionStatusChanged {
+            WalletEvent::TransactionInstantSendLocked {
                 wallet_id,
                 txid,
-                status,
+                instant_send_lock,
+                balance,
             } => {
-                if let Some(cb) = self.on_transaction_status_changed {
+                if let Some(cb) = self.on_transaction_instant_send_locked {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
                     let txid_bytes = txid.as_byte_array();
-                    let ffi_ctx = FFITransactionContext::from(status.clone());
+                    let islock_bytes = dashcore::consensus::serialize(instant_send_lock);
+                    let ffi_balance = FFIBalance::from(*balance);
 
                     cb(
                         c_wallet_id.as_ptr(),
                         txid_bytes as *const [u8; 32],
-                        ffi_ctx,
+                        islock_bytes.as_ptr(),
+                        islock_bytes.len(),
+                        &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
                 }
             }
-            WalletEvent::BalanceUpdated {
+            WalletEvent::BlockProcessChange {
                 wallet_id,
-                confirmed,
-                unconfirmed,
-                immature,
-                locked,
+                height,
+                updates,
+                balance,
             } => {
-                if let Some(cb) = self.on_balance_updated {
+                if let Some(cb) = self.on_block_process_change {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
+                    // Materialize one CString per update *before* building the
+                    // FFI views so the `*const c_char` pointers stored inside
+                    // `FFIBlockRecordUpdate` stay valid for the duration of
+                    // the callback invocation.
+                    let path_cstrs: Vec<CString> = updates
+                        .iter()
+                        .map(|u| CString::new(u.account_path.to_string()).unwrap_or_default())
+                        .collect();
+                    let ffi_updates: Vec<FFIBlockRecordUpdate> = updates
+                        .iter()
+                        .zip(path_cstrs.iter())
+                        .map(|(u, path)| FFIBlockRecordUpdate {
+                            account_path: path.as_ptr(),
+                            action: FFIRecordAction::from(u.action),
+                            record: FFITransactionRecord::from(&u.record),
+                        })
+                        .collect();
+                    let ffi_balance = FFIBalance::from(*balance);
+
                     cb(
                         c_wallet_id.as_ptr(),
-                        *confirmed,
-                        *unconfirmed,
-                        *immature,
-                        *locked,
+                        *height,
+                        ffi_updates.as_ptr(),
+                        ffi_updates.len() as u32,
+                        &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
+
+                    drop(ffi_updates);
+                    drop(path_cstrs);
+                }
+            }
+            WalletEvent::SyncedHeightUpdated {
+                wallet_id,
+                height,
+            } => {
+                if let Some(cb) = self.on_synced_height_updated {
+                    let wallet_id_hex = hex::encode(wallet_id);
+                    let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
+                    cb(c_wallet_id.as_ptr(), *height, self.user_data);
                 }
             }
         }

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -16,6 +16,7 @@ use key_wallet_ffi::types::FFIBalance;
 use key_wallet_manager::{RecordAction, WalletEvent};
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
+use std::ptr;
 
 // ============================================================================
 // Sync Event Types (for FFISyncEventCallbacks)
@@ -822,10 +823,19 @@ impl FFIWalletEventCallbacks {
                         .collect();
                     let ffi_balance = FFIBalance::from(*balance);
 
+                    // Pass a null `updates` pointer when the array is empty so
+                    // C/Swift consumers that null-check before reading don't
+                    // see a non-null dangling pointer paired with a zero count.
+                    let updates_ptr = if ffi_updates.is_empty() {
+                        ptr::null()
+                    } else {
+                        ffi_updates.as_ptr()
+                    };
+
                     cb(
                         c_wallet_id.as_ptr(),
                         *height,
-                        ffi_updates.as_ptr(),
+                        updates_ptr,
                         ffi_updates.len() as u32,
                         &ffi_balance as *const FFIBalance,
                         self.user_data,

--- a/dash-spv-ffi/src/lib.rs
+++ b/dash-spv-ffi/src/lib.rs
@@ -14,6 +14,12 @@ pub use platform_integration::*;
 pub use types::*;
 pub use utils::*;
 
+// Re-export wallet-FFI types used by `FFIWalletEventCallbacks` so consumers
+// can refer to them via `dash_spv_ffi::*` without importing `key_wallet_ffi`
+// directly.
+pub use key_wallet_ffi::managed_account::FFITransactionRecord;
+pub use key_wallet_ffi::types::{FFIAccountType, FFIRecordAction, FFITransactionRecordUpdate};
+
 // FFINetwork is now defined in types.rs for cbindgen compatibility
 // It must match the definition in key_wallet_ffi
 

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -75,6 +75,11 @@ pub(super) struct CallbackTracker {
     pub(super) last_confirmed: AtomicU64,
     pub(super) last_unconfirmed: AtomicU64,
 
+    // Raw IS lock bytes captured from the most recent
+    // `on_transaction_instant_send_locked` callback. Lets tests verify the
+    // payload is non-empty and round-trips through `InstantLock` deserialisation.
+    pub(super) last_islock_bytes: Mutex<Option<Vec<u8>>>,
+
     // Lifecycle ordering via global sequence counter
     pub(super) sequence_counter: AtomicU32,
     pub(super) sync_start_seq: AtomicU32,
@@ -398,14 +403,18 @@ extern "C" fn on_mempool_transaction_received(
 extern "C" fn on_transaction_instant_send_locked(
     _wallet_id: *const c_char,
     _txid: *const [u8; 32],
-    _islock_data: *const u8,
-    _islock_len: usize,
+    islock_data: *const u8,
+    islock_len: usize,
     balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
+    if !islock_data.is_null() && islock_len > 0 {
+        let bytes = unsafe { slice::from_raw_parts(islock_data, islock_len) }.to_vec();
+        *tracker.last_islock_bytes.lock().unwrap_or_else(|e| e.into_inner()) = Some(bytes);
+    }
     tracker.transaction_instant_send_locked_count.fetch_add(1, Ordering::SeqCst);
     record_balance(tracker, balance);
     tracing::debug!("on_transaction_instant_send_locked");
@@ -422,25 +431,31 @@ extern "C" fn on_block_process_change(
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
-    // Bump the per-callback counter before the per-record counter so a test
-    // that waits on `block_process_change_record_count` and then reads
-    // `block_process_change_count` is guaranteed to observe a matching pair.
-    tracker.block_process_change_count.fetch_add(1, Ordering::SeqCst);
+    // Append all per-record state before bumping either counter so that a
+    // test waiting on `block_process_change_count` (the per-callback counter)
+    // is guaranteed to also observe the matching `block_process_change_record_count`
+    // and the underlying vectors. Tests should always wait on
+    // `block_process_change_count` and read the record counter afterwards.
     let mut sink = tracker.block_received_transactions.lock().unwrap_or_else(|e| e.into_inner());
     let mut paths = tracker.block_account_paths.lock().unwrap_or_else(|e| e.into_inner());
     let mut actions = tracker.block_record_actions.lock().unwrap_or_else(|e| e.into_inner());
+    let mut records_added = 0u32;
     if !updates.is_null() && update_count > 0 {
         let updates_slice = unsafe { slice::from_raw_parts(updates, update_count as usize) };
         for u in updates_slice {
             sink.push((u.record.txid, u.record.net_amount));
             paths.push(unsafe { cstr_or_unknown(u.account_path) });
             actions.push(u.action);
-            tracker.block_process_change_record_count.fetch_add(1, Ordering::SeqCst);
+            records_added += 1;
         }
     }
     drop(sink);
     drop(paths);
     drop(actions);
+    if records_added > 0 {
+        tracker.block_process_change_record_count.fetch_add(records_added, Ordering::SeqCst);
+    }
+    tracker.block_process_change_count.fetch_add(1, Ordering::SeqCst);
     record_balance(tracker, balance);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
     tracing::info!(
@@ -459,8 +474,11 @@ extern "C" fn on_synced_height_updated(
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
-    tracker.synced_height_updated_count.fetch_add(1, Ordering::SeqCst);
+    // Store the height before bumping the counter so a test that waits on the
+    // counter and then reads `last_synced_height` is guaranteed to observe the
+    // height for the same callback invocation.
     tracker.last_synced_height.store(height, Ordering::SeqCst);
+    tracker.synced_height_updated_count.fetch_add(1, Ordering::SeqCst);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
     tracing::info!("on_synced_height_updated: wallet={}, height={}", wallet_str, height);
 }

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -426,9 +426,10 @@ extern "C" fn on_block_process_change(
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
-    // `block_process_change_count` is incremented inside the same lock as
-    // `block_process_change_record_count` so a test that observes either
-    // counter via `wait_for_callback` is guaranteed to see the matching one.
+    // Bump the per-callback counter before the per-record counter so a test
+    // that waits on `block_process_change_record_count` and then reads
+    // `block_process_change_count` is guaranteed to observe a matching pair.
+    tracker.block_process_change_count.fetch_add(1, Ordering::SeqCst);
     let mut sink = tracker.block_received_transactions.lock().unwrap_or_else(|e| e.into_inner());
     let mut paths = tracker.block_account_paths.lock().unwrap_or_else(|e| e.into_inner());
     let mut actions = tracker.block_record_actions.lock().unwrap_or_else(|e| e.into_inner());
@@ -441,7 +442,6 @@ extern "C" fn on_block_process_change(
             tracker.block_process_change_record_count.fetch_add(1, Ordering::SeqCst);
         }
     }
-    tracker.block_process_change_count.fetch_add(1, Ordering::SeqCst);
     drop(sink);
     drop(paths);
     drop(actions);

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -66,8 +66,8 @@ pub(super) struct CallbackTracker {
 
     // `account_index` values captured alongside `FFIAccountType`, paired
     // positionally with the corresponding `*_account_types` entries.
-    pub(super) received_account_indices: Mutex<Vec<i32>>,
-    pub(super) block_account_indices: Mutex<Vec<i32>>,
+    pub(super) received_account_indices: Mutex<Vec<u32>>,
+    pub(super) block_account_indices: Mutex<Vec<u32>>,
 
     // `FFIRecordAction` values observed on `BlockProcessed` changes, in
     // delivery order. Lets tests assert the action discriminant is correct
@@ -380,7 +380,7 @@ fn record_balance(tracker: &CallbackTracker, balance: *const FFIBalance) {
 
 extern "C" fn on_transaction_received(
     wallet_id: *const c_char,
-    change: *const FFIRecordChange,
+    update: *const FFITransactionRecordUpdate,
     balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
@@ -388,24 +388,24 @@ extern "C" fn on_transaction_received(
         return;
     };
     let mut account_type_log = None;
-    if !change.is_null() {
-        let c = unsafe { &*change };
+    if !update.is_null() {
+        let u = unsafe { &*update };
         tracker
             .received_transactions
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .push((c.record.txid, c.record.net_amount));
+            .push((u.record.txid, u.record.net_amount));
         tracker
             .received_account_types
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .push(c.account_type);
+            .push(u.record.account_type);
         tracker
             .received_account_indices
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .push(c.account_index);
-        account_type_log = Some((c.account_type, c.account_index));
+            .push(u.record.account_index);
+        account_type_log = Some((u.record.account_type, u.record.account_index));
     }
     // Store the balance before bumping the counter so a test that waits on the
     // counter and then reads `last_unconfirmed` is guaranteed to observe the
@@ -443,8 +443,8 @@ extern "C" fn on_transaction_instant_send_locked(
 extern "C" fn on_wallet_block_processed(
     wallet_id: *const c_char,
     height: u32,
-    changes: *const FFIRecordChange,
-    change_count: u32,
+    updates: *const FFITransactionRecordUpdate,
+    update_count: u32,
     balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
@@ -461,13 +461,13 @@ extern "C" fn on_wallet_block_processed(
     let mut indices = tracker.block_account_indices.lock().unwrap_or_else(|e| e.into_inner());
     let mut actions = tracker.block_record_actions.lock().unwrap_or_else(|e| e.into_inner());
     let mut records_added = 0u32;
-    if !changes.is_null() && change_count > 0 {
-        let changes_slice = unsafe { slice::from_raw_parts(changes, change_count as usize) };
-        for c in changes_slice {
-            sink.push((c.record.txid, c.record.net_amount));
-            types.push(c.account_type);
-            indices.push(c.account_index);
-            actions.push(c.action);
+    if !updates.is_null() && update_count > 0 {
+        let updates_slice = unsafe { slice::from_raw_parts(updates, update_count as usize) };
+        for u in updates_slice {
+            sink.push((u.record.txid, u.record.net_amount));
+            types.push(u.record.account_type);
+            indices.push(u.record.account_index);
+            actions.push(u.action);
             records_added += 1;
         }
     }
@@ -482,10 +482,10 @@ extern "C" fn on_wallet_block_processed(
     record_balance(tracker, balance);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
     tracing::info!(
-        "on_wallet_block_processed: wallet={}, height={}, changes={}",
+        "on_wallet_block_processed: wallet={}, height={}, updates={}",
         wallet_str,
         height,
-        change_count
+        update_count
     );
 }
 

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -2,13 +2,14 @@
 
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
+use std::slice;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use dash_spv_ffi::*;
 use key_wallet_ffi::managed_account::FFITransactionRecord;
-use key_wallet_ffi::types::FFITransactionContext;
+use key_wallet_ffi::types::FFIBalance;
 
 /// Tracks callback invocations for verification.
 ///
@@ -37,9 +38,13 @@ pub(super) struct CallbackTracker {
     pub(super) peers_updated_count: AtomicU32,
 
     // Wallet event tracking
-    pub(super) transaction_received_count: AtomicU32,
-    pub(super) transaction_status_changed_count: AtomicU32,
-    pub(super) balance_updated_count: AtomicU32,
+    pub(super) mempool_transaction_received_count: AtomicU32,
+    pub(super) transaction_instant_send_locked_count: AtomicU32,
+    pub(super) block_process_change_count: AtomicU32,
+    pub(super) block_process_change_record_count: AtomicU32,
+    pub(super) synced_height_updated_count: AtomicU32,
+    /// Highest synced-height value observed from any `SyncedHeightUpdated`.
+    pub(super) last_synced_height: AtomicU32,
 
     // Data from callbacks
     pub(super) last_header_tip: AtomicU32,
@@ -49,11 +54,11 @@ pub(super) struct CallbackTracker {
     pub(super) connected_peers: Mutex<Vec<String>>,
     pub(super) errors: Mutex<Vec<String>>,
 
-    // Transaction data from on_transaction_received (txid, net_amount)
+    // Per-record (txid, net_amount) seen via any wallet event.
     pub(super) received_transactions: Mutex<Vec<([u8; 32], i64)>>,
 
-    // Balance data from on_balance_updated
-    pub(super) last_spendable: AtomicU64,
+    // Balance data from the most recent wallet event.
+    pub(super) last_confirmed: AtomicU64,
     pub(super) last_unconfirmed: AtomicU64,
 
     // Lifecycle ordering via global sequence counter
@@ -341,10 +346,20 @@ extern "C" fn on_peers_updated(connected_count: u32, best_height: u32, user_data
     tracing::debug!("on_peers_updated: connected={}, best_height={}", connected_count, best_height);
 }
 
-extern "C" fn on_transaction_received(
+fn record_balance(tracker: &CallbackTracker, balance: *const FFIBalance) {
+    if balance.is_null() {
+        return;
+    }
+    let b = unsafe { *balance };
+    tracker.last_confirmed.store(b.confirmed, Ordering::SeqCst);
+    tracker.last_unconfirmed.store(b.unconfirmed, Ordering::SeqCst);
+}
+
+extern "C" fn on_mempool_transaction_received(
     wallet_id: *const c_char,
-    account_index: u32,
+    account_path: *const c_char,
     record: *const FFITransactionRecord,
+    balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
@@ -358,47 +373,71 @@ extern "C" fn on_transaction_received(
             .unwrap_or_else(|e| e.into_inner())
             .push((r.txid, r.net_amount));
     }
-    tracker.transaction_received_count.fetch_add(1, Ordering::SeqCst);
+    tracker.mempool_transaction_received_count.fetch_add(1, Ordering::SeqCst);
+    record_balance(tracker, balance);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
-    tracing::info!("on_transaction_received: wallet={}, account={}", wallet_str, account_index,);
+    let path_str = unsafe { cstr_or_unknown(account_path) };
+    tracing::info!("on_mempool_transaction_received: wallet={}, account={}", wallet_str, path_str);
 }
 
-extern "C" fn on_transaction_status_changed(
+extern "C" fn on_transaction_instant_send_locked(
     _wallet_id: *const c_char,
     _txid: *const [u8; 32],
-    status: FFITransactionContext,
+    _islock_data: *const u8,
+    _islock_len: usize,
+    balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
-    tracker.transaction_status_changed_count.fetch_add(1, Ordering::SeqCst);
-    tracing::debug!("on_transaction_status_changed: status={:?}", status);
+    tracker.transaction_instant_send_locked_count.fetch_add(1, Ordering::SeqCst);
+    record_balance(tracker, balance);
+    tracing::debug!("on_transaction_instant_send_locked");
 }
 
-extern "C" fn on_balance_updated(
+extern "C" fn on_block_process_change(
     wallet_id: *const c_char,
-    spendable: u64,
-    unconfirmed: u64,
-    immature: u64,
-    locked: u64,
+    height: u32,
+    updates: *const FFIBlockRecordUpdate,
+    update_count: u32,
+    balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
-    tracker.last_spendable.store(spendable, Ordering::SeqCst);
-    tracker.last_unconfirmed.store(unconfirmed, Ordering::SeqCst);
-    tracker.balance_updated_count.fetch_add(1, Ordering::SeqCst);
+    if !updates.is_null() && update_count > 0 {
+        let updates_slice = unsafe { slice::from_raw_parts(updates, update_count as usize) };
+        let mut sink = tracker.received_transactions.lock().unwrap_or_else(|e| e.into_inner());
+        for u in updates_slice {
+            sink.push((u.record.txid, u.record.net_amount));
+            tracker.block_process_change_record_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+    tracker.block_process_change_count.fetch_add(1, Ordering::SeqCst);
+    record_balance(tracker, balance);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
     tracing::info!(
-        "on_balance_updated: wallet={}, spendable={}, unconfirmed={}, immature={}, locked={}",
+        "on_block_process_change: wallet={}, height={}, updates={}",
         wallet_str,
-        spendable,
-        unconfirmed,
-        immature,
-        locked,
+        height,
+        update_count
     );
+}
+
+extern "C" fn on_synced_height_updated(
+    wallet_id: *const c_char,
+    height: u32,
+    user_data: *mut c_void,
+) {
+    let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
+        return;
+    };
+    tracker.synced_height_updated_count.fetch_add(1, Ordering::SeqCst);
+    tracker.last_synced_height.store(height, Ordering::SeqCst);
+    let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
+    tracing::info!("on_synced_height_updated: wallet={}, height={}", wallet_str, height);
 }
 
 /// Create sync callbacks with all event handlers wired to the tracker.
@@ -444,9 +483,10 @@ pub(super) fn create_network_callbacks(tracker: &Arc<CallbackTracker>) -> FFINet
 /// Arc outlives all callback invocations.
 pub(super) fn create_wallet_callbacks(tracker: &Arc<CallbackTracker>) -> FFIWalletEventCallbacks {
     FFIWalletEventCallbacks {
-        on_transaction_received: Some(on_transaction_received),
-        on_transaction_status_changed: Some(on_transaction_status_changed),
-        on_balance_updated: Some(on_balance_updated),
+        on_mempool_transaction_received: Some(on_mempool_transaction_received),
+        on_transaction_instant_send_locked: Some(on_transaction_instant_send_locked),
+        on_block_process_change: Some(on_block_process_change),
+        on_synced_height_updated: Some(on_synced_height_updated),
         user_data: Arc::as_ptr(tracker) as *mut c_void,
     }
 }

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -394,8 +394,11 @@ extern "C" fn on_mempool_transaction_received(
     }
     let path_str = unsafe { cstr_or_unknown(account_path) };
     tracker.mempool_account_paths.lock().unwrap_or_else(|e| e.into_inner()).push(path_str.clone());
-    tracker.mempool_transaction_received_count.fetch_add(1, Ordering::SeqCst);
+    // Store the balance before bumping the counter so a test that waits on the
+    // counter and then reads `last_unconfirmed` is guaranteed to observe the
+    // balance for the same callback invocation.
     record_balance(tracker, balance);
+    tracker.mempool_transaction_received_count.fetch_add(1, Ordering::SeqCst);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
     tracing::info!("on_mempool_transaction_received: wallet={}, account={}", wallet_str, path_str);
 }

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -54,8 +54,22 @@ pub(super) struct CallbackTracker {
     pub(super) connected_peers: Mutex<Vec<String>>,
     pub(super) errors: Mutex<Vec<String>>,
 
-    // Per-record (txid, net_amount) seen via any wallet event.
-    pub(super) received_transactions: Mutex<Vec<([u8; 32], i64)>>,
+    // Per-record (txid, net_amount) seen via the mempool wallet callback.
+    pub(super) mempool_received_transactions: Mutex<Vec<([u8; 32], i64)>>,
+    // Per-record (txid, net_amount) seen via the block-process-change callback.
+    pub(super) block_received_transactions: Mutex<Vec<([u8; 32], i64)>>,
+
+    // Account derivation paths captured from wallet callbacks (BIP-32 strings
+    // like `"m/44'/1'/0'"`). Lets tests assert that path delivery is
+    // well-formed and matches the expected account.
+    pub(super) mempool_account_paths: Mutex<Vec<String>>,
+    pub(super) block_account_paths: Mutex<Vec<String>>,
+
+    // `FFIRecordAction` values observed on `BlockProcessChange` updates, in
+    // delivery order. Lets tests assert the action discriminant is correct
+    // (`Inserted` for first-seen records, `Updated` for confirmation of
+    // previously-known mempool transactions).
+    pub(super) block_record_actions: Mutex<Vec<FFIRecordAction>>,
 
     // Balance data from the most recent wallet event.
     pub(super) last_confirmed: AtomicU64,
@@ -368,15 +382,20 @@ extern "C" fn on_mempool_transaction_received(
     if !record.is_null() {
         let r = unsafe { &*record };
         tracker
-            .received_transactions
+            .mempool_received_transactions
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .push((r.txid, r.net_amount));
     }
+    let path_str = unsafe { cstr_or_unknown(account_path) };
+    tracker
+        .mempool_account_paths
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .push(path_str.clone());
     tracker.mempool_transaction_received_count.fetch_add(1, Ordering::SeqCst);
     record_balance(tracker, balance);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
-    let path_str = unsafe { cstr_or_unknown(account_path) };
     tracing::info!("on_mempool_transaction_received: wallet={}, account={}", wallet_str, path_str);
 }
 
@@ -407,15 +426,25 @@ extern "C" fn on_block_process_change(
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
+    // `block_process_change_count` is incremented inside the same lock as
+    // `block_process_change_record_count` so a test that observes either
+    // counter via `wait_for_callback` is guaranteed to see the matching one.
+    let mut sink = tracker.block_received_transactions.lock().unwrap_or_else(|e| e.into_inner());
+    let mut paths = tracker.block_account_paths.lock().unwrap_or_else(|e| e.into_inner());
+    let mut actions = tracker.block_record_actions.lock().unwrap_or_else(|e| e.into_inner());
     if !updates.is_null() && update_count > 0 {
         let updates_slice = unsafe { slice::from_raw_parts(updates, update_count as usize) };
-        let mut sink = tracker.received_transactions.lock().unwrap_or_else(|e| e.into_inner());
         for u in updates_slice {
             sink.push((u.record.txid, u.record.net_amount));
+            paths.push(unsafe { cstr_or_unknown(u.account_path) });
+            actions.push(u.action);
             tracker.block_process_change_record_count.fetch_add(1, Ordering::SeqCst);
         }
     }
     tracker.block_process_change_count.fetch_add(1, Ordering::SeqCst);
+    drop(sink);
+    drop(paths);
+    drop(actions);
     record_balance(tracker, balance);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
     tracing::info!(

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use dash_spv_ffi::*;
-use key_wallet_ffi::managed_account::FFITransactionRecord;
 use key_wallet_ffi::types::FFIBalance;
 
 /// Tracks callback invocations for verification.
@@ -38,10 +37,10 @@ pub(super) struct CallbackTracker {
     pub(super) peers_updated_count: AtomicU32,
 
     // Wallet event tracking
-    pub(super) mempool_transaction_received_count: AtomicU32,
+    pub(super) transaction_received_count: AtomicU32,
     pub(super) transaction_instant_send_locked_count: AtomicU32,
-    pub(super) block_process_change_count: AtomicU32,
-    pub(super) block_process_change_record_count: AtomicU32,
+    pub(super) block_processed_wallet_count: AtomicU32,
+    pub(super) block_processed_wallet_record_count: AtomicU32,
     pub(super) synced_height_updated_count: AtomicU32,
     /// Highest synced-height value observed from any `SyncedHeightUpdated`.
     pub(super) last_synced_height: AtomicU32,
@@ -54,18 +53,23 @@ pub(super) struct CallbackTracker {
     pub(super) connected_peers: Mutex<Vec<String>>,
     pub(super) errors: Mutex<Vec<String>>,
 
-    // Per-record (txid, net_amount) seen via the mempool wallet callback.
-    pub(super) mempool_received_transactions: Mutex<Vec<([u8; 32], i64)>>,
-    // Per-record (txid, net_amount) seen via the block-process-change callback.
+    // Per-record (txid, net_amount) seen via the off-chain wallet callback.
+    pub(super) received_transactions: Mutex<Vec<([u8; 32], i64)>>,
+    // Per-record (txid, net_amount) seen via the block-processed callback.
     pub(super) block_received_transactions: Mutex<Vec<([u8; 32], i64)>>,
 
-    // Account derivation paths captured from wallet callbacks (BIP-32 strings
-    // like `"m/44'/1'/0'"`). Lets tests assert that path delivery is
-    // well-formed and matches the expected account.
-    pub(super) mempool_account_paths: Mutex<Vec<String>>,
-    pub(super) block_account_paths: Mutex<Vec<String>>,
+    // `FFIAccountType` discriminants captured from wallet callbacks. Lets
+    // tests assert that account-type delivery is well-formed and matches the
+    // expected account.
+    pub(super) received_account_types: Mutex<Vec<FFIAccountType>>,
+    pub(super) block_account_types: Mutex<Vec<FFIAccountType>>,
 
-    // `FFIRecordAction` values observed on `BlockProcessChange` updates, in
+    // `account_index` values captured alongside `FFIAccountType`, paired
+    // positionally with the corresponding `*_account_types` entries.
+    pub(super) received_account_indices: Mutex<Vec<i32>>,
+    pub(super) block_account_indices: Mutex<Vec<i32>>,
+
+    // `FFIRecordAction` values observed on `BlockProcessed` changes, in
     // delivery order. Lets tests assert the action discriminant is correct
     // (`Inserted` for first-seen records, `Updated` for confirmation of
     // previously-known mempool transactions).
@@ -374,33 +378,46 @@ fn record_balance(tracker: &CallbackTracker, balance: *const FFIBalance) {
     tracker.last_unconfirmed.store(b.unconfirmed, Ordering::SeqCst);
 }
 
-extern "C" fn on_mempool_transaction_received(
+extern "C" fn on_transaction_received(
     wallet_id: *const c_char,
-    account_path: *const c_char,
-    record: *const FFITransactionRecord,
+    change: *const FFIRecordChange,
     balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
-    if !record.is_null() {
-        let r = unsafe { &*record };
+    let mut account_type_log = None;
+    if !change.is_null() {
+        let c = unsafe { &*change };
         tracker
-            .mempool_received_transactions
+            .received_transactions
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .push((r.txid, r.net_amount));
+            .push((c.record.txid, c.record.net_amount));
+        tracker
+            .received_account_types
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(c.account_type);
+        tracker
+            .received_account_indices
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(c.account_index);
+        account_type_log = Some((c.account_type, c.account_index));
     }
-    let path_str = unsafe { cstr_or_unknown(account_path) };
-    tracker.mempool_account_paths.lock().unwrap_or_else(|e| e.into_inner()).push(path_str.clone());
     // Store the balance before bumping the counter so a test that waits on the
     // counter and then reads `last_unconfirmed` is guaranteed to observe the
     // balance for the same callback invocation.
     record_balance(tracker, balance);
-    tracker.mempool_transaction_received_count.fetch_add(1, Ordering::SeqCst);
+    tracker.transaction_received_count.fetch_add(1, Ordering::SeqCst);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
-    tracing::info!("on_mempool_transaction_received: wallet={}, account={}", wallet_str, path_str);
+    tracing::info!(
+        "on_transaction_received: wallet={}, account={:?}",
+        wallet_str,
+        account_type_log
+    );
 }
 
 extern "C" fn on_transaction_instant_send_locked(
@@ -423,11 +440,11 @@ extern "C" fn on_transaction_instant_send_locked(
     tracing::debug!("on_transaction_instant_send_locked");
 }
 
-extern "C" fn on_block_process_change(
+extern "C" fn on_wallet_block_processed(
     wallet_id: *const c_char,
     height: u32,
-    updates: *const FFIBlockRecordUpdate,
-    update_count: u32,
+    changes: *const FFIRecordChange,
+    change_count: u32,
     balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
@@ -435,37 +452,40 @@ extern "C" fn on_block_process_change(
         return;
     };
     // Append all per-record state before bumping either counter so that a
-    // test waiting on `block_process_change_count` (the per-callback counter)
-    // is guaranteed to also observe the matching `block_process_change_record_count`
+    // test waiting on `block_processed_wallet_count` (the per-callback counter)
+    // is guaranteed to also observe the matching `block_processed_wallet_record_count`
     // and the underlying vectors. Tests should always wait on
-    // `block_process_change_count` and read the record counter afterwards.
+    // `block_processed_wallet_count` and read the record counter afterwards.
     let mut sink = tracker.block_received_transactions.lock().unwrap_or_else(|e| e.into_inner());
-    let mut paths = tracker.block_account_paths.lock().unwrap_or_else(|e| e.into_inner());
+    let mut types = tracker.block_account_types.lock().unwrap_or_else(|e| e.into_inner());
+    let mut indices = tracker.block_account_indices.lock().unwrap_or_else(|e| e.into_inner());
     let mut actions = tracker.block_record_actions.lock().unwrap_or_else(|e| e.into_inner());
     let mut records_added = 0u32;
-    if !updates.is_null() && update_count > 0 {
-        let updates_slice = unsafe { slice::from_raw_parts(updates, update_count as usize) };
-        for u in updates_slice {
-            sink.push((u.record.txid, u.record.net_amount));
-            paths.push(unsafe { cstr_or_unknown(u.account_path) });
-            actions.push(u.action);
+    if !changes.is_null() && change_count > 0 {
+        let changes_slice = unsafe { slice::from_raw_parts(changes, change_count as usize) };
+        for c in changes_slice {
+            sink.push((c.record.txid, c.record.net_amount));
+            types.push(c.account_type);
+            indices.push(c.account_index);
+            actions.push(c.action);
             records_added += 1;
         }
     }
     drop(sink);
-    drop(paths);
+    drop(types);
+    drop(indices);
     drop(actions);
     if records_added > 0 {
-        tracker.block_process_change_record_count.fetch_add(records_added, Ordering::SeqCst);
+        tracker.block_processed_wallet_record_count.fetch_add(records_added, Ordering::SeqCst);
     }
-    tracker.block_process_change_count.fetch_add(1, Ordering::SeqCst);
+    tracker.block_processed_wallet_count.fetch_add(1, Ordering::SeqCst);
     record_balance(tracker, balance);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
     tracing::info!(
-        "on_block_process_change: wallet={}, height={}, updates={}",
+        "on_wallet_block_processed: wallet={}, height={}, changes={}",
         wallet_str,
         height,
-        update_count
+        change_count
     );
 }
 
@@ -529,9 +549,9 @@ pub(super) fn create_network_callbacks(tracker: &Arc<CallbackTracker>) -> FFINet
 /// Arc outlives all callback invocations.
 pub(super) fn create_wallet_callbacks(tracker: &Arc<CallbackTracker>) -> FFIWalletEventCallbacks {
     FFIWalletEventCallbacks {
-        on_mempool_transaction_received: Some(on_mempool_transaction_received),
+        on_transaction_received: Some(on_transaction_received),
         on_transaction_instant_send_locked: Some(on_transaction_instant_send_locked),
-        on_block_process_change: Some(on_block_process_change),
+        on_block_processed: Some(on_wallet_block_processed),
         on_synced_height_updated: Some(on_synced_height_updated),
         user_data: Arc::as_ptr(tracker) as *mut c_void,
     }

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -388,11 +388,7 @@ extern "C" fn on_mempool_transaction_received(
             .push((r.txid, r.net_amount));
     }
     let path_str = unsafe { cstr_or_unknown(account_path) };
-    tracker
-        .mempool_account_paths
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .push(path_str.clone());
+    tracker.mempool_account_paths.lock().unwrap_or_else(|e| e.into_inner()).push(path_str.clone());
     tracker.mempool_transaction_received_count.fetch_add(1, Ordering::SeqCst);
     record_balance(tracker, balance);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -101,11 +101,15 @@ fn test_all_callbacks_during_sync() {
         );
         drop(connected_peers);
 
-        // Wait for wallet callbacks (they travel on a separate channel from sync events)
+        // Wait for wallet callbacks (they travel on a separate channel from sync events).
+        // Wait on `block_process_change_count` because it is bumped last in the
+        // callback, after all per-record state has been written. Reading the
+        // record counter afterwards is therefore guaranteed to see the matching
+        // increment.
         tracker.wait_for_callback(
-            &tracker.block_process_change_record_count,
+            &tracker.block_process_change_count,
             0,
-            "block_process_change_record",
+            "block_process_change",
         );
 
         // Validate wallet event callbacks (test wallet has transactions)
@@ -152,9 +156,11 @@ fn test_all_callbacks_during_sync() {
             synced_height_fired > 0,
             "on_synced_height_updated should fire at least once during sync"
         );
-        assert_eq!(
-            last_synced_height, dashd.initial_height,
-            "last_synced_height should match initial_height after sync"
+        assert!(
+            last_synced_height >= dashd.initial_height,
+            "last_synced_height ({}) should be at least initial_height ({}) after sync",
+            last_synced_height,
+            dashd.initial_height
         );
 
         // Validate sync cycle (initial sync is cycle 0)
@@ -318,6 +324,7 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         // Record callback counts before post-sync operations
         let mempool_received_before =
             tracker.mempool_transaction_received_count.load(Ordering::SeqCst);
+        let block_changes_before = tracker.block_process_change_count.load(Ordering::SeqCst);
         let block_records_before = tracker.block_process_change_record_count.load(Ordering::SeqCst);
 
         // Send DASH to the wallet. Wait for the mempool callback before mining
@@ -335,17 +342,31 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
             "mempool_transaction_received",
         );
 
+        // The mempool callback updates `last_unconfirmed` with the post-event
+        // balance. Snapshot it now, before mining. After confirmation the
+        // block-process callback overwrites the same field back toward zero,
+        // so this is the only window in which the unconfirmed-balance update
+        // is observable.
+        let unconfirmed_after_mempool = tracker.last_unconfirmed.load(Ordering::SeqCst);
+        assert!(
+            unconfirmed_after_mempool > 0,
+            "balance.unconfirmed should be positive after mempool receipt, got {}",
+            unconfirmed_after_mempool
+        );
+
         let miner_address = dashd.node.get_new_address_from_wallet("default");
         dashd.node.generate_blocks(1, &miner_address);
 
         // Wait for incremental sync to complete
         ctx.wait_for_sync(dashd.initial_height + 1);
 
-        // Wait for the block-record callback (mempool callback already observed above).
+        // Wait for the block-process callback. The per-callback counter is
+        // bumped last in the callback, so observing it incremented guarantees
+        // the per-record vectors and counters have already been updated.
         tracker.wait_for_callback(
-            &tracker.block_process_change_record_count,
-            block_records_before,
-            "block_process_change_record",
+            &tracker.block_process_change_count,
+            block_changes_before,
+            "block_process_change",
         );
 
         // Verify on_mempool_transaction_received fired for the new transaction
@@ -398,13 +419,17 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
 
         // The post-sync block confirms a transaction that was already known
         // from the mempool, so the corresponding `BlockProcessChange` update
-        // must carry `FFIRecordAction::Updated` rather than `Inserted`.
+        // must carry `FFIRecordAction::Updated` rather than `Inserted`. Slice
+        // by the pre-captured index so only post-sync entries are checked,
+        // avoiding masking by any `Updated` that might appear during initial
+        // sync.
         let block_actions = tracker.block_record_actions.lock().unwrap();
+        let new_actions = &block_actions[block_records_before as usize..];
         assert!(
-            block_actions.contains(&FFIRecordAction::Updated),
+            new_actions.contains(&FFIRecordAction::Updated),
             "post-sync block confirming a known mempool tx should deliver \
              FFIRecordAction::Updated, got: {:?}",
-            *block_actions
+            new_actions
         );
         drop(block_actions);
 

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use dash_spv::test_utils::{DashdTestContext, TestChain};
-use dash_spv_ffi::FFIRecordAction;
+use dash_spv_ffi::{FFIAccountType, FFIRecordAction};
 use dashcore::hashes::Hash;
 use dashcore::Amount;
 
@@ -102,23 +102,22 @@ fn test_all_callbacks_during_sync() {
         drop(connected_peers);
 
         // Wait for wallet callbacks (they travel on a separate channel from sync events).
-        // Wait on `block_process_change_count` because it is bumped last in the
+        // Wait on `block_processed_wallet_count` because it is bumped last in the
         // callback, after all per-record state has been written. Reading the
         // record counter afterwards is therefore guaranteed to see the matching
         // increment.
-        tracker.wait_for_callback(&tracker.block_process_change_count, 0, "block_process_change");
+        tracker.wait_for_callback(&tracker.block_processed_wallet_count, 0, "block_processed");
 
         // Validate wallet event callbacks (test wallet has transactions)
-        let block_records = tracker.block_process_change_record_count.load(Ordering::SeqCst);
-        let block_changes = tracker.block_process_change_count.load(Ordering::SeqCst);
-        let mempool_received = tracker.mempool_transaction_received_count.load(Ordering::SeqCst);
+        let block_records = tracker.block_processed_wallet_record_count.load(Ordering::SeqCst);
+        let block_changes = tracker.block_processed_wallet_count.load(Ordering::SeqCst);
+        let received = tracker.transaction_received_count.load(Ordering::SeqCst);
         let instant_send_locked =
             tracker.transaction_instant_send_locked_count.load(Ordering::SeqCst);
 
         tracing::info!(
-            "Wallet: mempool_received={}, instant_send_locked={}, block_changes={}, \
-             block_records={}",
-            mempool_received,
+            "Wallet: received={}, instant_send_locked={}, block_changes={}, block_records={}",
+            received,
             instant_send_locked,
             block_changes,
             block_records
@@ -126,15 +125,15 @@ fn test_all_callbacks_during_sync() {
 
         assert!(
             block_records > 0,
-            "on_block_process_change should deliver records for a wallet with transactions"
+            "on_block_processed should deliver records for a wallet with transactions"
         );
         assert!(
             block_changes > 0,
-            "on_block_process_change should fire for blocks containing wallet records"
+            "on_block_processed should fire for blocks containing wallet records"
         );
         assert_eq!(
-            mempool_received, 0,
-            "on_mempool_transaction_received must not fire during historical block sync"
+            received, 0,
+            "on_transaction_received must not fire during historical block sync"
         );
         assert_eq!(
             instant_send_locked, 0,
@@ -143,8 +142,8 @@ fn test_all_callbacks_during_sync() {
 
         // Validate SyncedHeightUpdated callback (atomicity boundary for persistence flush).
         // Wait explicitly for the callback because it travels on the same wallet
-        // broadcast channel as `BlockProcessChange` but is dispatched separately,
-        // so observing block-process records does not guarantee it has fired yet.
+        // broadcast channel as `BlockProcessed` but is dispatched separately,
+        // so observing block-processed records does not guarantee it has fired yet.
         tracker.wait_for_callback(&tracker.synced_height_updated_count, 0, "synced_height_updated");
         let synced_height_fired = tracker.synced_height_updated_count.load(Ordering::SeqCst);
         let last_synced_height = tracker.last_synced_height.load(Ordering::SeqCst);
@@ -245,7 +244,7 @@ fn test_all_callbacks_during_sync() {
         );
 
         // Validate transaction data from initial sync. Historical sync only
-        // touches the block-process-change callback (mempool callback must
+        // touches the block-processed callback (off-chain callback must
         // remain silent during initial sync), so assert against that bucket
         // explicitly.
         let block_received = tracker.block_received_transactions.lock().unwrap();
@@ -267,16 +266,29 @@ fn test_all_callbacks_during_sync() {
         );
         drop(actions);
 
-        // Validate every block-record callback delivered a well-formed BIP-32
-        // account path string (e.g. `m/44'/1'/0'`).
-        let paths = tracker.block_account_paths.lock().unwrap();
-        assert!(!paths.is_empty(), "block account paths should be captured");
-        assert!(
-            paths.iter().all(|p| p.starts_with("m/")),
-            "every account_path should be a BIP-32 path string starting with `m/`, got: {:?}",
-            *paths
+        // Validate the BIP-44 account discriminant + index reach the FFI
+        // boundary intact: every change observed during historical sync
+        // belongs to the default BIP-44 account (index 0) of the test wallet.
+        let account_types = tracker.block_account_types.lock().unwrap();
+        let account_indices = tracker.block_account_indices.lock().unwrap();
+        assert!(!account_types.is_empty(), "block account types should be captured");
+        assert_eq!(
+            account_types.len(),
+            account_indices.len(),
+            "block account types and indices must be paired 1:1"
         );
-        drop(paths);
+        assert!(
+            account_types.iter().all(|t| *t == FFIAccountType::StandardBIP44),
+            "every block change should carry FFIAccountType::StandardBIP44, got: {:?}",
+            *account_types
+        );
+        assert!(
+            account_indices.iter().all(|i| *i == 0),
+            "every BIP-44 change should carry account_index = 0, got: {:?}",
+            *account_indices
+        );
+        drop(account_indices);
+        drop(account_types);
 
         // Masternodes are disabled in test config, so these should not fire
         let masternode_updated = tracker.masternode_state_updated_count.load(Ordering::SeqCst);
@@ -318,31 +330,31 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         tracing::info!("Initial sync complete");
 
         // Record callback counts before post-sync operations
-        let mempool_received_before =
-            tracker.mempool_transaction_received_count.load(Ordering::SeqCst);
-        let block_changes_before = tracker.block_process_change_count.load(Ordering::SeqCst);
-        let block_records_before = tracker.block_process_change_record_count.load(Ordering::SeqCst);
+        let received_before = tracker.transaction_received_count.load(Ordering::SeqCst);
+        let block_changes_before = tracker.block_processed_wallet_count.load(Ordering::SeqCst);
+        let block_records_before =
+            tracker.block_processed_wallet_record_count.load(Ordering::SeqCst);
 
-        // Send DASH to the wallet. Wait for the mempool callback before mining
-        // so the SPV node observes the transaction in the mempool. If we mine
-        // immediately, the block path can deliver the transaction first and
-        // the mempool callback would never fire.
+        // Send DASH to the wallet. Wait for the off-chain callback before
+        // mining so the SPV node observes the transaction in the mempool.
+        // If we mine immediately, the block path can deliver the transaction
+        // first and the off-chain callback would never fire.
         let receive_address = ctx.get_receive_address(&wallet_id);
         let send_amount = Amount::from_sat(100_000_000);
         let txid = dashd.node.send_to_address(&receive_address, send_amount);
         tracing::info!("Sent {} to wallet, txid: {}", send_amount, txid);
 
         tracker.wait_for_callback(
-            &tracker.mempool_transaction_received_count,
-            mempool_received_before,
-            "mempool_transaction_received",
+            &tracker.transaction_received_count,
+            received_before,
+            "transaction_received",
         );
 
-        // The mempool callback updates `last_unconfirmed` with the post-event
-        // balance. Snapshot it now, before mining. After confirmation the
-        // block-process callback overwrites the same field back toward zero,
-        // so this is the only window in which the unconfirmed-balance update
-        // is observable.
+        // The off-chain callback updates `last_unconfirmed` with the
+        // post-event balance. Snapshot it now, before mining. After
+        // confirmation the block-processed callback overwrites the same
+        // field back toward zero, so this is the only window in which the
+        // unconfirmed-balance update is observable.
         let unconfirmed_after_mempool = tracker.last_unconfirmed.load(Ordering::SeqCst);
         assert!(
             unconfirmed_after_mempool > 0,
@@ -356,43 +368,42 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         // Wait for incremental sync to complete
         ctx.wait_for_sync(dashd.initial_height + 1);
 
-        // Wait for the block-process callback. The per-callback counter is
+        // Wait for the block-processed callback. The per-callback counter is
         // bumped last in the callback, so observing it incremented guarantees
         // the per-record vectors and counters have already been updated.
         tracker.wait_for_callback(
-            &tracker.block_process_change_count,
+            &tracker.block_processed_wallet_count,
             block_changes_before,
-            "block_process_change",
+            "block_processed",
         );
 
-        // Verify on_mempool_transaction_received fired for the new transaction
-        let mempool_received_after =
-            tracker.mempool_transaction_received_count.load(Ordering::SeqCst);
+        // Verify on_transaction_received fired for the new transaction
+        let received_after = tracker.transaction_received_count.load(Ordering::SeqCst);
         assert!(
-            mempool_received_after > mempool_received_before,
-            "on_mempool_transaction_received should fire for post-sync transaction: {} -> {}",
-            mempool_received_before,
-            mempool_received_after
+            received_after > received_before,
+            "on_transaction_received should fire for post-sync transaction: {} -> {}",
+            received_before,
+            received_after
         );
         tracing::info!(
-            "Mempool transaction callback verified: {} -> {}",
-            mempool_received_before,
-            mempool_received_after
+            "Off-chain transaction callback verified: {} -> {}",
+            received_before,
+            received_after
         );
 
-        // Verify the sent txid appears in the mempool callback data with a
-        // non-zero net_amount. Asserting against the mempool bucket (rather
-        // than the union of mempool+block records) ensures the mempool
-        // callback specifically delivered the txid — a broken mempool callback
-        // that pushed the wrong txid wouldn't be masked by the block path.
-        // The SPV wallet and dashd share the same mnemonic so the transaction
-        // is an internal transfer (wallet owns both inputs and outputs);
-        // net_amount therefore equals approximately -fee, not the nominal
-        // send amount.
+        // Verify the sent txid appears in the off-chain callback data with a
+        // non-zero net_amount. Asserting against the off-chain bucket (rather
+        // than the union of off-chain + block records) ensures the off-chain
+        // callback specifically delivered the txid — a broken off-chain
+        // callback that pushed the wrong txid wouldn't be masked by the
+        // block path. The SPV wallet and dashd share the same mnemonic so
+        // the transaction is an internal transfer (wallet owns both inputs
+        // and outputs); net_amount therefore equals approximately -fee, not
+        // the nominal send amount.
         let sent_txid_bytes = *txid.as_byte_array();
-        let mempool_received_txs = tracker.mempool_received_transactions.lock().unwrap();
-        let sent_entry = mempool_received_txs.iter().find(|&&(id, _)| id == sent_txid_bytes);
-        assert!(sent_entry.is_some(), "sent txid should appear in mempool callback data");
+        let received_txs = tracker.received_transactions.lock().unwrap();
+        let sent_entry = received_txs.iter().find(|&&(id, _)| id == sent_txid_bytes);
+        assert!(sent_entry.is_some(), "sent txid should appear in transaction callback data");
         let &(_, net_amount) = sent_entry.unwrap();
         // Internal transfer: net_amount = received - sent = (send_amount + change) - input = -fee.
         // The fee must be negative, non-zero, and small (< 0.001 DASH).
@@ -401,20 +412,27 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
             "internal transfer net_amount should equal -fee (small negative), got: {}",
             net_amount
         );
-        drop(mempool_received_txs);
+        drop(received_txs);
 
-        // Verify the mempool callback delivered a well-formed BIP-32 account
-        // path (e.g. `m/44'/1'/0'`).
-        let mempool_paths = tracker.mempool_account_paths.lock().unwrap();
+        // Verify the off-chain callback delivered the BIP-44 account
+        // discriminant + index 0 (default test account).
+        let received_types = tracker.received_account_types.lock().unwrap();
+        let received_indices = tracker.received_account_indices.lock().unwrap();
         assert!(
-            mempool_paths.iter().all(|p| p.starts_with("m/")),
-            "mempool callback should deliver a BIP-32 account path, got: {:?}",
-            *mempool_paths
+            received_types.iter().all(|t| *t == FFIAccountType::StandardBIP44),
+            "off-chain callback should deliver FFIAccountType::StandardBIP44, got: {:?}",
+            *received_types
         );
-        drop(mempool_paths);
+        assert!(
+            received_indices.iter().all(|i| *i == 0),
+            "off-chain BIP-44 callback should deliver account_index = 0, got: {:?}",
+            *received_indices
+        );
+        drop(received_indices);
+        drop(received_types);
 
         // The post-sync block confirms a transaction that was already known
-        // from the mempool, so the corresponding `BlockProcessChange` update
+        // from the mempool, so the corresponding `BlockProcessed` change
         // must carry `FFIRecordAction::Updated` rather than `Inserted`. Slice
         // by the pre-captured index so only post-sync entries are checked,
         // avoiding masking by any `Updated` that might appear during initial
@@ -435,9 +453,10 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         );
         drop(block_actions);
 
-        let block_records_after = tracker.block_process_change_record_count.load(Ordering::SeqCst);
+        let block_records_after =
+            tracker.block_processed_wallet_record_count.load(Ordering::SeqCst);
         tracing::info!(
-            "Block-process record callback verified: {} -> {}",
+            "Block-processed record callback verified: {} -> {}",
             block_records_before,
             block_records_after
         );

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use dash_spv::test_utils::{DashdTestContext, TestChain};
+use dash_spv_ffi::FFIRecordAction;
 use dashcore::hashes::Hash;
 use dashcore::Amount;
 
@@ -140,7 +141,11 @@ fn test_all_callbacks_during_sync() {
             "on_transaction_instant_send_locked should not fire during initial sync"
         );
 
-        // Validate SyncedHeightUpdated callback (atomicity boundary for persistence flush)
+        // Validate SyncedHeightUpdated callback (atomicity boundary for persistence flush).
+        // Wait explicitly for the callback because it travels on the same wallet
+        // broadcast channel as `BlockProcessChange` but is dispatched separately,
+        // so observing block-process records does not guarantee it has fired yet.
+        tracker.wait_for_callback(&tracker.synced_height_updated_count, 0, "synced_height_updated");
         let synced_height_fired = tracker.synced_height_updated_count.load(Ordering::SeqCst);
         let last_synced_height = tracker.last_synced_height.load(Ordering::SeqCst);
         assert!(
@@ -237,14 +242,39 @@ fn test_all_callbacks_during_sync() {
             "best height from peers should match initial height"
         );
 
-        // Validate transaction data from initial sync
-        let received_txs = tracker.received_transactions.lock().unwrap();
-        assert!(!received_txs.is_empty(), "should have received transactions during sync");
+        // Validate transaction data from initial sync. Historical sync only
+        // touches the block-process-change callback (mempool callback must
+        // remain silent during initial sync), so assert against that bucket
+        // explicitly.
+        let block_received = tracker.block_received_transactions.lock().unwrap();
+        assert!(!block_received.is_empty(), "should have received block records during sync");
         assert!(
-            received_txs.iter().any(|&(_, amount)| amount != 0),
-            "at least one received transaction amount should be non-zero"
+            block_received.iter().any(|&(_, amount)| amount != 0),
+            "at least one block-record net_amount should be non-zero"
         );
-        drop(received_txs);
+        drop(block_received);
+
+        // Validate FFIRecordAction is delivered: every record observed during
+        // initial sync is a fresh insertion (no prior mempool sighting).
+        let actions = tracker.block_record_actions.lock().unwrap();
+        assert!(!actions.is_empty(), "FFIRecordAction should be captured for block records");
+        assert!(
+            actions.iter().all(|a| *a == FFIRecordAction::Inserted),
+            "every block record during historical sync should carry FFIRecordAction::Inserted, got: {:?}",
+            *actions
+        );
+        drop(actions);
+
+        // Validate every block-record callback delivered a well-formed BIP-32
+        // account path string (e.g. `m/44'/1'/0'`).
+        let paths = tracker.block_account_paths.lock().unwrap();
+        assert!(!paths.is_empty(), "block account paths should be captured");
+        assert!(
+            paths.iter().all(|p| p.starts_with("m/")),
+            "every account_path should be a BIP-32 path string starting with `m/`, got: {:?}",
+            *paths
+        );
+        drop(paths);
 
         // Masternodes are disabled in test config, so these should not fire
         let masternode_updated = tracker.masternode_state_updated_count.load(Ordering::SeqCst);
@@ -333,17 +363,21 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
             mempool_received_after
         );
 
-        // Verify the sent txid appears in the callback data with a non-zero
-        // net_amount.  The SPV wallet and dashd share the same mnemonic so the
-        // transaction is an internal transfer (wallet owns both inputs and
-        // outputs); net_amount therefore equals approximately -fee, not the
-        // nominal send amount.
+        // Verify the sent txid appears in the mempool callback data with a
+        // non-zero net_amount. Asserting against the mempool bucket (rather
+        // than the union of mempool+block records) ensures the mempool
+        // callback specifically delivered the txid — a broken mempool callback
+        // that pushed the wrong txid wouldn't be masked by the block path.
+        // The SPV wallet and dashd share the same mnemonic so the transaction
+        // is an internal transfer (wallet owns both inputs and outputs);
+        // net_amount therefore equals approximately -fee, not the nominal
+        // send amount.
         let sent_txid_bytes = *txid.as_byte_array();
-        let received_txs = tracker.received_transactions.lock().unwrap();
-        let sent_entry = received_txs.iter().find(|&&(id, _)| id == sent_txid_bytes);
+        let mempool_received_txs = tracker.mempool_received_transactions.lock().unwrap();
+        let sent_entry = mempool_received_txs.iter().find(|&&(id, _)| id == sent_txid_bytes);
         assert!(
             sent_entry.is_some(),
-            "sent txid should appear in received transaction callback data"
+            "sent txid should appear in mempool callback data"
         );
         let &(_, net_amount) = sent_entry.unwrap();
         // Internal transfer: net_amount = received - sent = (send_amount + change) - input = -fee.
@@ -353,7 +387,29 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
             "internal transfer net_amount should equal -fee (small negative), got: {}",
             net_amount
         );
-        drop(received_txs);
+        drop(mempool_received_txs);
+
+        // Verify the mempool callback delivered a well-formed BIP-32 account
+        // path (e.g. `m/44'/1'/0'`).
+        let mempool_paths = tracker.mempool_account_paths.lock().unwrap();
+        assert!(
+            mempool_paths.iter().any(|p| p.starts_with("m/")),
+            "mempool callback should deliver a BIP-32 account path, got: {:?}",
+            *mempool_paths
+        );
+        drop(mempool_paths);
+
+        // The post-sync block confirms a transaction that was already known
+        // from the mempool, so the corresponding `BlockProcessChange` update
+        // must carry `FFIRecordAction::Updated` rather than `Inserted`.
+        let block_actions = tracker.block_record_actions.lock().unwrap();
+        assert!(
+            block_actions.contains(&FFIRecordAction::Updated),
+            "post-sync block confirming a known mempool tx should deliver \
+             FFIRecordAction::Updated, got: {:?}",
+            *block_actions
+        );
+        drop(block_actions);
 
         let block_records_after = tracker.block_process_change_record_count.load(Ordering::SeqCst);
         tracing::info!(

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -407,7 +407,7 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         // path (e.g. `m/44'/1'/0'`).
         let mempool_paths = tracker.mempool_account_paths.lock().unwrap();
         assert!(
-            mempool_paths.iter().any(|p| p.starts_with("m/")),
+            mempool_paths.iter().all(|p| p.starts_with("m/")),
             "mempool callback should deliver a BIP-32 account path, got: {:?}",
             *mempool_paths
         );

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -274,11 +274,20 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
             tracker.mempool_transaction_received_count.load(Ordering::SeqCst);
         let block_records_before = tracker.block_process_change_record_count.load(Ordering::SeqCst);
 
-        // Send DASH to the wallet and mine a block
+        // Send DASH to the wallet. Wait for the mempool callback before mining
+        // so the SPV node observes the transaction in the mempool. If we mine
+        // immediately, the block path can deliver the transaction first and
+        // the mempool callback would never fire.
         let receive_address = ctx.get_receive_address(&wallet_id);
         let send_amount = Amount::from_sat(100_000_000);
         let txid = dashd.node.send_to_address(&receive_address, send_amount);
         tracing::info!("Sent {} to wallet, txid: {}", send_amount, txid);
+
+        tracker.wait_for_callback(
+            &tracker.mempool_transaction_received_count,
+            mempool_received_before,
+            "mempool_transaction_received",
+        );
 
         let miner_address = dashd.node.get_new_address_from_wallet("default");
         dashd.node.generate_blocks(1, &miner_address);
@@ -286,12 +295,7 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         // Wait for incremental sync to complete
         ctx.wait_for_sync(dashd.initial_height + 1);
 
-        // Wait for wallet callbacks (they travel on a separate channel from sync events)
-        tracker.wait_for_callback(
-            &tracker.mempool_transaction_received_count,
-            mempool_received_before,
-            "mempool_transaction_received",
-        );
+        // Wait for the block-record callback (mempool callback already observed above).
         tracker.wait_for_callback(
             &tracker.block_process_change_record_count,
             block_records_before,

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -420,6 +420,12 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         // avoiding masking by any `Updated` that might appear during initial
         // sync.
         let block_actions = tracker.block_record_actions.lock().unwrap();
+        assert!(
+            block_actions.len() >= block_records_before as usize,
+            "block_record_actions length ({}) < block_records_before ({}): counter/vector mismatch",
+            block_actions.len(),
+            block_records_before
+        );
         let new_actions = &block_actions[block_records_before as usize..];
         assert!(
             new_actions.contains(&FFIRecordAction::Updated),

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -132,6 +132,10 @@ fn test_all_callbacks_during_sync() {
             "on_block_process_change should fire for blocks containing wallet records"
         );
         assert_eq!(
+            mempool_received, 0,
+            "on_mempool_transaction_received must not fire during historical block sync"
+        );
+        assert_eq!(
             instant_send_locked, 0,
             "on_transaction_instant_send_locked should not fire during initial sync"
         );

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -101,30 +101,40 @@ fn test_all_callbacks_during_sync() {
         drop(connected_peers);
 
         // Wait for wallet callbacks (they travel on a separate channel from sync events)
-        tracker.wait_for_callback(&tracker.transaction_received_count, 0, "transaction_received");
-        tracker.wait_for_callback(&tracker.balance_updated_count, 0, "balance_updated");
+        tracker.wait_for_callback(
+            &tracker.block_process_change_record_count,
+            0,
+            "block_process_change_record",
+        );
 
         // Validate wallet event callbacks (test wallet has transactions)
-        let tx_received = tracker.transaction_received_count.load(Ordering::SeqCst);
-        let balance_updated = tracker.balance_updated_count.load(Ordering::SeqCst);
-        let tx_status_changed = tracker.transaction_status_changed_count.load(Ordering::SeqCst);
+        let block_records = tracker.block_process_change_record_count.load(Ordering::SeqCst);
+        let block_changes = tracker.block_process_change_count.load(Ordering::SeqCst);
+        let mempool_received = tracker.mempool_transaction_received_count.load(Ordering::SeqCst);
+        let instant_send_locked =
+            tracker.transaction_instant_send_locked_count.load(Ordering::SeqCst);
 
         tracing::info!(
-            "Wallet: tx_received={}, tx_status_changed={}, balance_updated={}",
-            tx_received,
-            tx_status_changed,
-            balance_updated
+            "Wallet: mempool_received={}, instant_send_locked={}, block_changes={}, \
+             block_records={}",
+            mempool_received,
+            instant_send_locked,
+            block_changes,
+            block_records
         );
 
         assert!(
-            tx_received > 0,
-            "on_transaction_received should fire for wallet with transactions"
+            block_records > 0,
+            "on_block_process_change should deliver records for a wallet with transactions"
+        );
+        assert!(
+            block_changes > 0,
+            "on_block_process_change should fire for blocks containing wallet records"
         );
         assert_eq!(
-            tx_status_changed, 0,
-            "on_transaction_status_changed should not fire here, all transactions are confirmed."
+            instant_send_locked, 0,
+            "on_transaction_instant_send_locked should not fire during initial sync"
         );
-        assert!(balance_updated > 0, "on_balance_updated should fire for wallet with transactions");
 
         // Validate sync cycle (initial sync is cycle 0)
         let last_sync_cycle = tracker.last_sync_cycle.load(Ordering::SeqCst);
@@ -260,8 +270,9 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         tracing::info!("Initial sync complete");
 
         // Record callback counts before post-sync operations
-        let tx_received_before = tracker.transaction_received_count.load(Ordering::SeqCst);
-        let balance_updated_before = tracker.balance_updated_count.load(Ordering::SeqCst);
+        let mempool_received_before =
+            tracker.mempool_transaction_received_count.load(Ordering::SeqCst);
+        let block_records_before = tracker.block_process_change_record_count.load(Ordering::SeqCst);
 
         // Send DASH to the wallet and mine a block
         let receive_address = ctx.get_receive_address(&wallet_id);
@@ -277,28 +288,29 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
 
         // Wait for wallet callbacks (they travel on a separate channel from sync events)
         tracker.wait_for_callback(
-            &tracker.transaction_received_count,
-            tx_received_before,
-            "transaction_received",
+            &tracker.mempool_transaction_received_count,
+            mempool_received_before,
+            "mempool_transaction_received",
         );
         tracker.wait_for_callback(
-            &tracker.balance_updated_count,
-            balance_updated_before,
-            "balance_updated",
+            &tracker.block_process_change_record_count,
+            block_records_before,
+            "block_process_change_record",
         );
 
-        // Verify on_transaction_received fired for the new transaction
-        let tx_received_after = tracker.transaction_received_count.load(Ordering::SeqCst);
+        // Verify on_mempool_transaction_received fired for the new transaction
+        let mempool_received_after =
+            tracker.mempool_transaction_received_count.load(Ordering::SeqCst);
         assert!(
-            tx_received_after > tx_received_before,
-            "on_transaction_received should fire for post-sync transaction: {} -> {}",
-            tx_received_before,
-            tx_received_after
+            mempool_received_after > mempool_received_before,
+            "on_mempool_transaction_received should fire for post-sync transaction: {} -> {}",
+            mempool_received_before,
+            mempool_received_after
         );
         tracing::info!(
-            "Transaction callback verified: {} -> {}",
-            tx_received_before,
-            tx_received_after
+            "Mempool transaction callback verified: {} -> {}",
+            mempool_received_before,
+            mempool_received_after
         );
 
         // Verify the sent txid appears in the callback data with a non-zero
@@ -323,20 +335,18 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         );
         drop(received_txs);
 
-        let balance_updated_after = tracker.balance_updated_count.load(Ordering::SeqCst);
+        let block_records_after = tracker.block_process_change_record_count.load(Ordering::SeqCst);
         tracing::info!(
-            "Balance updated callback verified: {} -> {}",
-            balance_updated_before,
-            balance_updated_after
+            "Block-process record callback verified: {} -> {}",
+            block_records_before,
+            block_records_after
         );
 
-        // Verify balance data from callback reflects a positive spendable balance
-        let last_spendable = tracker.last_spendable.load(Ordering::SeqCst);
-        assert!(
-            last_spendable > 0,
-            "last_spendable from on_balance_updated should be positive after receiving funds"
-        );
-        tracing::info!("Balance data verified: last_spendable={}", last_spendable);
+        // Verify balance data from the most recent wallet event reflects a positive
+        // confirmed balance.
+        let last_confirmed = tracker.last_confirmed.load(Ordering::SeqCst);
+        assert!(last_confirmed > 0, "last_confirmed should be positive after receiving funds");
+        tracing::info!("Balance data verified: last_confirmed={}", last_confirmed);
 
         // Record connect count before disconnect
         let connect_before = tracker.peer_connected_count.load(Ordering::SeqCst);

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -140,6 +140,18 @@ fn test_all_callbacks_during_sync() {
             "on_transaction_instant_send_locked should not fire during initial sync"
         );
 
+        // Validate SyncedHeightUpdated callback (atomicity boundary for persistence flush)
+        let synced_height_fired = tracker.synced_height_updated_count.load(Ordering::SeqCst);
+        let last_synced_height = tracker.last_synced_height.load(Ordering::SeqCst);
+        assert!(
+            synced_height_fired > 0,
+            "on_synced_height_updated should fire at least once during sync"
+        );
+        assert_eq!(
+            last_synced_height, dashd.initial_height,
+            "last_synced_height should match initial_height after sync"
+        );
+
         // Validate sync cycle (initial sync is cycle 0)
         let last_sync_cycle = tracker.last_sync_cycle.load(Ordering::SeqCst);
         assert_eq!(last_sync_cycle, 0, "Initial sync should be cycle 0");

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -375,10 +375,7 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         let sent_txid_bytes = *txid.as_byte_array();
         let mempool_received_txs = tracker.mempool_received_transactions.lock().unwrap();
         let sent_entry = mempool_received_txs.iter().find(|&&(id, _)| id == sent_txid_bytes);
-        assert!(
-            sent_entry.is_some(),
-            "sent txid should appear in mempool callback data"
-        );
+        assert!(sent_entry.is_some(), "sent txid should appear in mempool callback data");
         let &(_, net_amount) = sent_entry.unwrap();
         // Internal transfer: net_amount = received - sent = (send_amount + change) - input = -fee.
         // The fee must be negative, non-zero, and small (< 0.001 DASH).

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -106,11 +106,7 @@ fn test_all_callbacks_during_sync() {
         // callback, after all per-record state has been written. Reading the
         // record counter afterwards is therefore guaranteed to see the matching
         // increment.
-        tracker.wait_for_callback(
-            &tracker.block_process_change_count,
-            0,
-            "block_process_change",
-        );
+        tracker.wait_for_callback(&tracker.block_process_change_count, 0, "block_process_change");
 
         // Validate wallet event callbacks (test wallet has transactions)
         let block_records = tracker.block_process_change_record_count.load(Ordering::SeqCst);

--- a/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
@@ -89,6 +89,12 @@ fn test_ffi_sync_then_generate_blocks() {
 
         // Verify FFIRecordAction was captured for the post-sync block records.
         let actions = ctx.tracker().block_record_actions.lock().unwrap();
+        assert!(
+            actions.len() >= block_records_before as usize,
+            "block_record_actions length ({}) < block_records_before ({}): counter/vector mismatch",
+            actions.len(),
+            block_records_before
+        );
         let new_actions = &actions[block_records_before as usize..];
         assert!(
             !new_actions.is_empty(),
@@ -98,6 +104,12 @@ fn test_ffi_sync_then_generate_blocks() {
 
         // Verify the BIP-32 account path was delivered for the post-sync block records.
         let paths = ctx.tracker().block_account_paths.lock().unwrap();
+        assert!(
+            paths.len() >= block_records_before as usize,
+            "block_account_paths length ({}) < block_records_before ({}): counter/vector mismatch",
+            paths.len(),
+            block_records_before
+        );
         let new_paths = &paths[block_records_before as usize..];
         assert!(
             new_paths.iter().any(|p| p.starts_with("m/")),

--- a/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
@@ -74,12 +74,12 @@ fn test_ffi_sync_then_generate_blocks() {
             "block_process_change_record",
         );
 
-        // Verify the transaction was received via wallet callback
-        let received_txs = ctx.tracker().received_transactions.lock().unwrap();
+        // Verify the transaction was received via the block-process-change callback
+        let received_txs = ctx.tracker().block_received_transactions.lock().unwrap();
         let txid_bytes = *txid.as_byte_array();
         assert!(
             received_txs.iter().any(|&(txid, _)| txid == txid_bytes),
-            "Wallet callback should have received txid {}",
+            "Block-process-change callback should have received txid {}",
             txid
         );
         drop(received_txs);

--- a/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
@@ -47,7 +47,8 @@ fn test_ffi_sync_then_generate_blocks() {
 
         // Generate a block containing a wallet transaction and wait for sync.
         let cycle_before = ctx.tracker().last_sync_cycle.load(Ordering::SeqCst);
-        let tx_received_before = ctx.tracker().transaction_received_count.load(Ordering::SeqCst);
+        let block_records_before =
+            ctx.tracker().block_process_change_record_count.load(Ordering::SeqCst);
         let receive_address = ctx.get_receive_address(&wallet_id);
         let send_amount = Amount::from_sat(100_000_000);
         let txid = dashd.node.send_to_address(&receive_address, send_amount);
@@ -68,9 +69,9 @@ fn test_ffi_sync_then_generate_blocks() {
 
         // Wait for wallet callback (travels on a separate channel from sync events)
         ctx.tracker().wait_for_callback(
-            &ctx.tracker().transaction_received_count,
-            tx_received_before,
-            "transaction_received",
+            &ctx.tracker().block_process_change_record_count,
+            block_records_before,
+            "block_process_change_record",
         );
 
         // Verify the transaction was received via wallet callback

--- a/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
@@ -47,8 +47,7 @@ fn test_ffi_sync_then_generate_blocks() {
 
         // Generate a block containing a wallet transaction and wait for sync.
         let cycle_before = ctx.tracker().last_sync_cycle.load(Ordering::SeqCst);
-        let block_changes_before =
-            ctx.tracker().block_process_change_count.load(Ordering::SeqCst);
+        let block_changes_before = ctx.tracker().block_process_change_count.load(Ordering::SeqCst);
         let block_records_before =
             ctx.tracker().block_process_change_record_count.load(Ordering::SeqCst);
         let receive_address = ctx.get_receive_address(&wallet_id);

--- a/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
@@ -47,6 +47,8 @@ fn test_ffi_sync_then_generate_blocks() {
 
         // Generate a block containing a wallet transaction and wait for sync.
         let cycle_before = ctx.tracker().last_sync_cycle.load(Ordering::SeqCst);
+        let block_changes_before =
+            ctx.tracker().block_process_change_count.load(Ordering::SeqCst);
         let block_records_before =
             ctx.tracker().block_process_change_record_count.load(Ordering::SeqCst);
         let receive_address = ctx.get_receive_address(&wallet_id);
@@ -67,11 +69,13 @@ fn test_ffi_sync_then_generate_blocks() {
             cycle_after_first
         );
 
-        // Wait for wallet callback (travels on a separate channel from sync events)
+        // Wait for wallet callback (travels on a separate channel from sync events).
+        // The per-callback counter is bumped last in the callback, so observing
+        // it incremented guarantees the per-record vectors are also updated.
         ctx.tracker().wait_for_callback(
-            &ctx.tracker().block_process_change_record_count,
-            block_records_before,
-            "block_process_change_record",
+            &ctx.tracker().block_process_change_count,
+            block_changes_before,
+            "block_process_change",
         );
 
         // Verify the transaction was received via the block-process-change callback
@@ -83,6 +87,25 @@ fn test_ffi_sync_then_generate_blocks() {
             txid
         );
         drop(received_txs);
+
+        // Verify FFIRecordAction was captured for the post-sync block records.
+        let actions = ctx.tracker().block_record_actions.lock().unwrap();
+        let new_actions = &actions[block_records_before as usize..];
+        assert!(
+            !new_actions.is_empty(),
+            "block_record_actions should be populated for the post-sync block"
+        );
+        drop(actions);
+
+        // Verify the BIP-32 account path was delivered for the post-sync block records.
+        let paths = ctx.tracker().block_account_paths.lock().unwrap();
+        let new_paths = &paths[block_records_before as usize..];
+        assert!(
+            new_paths.iter().any(|p| p.starts_with("m/")),
+            "block account path should be a valid BIP-32 path, got: {:?}",
+            new_paths
+        );
+        drop(paths);
 
         // Verify via wallet query as well
         assert!(

--- a/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::Ordering;
 
 use dash_spv::test_utils::{DashdTestContext, TestChain};
+use dash_spv_ffi::FFIAccountType;
 use dashcore::hashes::Hash;
 use dashcore::Amount;
 
@@ -47,9 +48,10 @@ fn test_ffi_sync_then_generate_blocks() {
 
         // Generate a block containing a wallet transaction and wait for sync.
         let cycle_before = ctx.tracker().last_sync_cycle.load(Ordering::SeqCst);
-        let block_changes_before = ctx.tracker().block_process_change_count.load(Ordering::SeqCst);
+        let block_changes_before =
+            ctx.tracker().block_processed_wallet_count.load(Ordering::SeqCst);
         let block_records_before =
-            ctx.tracker().block_process_change_record_count.load(Ordering::SeqCst);
+            ctx.tracker().block_processed_wallet_record_count.load(Ordering::SeqCst);
         let receive_address = ctx.get_receive_address(&wallet_id);
         let send_amount = Amount::from_sat(100_000_000);
         let txid = dashd.node.send_to_address(&receive_address, send_amount);
@@ -72,17 +74,17 @@ fn test_ffi_sync_then_generate_blocks() {
         // The per-callback counter is bumped last in the callback, so observing
         // it incremented guarantees the per-record vectors are also updated.
         ctx.tracker().wait_for_callback(
-            &ctx.tracker().block_process_change_count,
+            &ctx.tracker().block_processed_wallet_count,
             block_changes_before,
-            "block_process_change",
+            "block_processed",
         );
 
-        // Verify the transaction was received via the block-process-change callback
+        // Verify the transaction was received via the block-processed callback
         let received_txs = ctx.tracker().block_received_transactions.lock().unwrap();
         let txid_bytes = *txid.as_byte_array();
         assert!(
             received_txs.iter().any(|&(txid, _)| txid == txid_bytes),
-            "Block-process-change callback should have received txid {}",
+            "Block-processed callback should have received txid {}",
             txid
         );
         drop(received_txs);
@@ -102,21 +104,35 @@ fn test_ffi_sync_then_generate_blocks() {
         );
         drop(actions);
 
-        // Verify the BIP-32 account path was delivered for the post-sync block records.
-        let paths = ctx.tracker().block_account_paths.lock().unwrap();
+        // Verify the BIP-44 account discriminant + index were delivered for
+        // the post-sync block records.
+        let types = ctx.tracker().block_account_types.lock().unwrap();
+        let indices = ctx.tracker().block_account_indices.lock().unwrap();
         assert!(
-            paths.len() >= block_records_before as usize,
-            "block_account_paths length ({}) < block_records_before ({}): counter/vector mismatch",
-            paths.len(),
+            types.len() >= block_records_before as usize,
+            "block_account_types length ({}) < block_records_before ({}): counter/vector mismatch",
+            types.len(),
             block_records_before
         );
-        let new_paths = &paths[block_records_before as usize..];
-        assert!(
-            new_paths.iter().any(|p| p.starts_with("m/")),
-            "block account path should be a valid BIP-32 path, got: {:?}",
-            new_paths
+        assert_eq!(
+            types.len(),
+            indices.len(),
+            "block account types and indices must be paired 1:1"
         );
-        drop(paths);
+        let new_types = &types[block_records_before as usize..];
+        let new_indices = &indices[block_records_before as usize..];
+        assert!(
+            new_types.iter().all(|t| *t == FFIAccountType::StandardBIP44),
+            "post-sync block changes should carry FFIAccountType::StandardBIP44, got: {:?}",
+            new_types
+        );
+        assert!(
+            new_indices.iter().all(|i| *i == 0),
+            "post-sync BIP-44 changes should carry account_index = 0, got: {:?}",
+            new_indices
+        );
+        drop(indices);
+        drop(types);
 
         // Verify via wallet query as well
         assert!(

--- a/dash-spv/src/network/addrv2.rs
+++ b/dash-spv/src/network/addrv2.rs
@@ -2,7 +2,7 @@
 
 use rand::prelude::*;
 use std::collections::{HashMap, HashSet};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
@@ -23,6 +23,19 @@ fn evict_if_needed(peers: &mut HashMap<SocketAddr, AddrV2Message>) {
         entries.sort_by_key(|(_, msg)| std::cmp::Reverse(msg.time));
         entries.truncate(MAX_ADDR_TO_STORE);
         peers.extend(entries);
+    }
+}
+
+fn make_addr_message(addr: SocketAddr, services: ServiceFlags, time: u32) -> AddrV2Message {
+    let addr_v2 = match addr.ip() {
+        IpAddr::V4(ipv4) => AddrV2::Ipv4(ipv4),
+        IpAddr::V6(ipv6) => AddrV2::Ipv6(ipv6),
+    };
+    AddrV2Message {
+        time,
+        services,
+        addr: addr_v2,
+        port: addr.port(),
     }
 }
 
@@ -134,21 +147,36 @@ impl AddrV2Handler {
             })
             .as_secs() as u32;
 
-        let addr_v2 = match addr.ip() {
-            std::net::IpAddr::V4(ipv4) => AddrV2::Ipv4(ipv4),
-            std::net::IpAddr::V6(ipv6) => AddrV2::Ipv6(ipv6),
-        };
+        let mut known_peers = self.known_peers.write().await;
+        known_peers.insert(addr, make_addr_message(addr, services, now));
+        evict_if_needed(&mut known_peers);
+    }
 
-        let addr_msg = AddrV2Message {
-            time: now,
-            services,
-            addr: addr_v2,
-            port: addr.port(),
-        };
+    /// Bump the stored `AddrV2.time` for `addr` to now after directly observing
+    /// the peer (e.g. a successful handshake) and record the handshake-verified
+    /// `services`. A first-hand observation is authoritative, so both `time` and
+    /// `services` are overwritten on existing entries. If the entry is missing it
+    /// is created with the provided values.
+    pub async fn mark_seen(&self, addr: SocketAddr, services: ServiceFlags) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|e| {
+                tracing::error!("System time error in mark_seen: {}", e);
+                Duration::from_secs(0)
+            })
+            .as_secs() as u32;
 
         let mut known_peers = self.known_peers.write().await;
-        known_peers.insert(addr, addr_msg);
-        evict_if_needed(&mut known_peers);
+        match known_peers.get_mut(&addr) {
+            Some(existing) => {
+                existing.time = now;
+                existing.services = services;
+            }
+            None => {
+                known_peers.insert(addr, make_addr_message(addr, services, now));
+                evict_if_needed(&mut known_peers);
+            }
+        }
     }
 
     /// Build a GetAddr response message
@@ -188,6 +216,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mark_seen_bumps_time_and_updates_services() {
+        let handler = AddrV2Handler::new();
+        let addr: SocketAddr = "10.0.0.5:9999".parse().unwrap();
+
+        // Seed via AddrV2 gossip with a stale-but-valid timestamp and richer services.
+        let gossip_services = ServiceFlags::NETWORK | ServiceFlags::COMPACT_FILTERS;
+        let ipv4_addr = match addr.ip() {
+            IpAddr::V4(v4) => v4,
+            _ => panic!("test expects IPv4"),
+        };
+        let now =
+            SystemTime::now().duration_since(UNIX_EPOCH).expect("system time").as_secs() as u32;
+        let stale_time = now.saturating_sub(3600);
+        handler
+            .handle_addrv2(vec![AddrV2Message {
+                time: stale_time,
+                services: gossip_services,
+                addr: AddrV2::Ipv4(ipv4_addr),
+                port: addr.port(),
+            }])
+            .await;
+
+        // Observe the peer directly — handshake-verified services are authoritative.
+        let handshake_services = ServiceFlags::NETWORK;
+        handler.mark_seen(addr, handshake_services).await;
+
+        let known = handler.get_known_addresses().await;
+        let entry = known.iter().find(|m| m.socket_addr().ok() == Some(addr)).expect("entry");
+        assert!(entry.time >= now);
+        assert!(entry.time > stale_time);
+        assert_eq!(entry.services, handshake_services);
+    }
+
+    #[tokio::test]
+    async fn test_mark_seen_inserts_new_entry() {
+        let handler = AddrV2Handler::new();
+        let addr: SocketAddr = "10.0.0.6:9999".parse().unwrap();
+
+        assert!(handler.get_known_addresses().await.is_empty());
+
+        handler.mark_seen(addr, ServiceFlags::NETWORK).await;
+
+        let known = handler.get_known_addresses().await;
+        assert_eq!(known.len(), 1);
+        assert_eq!(known[0].socket_addr().unwrap(), addr);
+        assert_eq!(known[0].services, ServiceFlags::NETWORK);
+    }
+
+    #[tokio::test]
+    async fn test_mark_seen_evicts_when_at_capacity() {
+        let handler = AddrV2Handler::new();
+
+        // Use staggered timestamps strictly older than the mark_seen call below so
+        // the new entry is definitively the freshest and survives eviction.
+        let base_time =
+            (SystemTime::now().duration_since(UNIX_EPOCH).expect("system time").as_secs() as u32)
+                .saturating_sub(ONE_WEEK / 2);
+
+        let msgs: Vec<AddrV2Message> = (0..MAX_ADDR_TO_STORE)
+            .map(|i| {
+                let addr: SocketAddr =
+                    format!("10.{}.{}.1:9999", i / 256, i % 256).parse().unwrap();
+                make_addr_message(addr, ServiceFlags::NETWORK, base_time - i as u32)
+            })
+            .collect();
+        handler.handle_addrv2(msgs).await;
+
+        assert_eq!(handler.get_known_addresses().await.len(), MAX_ADDR_TO_STORE);
+
+        let new_addr: SocketAddr = "192.168.99.99:9999".parse().unwrap();
+        handler.mark_seen(new_addr, ServiceFlags::NETWORK).await;
+
+        let known = handler.get_known_addresses().await;
+        assert_eq!(known.len(), MAX_ADDR_TO_STORE);
+        assert!(known.iter().any(|m| m.socket_addr().ok() == Some(new_addr)));
+    }
+
+    #[tokio::test]
     async fn test_addrv2_timestamp_validation() {
         let handler = AddrV2Handler::new();
         let now = SystemTime::now()
@@ -199,7 +305,7 @@ mod tests {
         let addr: SocketAddr =
             "127.0.0.1:9999".parse().expect("Failed to parse test socket address");
         let ipv4_addr = match addr.ip() {
-            std::net::IpAddr::V4(v4) => v4,
+            IpAddr::V4(v4) => v4,
             _ => panic!("Test expects IPv4 address but got IPv6"),
         };
 

--- a/dash-spv/src/network/handshake.rs
+++ b/dash-spv/src/network/handshake.rs
@@ -301,6 +301,11 @@ impl HandshakeManager {
         self.peer_version
     }
 
+    /// Get the service flags advertised by the peer in its version message.
+    pub fn peer_services(&self) -> Option<ServiceFlags> {
+        self.peer_services
+    }
+
     /// Check if peer supports headers2 compression.
     pub fn peer_supports_headers2(&self) -> bool {
         self.peer_services.map(|services| services.has(NODE_HEADERS_COMPRESSED)).unwrap_or(false)

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -308,6 +308,10 @@ impl PeerNetworkManager {
                                 tracing::warn!("Failed to send GetAddr to {}: {}", addr, e);
                             }
 
+                            // Capture peer-advertised services before the peer is moved into the pool.
+                            let peer_services =
+                                handshake_manager.peer_services().unwrap_or(ServiceFlags::NETWORK);
+
                             // Record successful connection
                             reputation_manager.record_successful_connection(addr).await;
 
@@ -333,8 +337,9 @@ impl PeerNetworkManager {
                                 best_height,
                             });
 
-                            // Add to known addresses
-                            addrv2_handler.add_known_address(addr, ServiceFlags::NETWORK).await;
+                            // Bump the AddrV2 time on direct observation, using the peer's
+                            // actual advertised services from the version message.
+                            addrv2_handler.mark_seen(addr, peer_services).await;
 
                             // // Start message reader for this peer
                             Self::start_peer_reader(
@@ -354,9 +359,8 @@ impl PeerNetworkManager {
                             tracing::warn!("Handshake failed with {}: {}", addr, e);
                             // Only clears connecting set. Peer was never added, so no count/event needed.
                             pool.remove_peer(&addr).await;
-                            // Update reputation for handshake failure
                             reputation_manager
-                                .update_reputation(
+                                .record_failure_with_penalty(
                                     addr,
                                     misbehavior_scores::INVALID_MESSAGE,
                                     "Handshake failed",
@@ -371,9 +375,8 @@ impl PeerNetworkManager {
                     tracing::debug!("Failed to connect to {}: {}", addr, e);
                     // Only clears connecting set. Peer was never added, so no count/event needed.
                     pool.remove_peer(&addr).await;
-                    // Minor reputation penalty for connection failure
                     reputation_manager
-                        .update_reputation(
+                        .record_failure_with_penalty(
                             addr,
                             misbehavior_scores::TIMEOUT / 2,
                             "Connection failed",

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::RwLock;
 
 /// Misbehavior score thresholds for different violations
@@ -129,6 +129,37 @@ where
     Ok(v)
 }
 
+const MAX_CONSECUTIVE_FAILURES: u32 = 1_000;
+
+fn clamp_peer_consecutive_failures<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut v = u32::deserialize(deserializer)?;
+
+    if v > MAX_CONSECUTIVE_FAILURES {
+        tracing::warn!(
+            "Peer has excessive consecutive failures {v}, clamping to {MAX_CONSECUTIVE_FAILURES}"
+        );
+        v = MAX_CONSECUTIVE_FAILURES
+    }
+
+    Ok(v)
+}
+
+/// Clock-drift tolerance for future timestamps: up to 10 seconds ahead is accepted.
+const FUTURE_TIMESTAMP_TOLERANCE: Duration = Duration::from_secs(10);
+
+fn clamp_future_system_time<'de, D>(d: D) -> Result<Option<SystemTime>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<SystemTime>::deserialize(d)?;
+    let now = SystemTime::now();
+    let deadline = now.checked_add(FUTURE_TIMESTAMP_TOLERANCE).unwrap_or(now);
+    Ok(opt.filter(|t| *t <= deadline))
+}
+
 /// Peer reputation entry
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeerReputation {
@@ -161,9 +192,25 @@ pub struct PeerReputation {
     /// Successful connection count
     pub successful_connections: u64,
 
-    /// Last connection time
+    /// Monotonic instant of the last connection attempt within the current process session.
+    /// Resets to `None` on restart. Used for runtime decisions such as immediate
+    /// reconnect throttling. For persistent cooldown/backoff logic use `last_tried`.
     #[serde(skip)]
     pub last_connection: Option<Instant>,
+
+    /// Wall-clock time of the last successful handshake with this peer.
+    #[serde(default, deserialize_with = "clamp_future_system_time")]
+    pub last_success: Option<SystemTime>,
+
+    /// Wall-clock time of the last attempted connection to this peer (persisted across
+    /// restarts). The canonical source for cooldown and backoff decisions that must
+    /// survive process restarts. Distinct from `last_connection`, which is session-only.
+    #[serde(default, deserialize_with = "clamp_future_system_time")]
+    pub last_tried: Option<SystemTime>,
+
+    /// Failures since the last success. Resets to 0 on a successful handshake.
+    #[serde(deserialize_with = "clamp_peer_consecutive_failures")]
+    pub consecutive_failures: u32,
 }
 
 impl Default for PeerReputation {
@@ -178,11 +225,24 @@ impl Default for PeerReputation {
             connection_attempts: 0,
             successful_connections: 0,
             last_connection: None,
+            last_success: None,
+            last_tried: None,
+            consecutive_failures: 0,
         }
     }
 }
 
 impl PeerReputation {
+    /// Enforce internal consistency after loading from persistent storage. If
+    /// `last_tried` was discarded (e.g., because it was a future timestamp),
+    /// `consecutive_failures` has no temporal anchor and must be reset to 0 to
+    /// avoid incorrect backoff behaviour.
+    fn normalize_after_load(&mut self) {
+        if self.last_tried.is_none() && self.consecutive_failures > 0 {
+            self.consecutive_failures = 0;
+        }
+    }
+
     /// Check if the peer is currently banned
     pub fn is_banned(&self) -> bool {
         self.banned_until.is_some_and(|until| Instant::now() < until)
@@ -198,6 +258,54 @@ impl PeerReputation {
                 None
             }
         })
+    }
+
+    /// Apply the common fields updated on every failure: refresh `last_tried` and
+    /// increment `consecutive_failures`, clamped to `MAX_CONSECUTIVE_FAILURES`.
+    fn record_failure_fields(&mut self) {
+        self.last_tried = Some(SystemTime::now());
+        self.consecutive_failures =
+            self.consecutive_failures.saturating_add(1).min(MAX_CONSECUTIVE_FAILURES);
+    }
+
+    /// Apply a score change. Assumes decay has already been applied.
+    /// Returns `true` if the peer was banned by this call.
+    fn apply_score_change(&mut self, score_change: i32, peer: SocketAddr, reason: &str) -> bool {
+        let old_score = self.score;
+        self.score =
+            (self.score + score_change).clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
+
+        if score_change > 0 {
+            self.negative_actions += 1;
+        } else if score_change < 0 {
+            self.positive_actions += 1;
+        }
+
+        let should_ban = self.score >= MAX_MISBEHAVIOR_SCORE && !self.is_banned();
+        if should_ban {
+            self.banned_until = Some(Instant::now() + BAN_DURATION);
+            self.ban_count += 1;
+            tracing::warn!(
+                "Peer {} banned for misbehavior (score: {}, ban #{}, reason: {})",
+                peer,
+                self.score,
+                self.ban_count,
+                reason
+            );
+        }
+
+        if score_change.abs() >= 10 || should_ban {
+            tracing::info!(
+                "Peer {} reputation changed: {} -> {} (change: {}, reason: {})",
+                peer,
+                old_score,
+                self.score,
+                score_change,
+                reason
+            );
+        }
+
+        should_ban
     }
 
     /// Apply reputation decay
@@ -270,48 +378,9 @@ impl PeerReputationManager {
         let mut reputations = self.reputations.write().await;
         let reputation = reputations.entry(peer).or_default();
 
-        // Apply decay first
         reputation.apply_decay();
+        let should_ban = reputation.apply_score_change(score_change, peer, reason);
 
-        // Update score
-        let old_score = reputation.score;
-        reputation.score =
-            (reputation.score + score_change).clamp(MIN_MISBEHAVIOR_SCORE, MAX_MISBEHAVIOR_SCORE);
-
-        // Track positive/negative actions
-        if score_change > 0 {
-            reputation.negative_actions += 1;
-        } else if score_change < 0 {
-            reputation.positive_actions += 1;
-        }
-
-        // Check if peer should be banned
-        let should_ban = reputation.score >= MAX_MISBEHAVIOR_SCORE && !reputation.is_banned();
-        if should_ban {
-            reputation.banned_until = Some(Instant::now() + BAN_DURATION);
-            reputation.ban_count += 1;
-            tracing::warn!(
-                "Peer {} banned for misbehavior (score: {}, ban #{}, reason: {})",
-                peer,
-                reputation.score,
-                reputation.ban_count,
-                reason
-            );
-        }
-
-        // Log significant changes
-        if score_change.abs() >= 10 || should_ban {
-            tracing::info!(
-                "Peer {} reputation changed: {} -> {} (change: {}, reason: {})",
-                peer,
-                old_score,
-                reputation.score,
-                score_change,
-                reason
-            );
-        }
-
-        // Record event
         let event = ReputationEvent {
             peer,
             change: score_change,
@@ -383,6 +452,7 @@ impl PeerReputationManager {
         let reputation = reputations.entry(peer).or_default();
         reputation.connection_attempts += 1;
         reputation.last_connection = Some(Instant::now());
+        reputation.last_tried = Some(SystemTime::now());
     }
 
     /// Record a successful connection
@@ -390,6 +460,47 @@ impl PeerReputationManager {
         let mut reputations = self.reputations.write().await;
         let reputation = reputations.entry(peer).or_default();
         reputation.successful_connections += 1;
+        reputation.last_success = Some(SystemTime::now());
+        reputation.consecutive_failures = 0;
+    }
+
+    /// Record a connection failure and apply a reputation penalty in a single write-lock
+    /// acquisition. Returns `true` if the peer was banned by this call.
+    ///
+    /// `score_change` must be non-negative. A value of `0` records the failure (increments
+    /// `consecutive_failures`, updates `last_tried`) without applying a reputation penalty,
+    /// which is useful for tracking failures whose root cause doesn't warrant a ban contribution.
+    /// Any negative `score_change` is clamped to 0 (panics in debug).
+    pub async fn record_failure_with_penalty(
+        &self,
+        peer: SocketAddr,
+        score_change: i32,
+        reason: &str,
+    ) -> bool {
+        debug_assert!(
+            score_change >= 0,
+            "record_failure_with_penalty expects non-negative score change"
+        );
+        let score_change = score_change.max(0);
+        let should_ban = {
+            let mut reputations = self.reputations.write().await;
+            let reputation = reputations.entry(peer).or_default();
+
+            reputation.record_failure_fields();
+
+            reputation.apply_decay();
+            reputation.apply_score_change(score_change, peer, reason)
+        };
+
+        let event = ReputationEvent {
+            peer,
+            change: score_change,
+            reason: reason.to_string(),
+            timestamp: Instant::now(),
+        };
+        self.record_event(event).await;
+
+        should_ban
     }
 
     /// Get all peer reputations
@@ -465,6 +576,8 @@ impl PeerReputationManager {
             // Validate successful connections don't exceed attempts
             reputation.successful_connections =
                 reputation.successful_connections.min(reputation.connection_attempts);
+
+            reputation.normalize_after_load();
 
             // Skip entry if data appears corrupted
             if reputation.positive_actions > MAX_ACTION_COUNT

--- a/dash-spv/src/network/reputation_tests.rs
+++ b/dash-spv/src/network/reputation_tests.rs
@@ -6,6 +6,7 @@ mod tests {
 
     use super::super::*;
     use std::net::SocketAddr;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[tokio::test]
     async fn test_basic_reputation_operations() {
@@ -114,5 +115,328 @@ mod tests {
 
         assert_eq!(rep.connection_attempts, 2);
         assert_eq!(rep.successful_connections, 1);
+    }
+
+    #[test]
+    fn test_default_session_outcomes_are_empty() {
+        let rep = PeerReputation::default();
+
+        assert!(rep.last_success.is_none());
+        assert!(rep.last_tried.is_none());
+        assert_eq!(rep.consecutive_failures, 0);
+    }
+
+    #[tokio::test]
+    async fn test_record_connection_attempt_sets_last_tried() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:1111".parse().unwrap();
+
+        let before = SystemTime::now();
+        manager.record_connection_attempt(peer).await;
+        let after = SystemTime::now();
+
+        let reputations = manager.get_all_reputations().await;
+        let rep = &reputations[&peer];
+
+        let last_tried = rep.last_tried.expect("last_tried should be set");
+        assert!(last_tried >= before);
+        assert!(last_tried <= after);
+        assert!(rep.last_success.is_none());
+        assert_eq!(rep.consecutive_failures, 0);
+    }
+
+    #[tokio::test]
+    async fn test_record_successful_connection_sets_last_success_and_resets_failures() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:2222".parse().unwrap();
+
+        // Seed a non-zero failure streak first to verify the reset behaviour.
+        manager.record_failure_with_penalty(peer, 1, "seed").await;
+        manager.record_failure_with_penalty(peer, 1, "seed").await;
+        manager.record_failure_with_penalty(peer, 1, "seed").await;
+        let last_tried_before_success = {
+            let reputations = manager.get_all_reputations().await;
+            assert_eq!(reputations[&peer].consecutive_failures, 3);
+            reputations[&peer].last_tried.expect("last_tried set by failure seeds")
+        };
+
+        let before = SystemTime::now();
+        manager.record_successful_connection(peer).await;
+        let after = SystemTime::now();
+
+        let reputations = manager.get_all_reputations().await;
+        let rep = &reputations[&peer];
+
+        let last_success = rep.last_success.expect("last_success should be set");
+        assert!(last_success >= before);
+        assert!(last_success <= after);
+        assert_eq!(rep.consecutive_failures, 0);
+        assert_eq!(rep.successful_connections, 1);
+        assert_eq!(
+            rep.last_tried,
+            Some(last_tried_before_success),
+            "record_successful_connection must not clear last_tried"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_increments_streak_and_applies_score() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:5555".parse().unwrap();
+
+        manager.record_successful_connection(peer).await;
+        let success_ts = manager
+            .get_all_reputations()
+            .await
+            .get(&peer)
+            .expect("peer exists")
+            .last_success
+            .expect("last_success should be set after successful connection");
+
+        let banned = manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_MESSAGE, "test")
+            .await;
+        assert!(!banned);
+
+        let reputations = manager.get_all_reputations().await;
+        let rep = &reputations[&peer];
+        assert_eq!(rep.consecutive_failures, 1);
+        assert_eq!(rep.score, misbehavior_scores::INVALID_MESSAGE);
+        assert_eq!(
+            rep.last_success,
+            Some(success_ts),
+            "record_failure_with_penalty must not clear last_success"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_always_sets_last_tried() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:6666".parse().unwrap();
+
+        let before = SystemTime::now();
+        manager.record_failure_with_penalty(peer, 5, "test").await;
+        let after = SystemTime::now();
+
+        let reputations = manager.get_all_reputations().await;
+        let last_tried = reputations[&peer].last_tried.expect("last_tried should be set");
+        assert!(last_tried >= before);
+        assert!(last_tried <= after);
+
+        let before_second = SystemTime::now();
+        manager.record_failure_with_penalty(peer, 5, "test again").await;
+        let after_second = SystemTime::now();
+
+        let second_tried = manager
+            .get_all_reputations()
+            .await
+            .get(&peer)
+            .unwrap()
+            .last_tried
+            .expect("last_tried should be updated");
+        assert!(second_tried >= before_second);
+        assert!(second_tried <= after_second);
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_triggers_ban() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:7777".parse().unwrap();
+
+        // Apply enough score to bring the peer to the ban threshold.
+        // INVALID_HEADER = 50, so two calls reach 100 = MAX_MISBEHAVIOR_SCORE.
+        let first = manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_HEADER, "bad header 1")
+            .await;
+        assert!(!first);
+
+        let second = manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_HEADER, "bad header 2")
+            .await;
+        assert!(second, "second call should trigger a ban");
+        assert!(manager.is_banned(&peer).await);
+        assert_eq!(manager.get_all_reputations().await[&peer].consecutive_failures, 2);
+    }
+
+    #[test]
+    fn test_consecutive_failures_clamped_on_deserialize() {
+        let json = r#"{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":0,"successful_connections":0,"last_success":null,"last_tried":null,"consecutive_failures":99999}"#;
+        let rep: PeerReputation = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(rep.consecutive_failures, MAX_CONSECUTIVE_FAILURES);
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_streak_keeps_incrementing() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:8888".parse().unwrap();
+
+        // Each call should increment the streak independently, never resetting.
+        for expected in 1u32..=5 {
+            manager.record_failure_with_penalty(peer, 1, "extra failure").await;
+            let reputations = manager.get_all_reputations().await;
+            assert_eq!(reputations[&peer].consecutive_failures, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_consecutive_failures_saturates_at_runtime() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:9191".parse().unwrap();
+
+        for _ in 0..=MAX_CONSECUTIVE_FAILURES {
+            manager.record_failure_with_penalty(peer, 1, "flood").await;
+        }
+
+        let reputations = manager.get_all_reputations().await;
+        assert_eq!(reputations[&peer].consecutive_failures, MAX_CONSECUTIVE_FAILURES);
+    }
+
+    #[tokio::test]
+    async fn test_record_failure_with_penalty_updates_last_tried_after_attempt() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:9100".parse().unwrap();
+
+        manager.record_connection_attempt(peer).await;
+        let attempt_time = manager.get_all_reputations().await[&peer]
+            .last_tried
+            .expect("last_tried set by attempt");
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        manager
+            .record_failure_with_penalty(peer, misbehavior_scores::INVALID_MESSAGE, "test")
+            .await;
+        let after_failure = manager.get_all_reputations().await[&peer]
+            .last_tried
+            .expect("last_tried still set after failure");
+
+        assert!(after_failure > attempt_time, "failure should update last_tried");
+    }
+
+    fn make_reputation_json(
+        last_tried_secs: Option<u64>,
+        last_success_secs: Option<u64>,
+    ) -> String {
+        let last_tried = match last_tried_secs {
+            Some(s) => format!(r#"{{"secs_since_epoch":{s},"nanos_since_epoch":0}}"#),
+            None => "null".to_string(),
+        };
+        let last_success = match last_success_secs {
+            Some(s) => format!(r#"{{"secs_since_epoch":{s},"nanos_since_epoch":0}}"#),
+            None => "null".to_string(),
+        };
+        format!(
+            r#"{{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":0,"successful_connections":0,"last_success":{last_success},"last_tried":{last_tried},"consecutive_failures":0}}"#
+        )
+    }
+
+    #[test]
+    fn test_clamp_future_system_time() {
+        let now_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+
+        // Future timestamps (1 hour ahead) must be discarded.
+        let future_secs = now_secs + 3600;
+        let json = make_reputation_json(Some(future_secs), Some(future_secs));
+        let rep: PeerReputation = serde_json::from_str(&json).expect("deserialize");
+        assert!(rep.last_tried.is_none(), "future last_tried must be nulled");
+        assert!(rep.last_success.is_none(), "future last_success must be nulled");
+
+        // Recent past (10 seconds ago) must be preserved.
+        let recent_secs = now_secs - 10;
+        let json = make_reputation_json(Some(recent_secs), Some(recent_secs));
+        let rep: PeerReputation = serde_json::from_str(&json).expect("deserialize");
+        assert!(rep.last_tried.is_some(), "recent last_tried must be preserved");
+        assert!(rep.last_success.is_some(), "recent last_success must be preserved");
+        let expected = UNIX_EPOCH + Duration::from_secs(recent_secs);
+        assert_eq!(rep.last_tried.unwrap(), expected);
+        assert_eq!(rep.last_success.unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_connection_attempt_then_success_preserves_last_tried() {
+        let manager = PeerReputationManager::new();
+        let peer: SocketAddr = "127.0.0.1:9101".parse().unwrap();
+
+        manager.record_connection_attempt(peer).await;
+        let tried_after_attempt =
+            manager.get_all_reputations().await[&peer].last_tried.expect("attempt sets last_tried");
+        assert!(manager.get_all_reputations().await[&peer].last_success.is_none());
+
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        manager.record_successful_connection(peer).await;
+
+        let rep = &manager.get_all_reputations().await[&peer];
+        assert_eq!(
+            rep.last_tried,
+            Some(tried_after_attempt),
+            "success must preserve last_tried from the preceding attempt"
+        );
+        assert!(rep.last_success.is_some(), "success sets last_success");
+        assert_eq!(rep.consecutive_failures, 0);
+    }
+
+    #[tokio::test]
+    async fn test_normalize_after_load_via_storage_round_trip() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        // Write a reputations.json directly so we can embed a future `last_tried`
+        // that `clamp_future_system_time` will discard on load, and a non-zero
+        // `consecutive_failures` that `normalize_after_load` must then reset to 0.
+        let peers_dir = temp_dir.path().join("peers");
+        std::fs::create_dir_all(&peers_dir).unwrap();
+        let reputation_file = peers_dir.join("reputations.json");
+
+        let future_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 3_600;
+        let json = format!(
+            r#"{{"127.0.0.1:9202":{{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":3,"successful_connections":2,"last_success":null,"last_tried":{{"secs_since_epoch":{future_secs},"nanos_since_epoch":0}},"consecutive_failures":5}}}}"#
+        );
+        std::fs::write(&reputation_file, json).unwrap();
+
+        let peer_storage = PersistentPeerStorage::open(temp_dir.path())
+            .await
+            .expect("Failed to open PersistentPeerStorage");
+
+        let manager = PeerReputationManager::new();
+        manager.load_from_storage(&peer_storage).await.unwrap();
+
+        let peer: SocketAddr = "127.0.0.1:9202".parse().unwrap();
+        let reputations = manager.get_all_reputations().await;
+        let rep = reputations.get(&peer).expect("peer must be present after load");
+
+        assert!(rep.last_tried.is_none(), "future last_tried must be discarded by clamp");
+        assert_eq!(
+            rep.consecutive_failures, 0,
+            "normalize_after_load must reset streak when last_tried is absent"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_normalize_after_load_preserves_failures_when_last_tried_valid() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        let peers_dir = temp_dir.path().join("peers");
+        std::fs::create_dir_all(&peers_dir).unwrap();
+        let reputation_file = peers_dir.join("reputations.json");
+
+        let recent_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() - 300;
+        let json = format!(
+            r#"{{"127.0.0.1:9203":{{"score":0,"ban_count":0,"positive_actions":0,"negative_actions":0,"connection_attempts":5,"successful_connections":2,"last_success":null,"last_tried":{{"secs_since_epoch":{recent_secs},"nanos_since_epoch":0}},"consecutive_failures":3}}}}"#
+        );
+        std::fs::write(&reputation_file, json).unwrap();
+
+        let peer_storage = PersistentPeerStorage::open(temp_dir.path())
+            .await
+            .expect("Failed to open PersistentPeerStorage");
+
+        let manager = PeerReputationManager::new();
+        manager.load_from_storage(&peer_storage).await.unwrap();
+
+        let peer: SocketAddr = "127.0.0.1:9203".parse().unwrap();
+        let reputations = manager.get_all_reputations().await;
+        let rep = reputations.get(&peer).expect("peer must be present after load");
+
+        assert!(rep.last_tried.is_some(), "valid last_tried must be preserved");
+        assert_eq!(
+            rep.consecutive_failures, 3,
+            "non-zero streak must be preserved when last_tried is valid"
+        );
     }
 }

--- a/dash-spv/tests/dashd_sync/helpers.rs
+++ b/dash-spv/tests/dashd_sync/helpers.rs
@@ -126,7 +126,7 @@ pub(super) async fn wait_for_network_event(
     }
 }
 
-/// Wait for a wallet `MempoolTransactionReceived` event within the given timeout.
+/// Wait for a wallet `TransactionReceived` event within the given timeout.
 /// Accepts both plain mempool and InstantSend-locked mempool arrivals.
 /// Returns `Some(txid)` if received, `None` on timeout.
 pub(super) async fn wait_for_mempool_tx(
@@ -141,13 +141,13 @@ pub(super) async fn wait_for_mempool_tx(
             _ = &mut timeout => return None,
             result = receiver.recv() => {
                 match result {
-                    Ok(WalletEvent::MempoolTransactionReceived { ref record, .. })
+                    Ok(WalletEvent::TransactionReceived { ref change, .. })
                         if matches!(
-                            record.context,
+                            change.record.context,
                             TransactionContext::Mempool | TransactionContext::InstantSend(_)
                         ) =>
                     {
-                        return Some(record.txid);
+                        return Some(change.record.txid);
                     }
                     Ok(_) => continue,
                     Err(_) => return None,
@@ -184,13 +184,13 @@ pub(super) async fn wait_for_mempool_synced(
     }
 }
 
-/// Assert that no mempool `MempoolTransactionReceived` event arrives within the given duration.
+/// Assert that no mempool `TransactionReceived` event arrives within the given duration.
 pub(super) async fn assert_no_mempool_tx(
     receiver: &mut broadcast::Receiver<WalletEvent>,
     wait: Duration,
 ) {
     if let Some(txid) = wait_for_mempool_tx(receiver, wait).await {
-        panic!("Unexpected MempoolTransactionReceived event with txid: {}", txid);
+        panic!("Unexpected TransactionReceived event with txid: {}", txid);
     }
 }
 
@@ -327,7 +327,7 @@ pub(super) async fn wait_for_mempool_txs_both(
         for _ in 0..count {
             let txid = wait_for_mempool_tx(receiver, timeout)
                 .await
-                .expect("Expected MempoolTransactionReceived event");
+                .expect("Expected TransactionReceived event");
             txids.insert(txid);
         }
         txids

--- a/dash-spv/tests/dashd_sync/helpers.rs
+++ b/dash-spv/tests/dashd_sync/helpers.rs
@@ -141,13 +141,13 @@ pub(super) async fn wait_for_mempool_tx(
             _ = &mut timeout => return None,
             result = receiver.recv() => {
                 match result {
-                    Ok(WalletEvent::TransactionReceived { ref change, .. })
+                    Ok(WalletEvent::TransactionReceived { ref update, .. })
                         if matches!(
-                            change.record.context,
+                            update.record.context,
                             TransactionContext::Mempool | TransactionContext::InstantSend(_)
                         ) =>
                     {
-                        return Some(change.record.txid);
+                        return Some(update.record.txid);
                     }
                     Ok(_) => continue,
                     Err(_) => return None,

--- a/dash-spv/tests/dashd_sync/helpers.rs
+++ b/dash-spv/tests/dashd_sync/helpers.rs
@@ -126,7 +126,8 @@ pub(super) async fn wait_for_network_event(
     }
 }
 
-/// Wait for a wallet `TransactionReceived` event with mempool status within the given timeout.
+/// Wait for a wallet `MempoolTransactionReceived` event within the given timeout.
+/// Accepts both plain mempool and InstantSend-locked mempool arrivals.
 /// Returns `Some(txid)` if received, `None` on timeout.
 pub(super) async fn wait_for_mempool_tx(
     receiver: &mut broadcast::Receiver<WalletEvent>,
@@ -140,7 +141,14 @@ pub(super) async fn wait_for_mempool_tx(
             _ = &mut timeout => return None,
             result = receiver.recv() => {
                 match result {
-                    Ok(WalletEvent::TransactionReceived { ref record, .. }) if record.context == TransactionContext::Mempool => return Some(record.txid),
+                    Ok(WalletEvent::MempoolTransactionReceived { ref record, .. })
+                        if matches!(
+                            record.context,
+                            TransactionContext::Mempool | TransactionContext::InstantSend(_)
+                        ) =>
+                    {
+                        return Some(record.txid);
+                    }
                     Ok(_) => continue,
                     Err(_) => return None,
                 }
@@ -176,13 +184,13 @@ pub(super) async fn wait_for_mempool_synced(
     }
 }
 
-/// Assert that no mempool `TransactionReceived` event arrives within the given duration.
+/// Assert that no mempool `MempoolTransactionReceived` event arrives within the given duration.
 pub(super) async fn assert_no_mempool_tx(
     receiver: &mut broadcast::Receiver<WalletEvent>,
     wait: Duration,
 ) {
     if let Some(txid) = wait_for_mempool_tx(receiver, wait).await {
-        panic!("Unexpected mempool TransactionReceived event with txid: {}", txid);
+        panic!("Unexpected MempoolTransactionReceived event with txid: {}", txid);
     }
 }
 
@@ -319,7 +327,7 @@ pub(super) async fn wait_for_mempool_txs_both(
         for _ in 0..count {
             let txid = wait_for_mempool_tx(receiver, timeout)
                 .await
-                .expect("Expected mempool TransactionReceived event");
+                .expect("Expected MempoolTransactionReceived event");
             txids.insert(txid);
         }
         txids

--- a/dash-spv/tests/dashd_sync/tests_mempool.rs
+++ b/dash-spv/tests/dashd_sync/tests_mempool.rs
@@ -38,7 +38,7 @@ async fn test_mempool_detects_incoming_tx() {
 
     let mempool_txid = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected mempool TransactionReceived event");
+        .expect("Expected MempoolTransactionReceived event");
     assert_eq!(mempool_txid, txid, "Mempool event txid should match sent txid");
 
     fa.stop().await;
@@ -106,7 +106,7 @@ async fn test_mempool_to_confirmed_lifecycle() {
 
     let mempool_txid = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected mempool TransactionReceived event");
+        .expect("Expected MempoolTransactionReceived event");
     assert_eq!(mempool_txid, txid);
 
     // Mine the transaction
@@ -552,7 +552,7 @@ async fn test_broadcast_transaction_local_detection() {
     // The locally dispatched transaction should be picked up by the mempool manager
     let detected = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected mempool TransactionReceived event after broadcast");
+        .expect("Expected MempoolTransactionReceived event after broadcast");
     assert_eq!(detected, txid, "Detected txid should match broadcast txid");
 
     // Step 4: Mine the broadcast tx and verify it transitions to confirmed

--- a/dash-spv/tests/dashd_sync/tests_mempool.rs
+++ b/dash-spv/tests/dashd_sync/tests_mempool.rs
@@ -38,7 +38,7 @@ async fn test_mempool_detects_incoming_tx() {
 
     let mempool_txid = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected MempoolTransactionReceived event");
+        .expect("Expected TransactionReceived event");
     assert_eq!(mempool_txid, txid, "Mempool event txid should match sent txid");
 
     fa.stop().await;
@@ -106,7 +106,7 @@ async fn test_mempool_to_confirmed_lifecycle() {
 
     let mempool_txid = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected MempoolTransactionReceived event");
+        .expect("Expected TransactionReceived event");
     assert_eq!(mempool_txid, txid);
 
     // Mine the transaction
@@ -552,7 +552,7 @@ async fn test_broadcast_transaction_local_detection() {
     // The locally dispatched transaction should be picked up by the mempool manager
     let detected = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected MempoolTransactionReceived event after broadcast");
+        .expect("Expected TransactionReceived event after broadcast");
     assert_eq!(detected, txid, "Detected txid should match broadcast txid");
 
     // Step 4: Mine the broadcast tx and verify it transitions to confirmed

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -668,6 +668,20 @@ pub unsafe extern "C" fn managed_core_account_get_utxo_count(
 ///
 /// Heap-allocated fields are freed automatically when the record is dropped
 /// (see `Drop` impl below).
+///
+/// The `account_*` fields together identify the wallet account that owns this
+/// record. They mirror the Rust-side `TransactionRecord::account_type`:
+/// `account_type` is the discriminant, `account_index` is the primary index
+/// (`0` for variants that have no meaningful primary index — see
+/// [`FFIAccountType::from_account_type`]), `account_index_secondary` carries
+/// the secondary index (`registration_index` for `IdentityTopUp`, `key_class`
+/// for `PlatformPayment`) or `-1` when not applicable. The
+/// `account_identity_user` and `account_identity_friend` pointers are non-null
+/// only for the Dashpay variants and point to 32-byte identity hashes owned
+/// by this record (freed in `Drop`). `account_key_class` is `-1` unless this
+/// is a `PlatformPayment` record, in which case it carries the `key_class`
+/// hardened index (also exposed in `account_index_secondary` for symmetry
+/// with the existing FFI tuple contract).
 #[repr(C)]
 pub struct FFITransactionRecord {
     /// Transaction ID (32 bytes)
@@ -682,6 +696,29 @@ pub struct FFITransactionRecord {
     pub direction: FFITransactionDirection,
     /// Fee if known, 0 if unknown
     pub fee: u64,
+    /// Discriminant identifying the owning account variant.
+    pub account_type: FFIAccountType,
+    /// Primary account index for variants that carry one (`Standard`,
+    /// `CoinJoin`, `IdentityTopUp` registration index, `Dashpay*` index,
+    /// `PlatformPayment` account). `0` for variants without a meaningful
+    /// primary index (identity-singleton, provider-key, asset-lock).
+    pub account_index: u32,
+    /// Secondary account index when applicable, `-1` otherwise. Currently
+    /// used only by `PlatformPayment` (`key_class`); see
+    /// [`FFIAccountType::from_account_type`] for the contract.
+    pub account_index_secondary: i32,
+    /// Pointer to the 32-byte `user_identity_id` of the Dashpay account that
+    /// owns this record, null when the account is not a Dashpay variant. The
+    /// pointee is owned by this record and freed when the record is dropped.
+    pub account_identity_user: *const [u8; 32],
+    /// Pointer to the 32-byte `friend_identity_id` of the Dashpay account
+    /// that owns this record, null when the account is not a Dashpay variant.
+    /// The pointee is owned by this record and freed when the record is
+    /// dropped.
+    pub account_identity_friend: *const [u8; 32],
+    /// `PlatformPayment` `key_class` hardened index, `-1` for any other
+    /// account variant. Mirrors `account_index_secondary` for `PlatformPayment`.
+    pub account_key_class: i32,
     /// Input details array
     pub input_details: *mut FFIInputDetail,
     /// Number of input details
@@ -706,6 +743,18 @@ impl From<&TransactionRecord> for FFITransactionRecord {
         let transaction_type = FFITransactionType::from(value.transaction_type);
         let direction = FFITransactionDirection::from(value.direction);
         let fee = value.fee.unwrap_or(0);
+
+        let (account_type, account_index, account_index_secondary) =
+            decompose_account_type(&value.account_type);
+        let (account_identity_user, account_identity_friend) =
+            extract_dashpay_identity_ids(&value.account_type);
+        let account_key_class = match value.account_type {
+            AccountType::PlatformPayment {
+                key_class,
+                ..
+            } => key_class as i32,
+            _ => -1,
+        };
 
         // Serialize transaction bytes
         let tx_slice = dashcore::consensus::serialize(&value.transaction).into_boxed_slice();
@@ -750,6 +799,12 @@ impl From<&TransactionRecord> for FFITransactionRecord {
             transaction_type,
             direction,
             fee,
+            account_type,
+            account_index,
+            account_index_secondary,
+            account_identity_user,
+            account_identity_friend,
+            account_key_class,
             input_details,
             input_details_count,
             output_details,
@@ -759,6 +814,87 @@ impl From<&TransactionRecord> for FFITransactionRecord {
             label,
         }
     }
+}
+
+/// Decompose an `AccountType` into the FFI-tuple shape `(discriminant,
+/// primary_index, secondary_index_or_minus_one)`.
+///
+/// This is the non-panicking counterpart of [`FFIAccountType::from_account_type`]:
+/// Dashpay variants do not abort here because the identity-id payload is
+/// preserved separately on `FFITransactionRecord` via
+/// [`extract_dashpay_identity_ids`].
+fn decompose_account_type(account_type: &AccountType) -> (FFIAccountType, u32, i32) {
+    use key_wallet::account::StandardAccountType;
+    match *account_type {
+        AccountType::Standard {
+            index,
+            standard_account_type: StandardAccountType::BIP44Account,
+        } => (FFIAccountType::StandardBIP44, index, -1),
+        AccountType::Standard {
+            index,
+            standard_account_type: StandardAccountType::BIP32Account,
+        } => (FFIAccountType::StandardBIP32, index, -1),
+        AccountType::CoinJoin {
+            index,
+        } => (FFIAccountType::CoinJoin, index, -1),
+        AccountType::IdentityRegistration => (FFIAccountType::IdentityRegistration, 0, -1),
+        AccountType::IdentityTopUp {
+            registration_index,
+        } => (FFIAccountType::IdentityTopUp, registration_index, -1),
+        AccountType::IdentityTopUpNotBoundToIdentity => {
+            (FFIAccountType::IdentityTopUpNotBoundToIdentity, 0, -1)
+        }
+        AccountType::IdentityInvitation => (FFIAccountType::IdentityInvitation, 0, -1),
+        AccountType::AssetLockAddressTopUp => (FFIAccountType::AssetLockAddressTopUp, 0, -1),
+        AccountType::AssetLockShieldedAddressTopUp => {
+            (FFIAccountType::AssetLockShieldedAddressTopUp, 0, -1)
+        }
+        AccountType::ProviderVotingKeys => (FFIAccountType::ProviderVotingKeys, 0, -1),
+        AccountType::ProviderOwnerKeys => (FFIAccountType::ProviderOwnerKeys, 0, -1),
+        AccountType::ProviderOperatorKeys => (FFIAccountType::ProviderOperatorKeys, 0, -1),
+        AccountType::ProviderPlatformKeys => (FFIAccountType::ProviderPlatformKeys, 0, -1),
+        AccountType::DashpayReceivingFunds {
+            index,
+            ..
+        } => (FFIAccountType::DashpayReceivingFunds, index, -1),
+        AccountType::DashpayExternalAccount {
+            index,
+            ..
+        } => (FFIAccountType::DashpayExternalAccount, index, -1),
+        AccountType::PlatformPayment {
+            account,
+            key_class,
+        } => (FFIAccountType::PlatformPayment, account, key_class as i32),
+    }
+}
+
+/// Heap-allocate copies of the Dashpay identity ids carried by `account_type`,
+/// returning raw pointers owned by the caller. Returns `(null, null)` for any
+/// non-Dashpay variant. The caller is responsible for freeing the boxes
+/// (see `FFITransactionRecord::Drop`).
+fn extract_dashpay_identity_ids(account_type: &AccountType) -> (*const [u8; 32], *const [u8; 32]) {
+    let (user, friend) = match *account_type {
+        AccountType::DashpayReceivingFunds {
+            user_identity_id,
+            friend_identity_id,
+            ..
+        } => (Some(user_identity_id), Some(friend_identity_id)),
+        AccountType::DashpayExternalAccount {
+            user_identity_id,
+            friend_identity_id,
+            ..
+        } => (Some(user_identity_id), Some(friend_identity_id)),
+        _ => (None, None),
+    };
+    let user_ptr = match user {
+        Some(bytes) => Box::into_raw(Box::new(bytes)) as *const [u8; 32],
+        None => std::ptr::null(),
+    };
+    let friend_ptr = match friend {
+        Some(bytes) => Box::into_raw(Box::new(bytes)) as *const [u8; 32],
+        None => std::ptr::null(),
+    };
+    (user_ptr, friend_ptr)
 }
 
 impl Drop for FFITransactionRecord {
@@ -793,6 +929,18 @@ impl Drop for FFITransactionRecord {
             let _ = unsafe { std::ffi::CString::from_raw(self.label) };
 
             self.label = std::ptr::null_mut();
+        }
+
+        if !self.account_identity_user.is_null() {
+            let _ = unsafe { Box::from_raw(self.account_identity_user as *mut [u8; 32]) };
+
+            self.account_identity_user = std::ptr::null();
+        }
+
+        if !self.account_identity_friend.is_null() {
+            let _ = unsafe { Box::from_raw(self.account_identity_friend as *mut [u8; 32]) };
+
+            self.account_identity_friend = std::ptr::null();
         }
     }
 }
@@ -2014,6 +2162,12 @@ mod tests {
             transaction_type: FFITransactionType::Standard,
             direction: FFITransactionDirection::Incoming,
             fee: 226,
+            account_type: FFIAccountType::StandardBIP44,
+            account_index: 0,
+            account_index_secondary: -1,
+            account_identity_user: std::ptr::null(),
+            account_identity_friend: std::ptr::null(),
+            account_key_class: -1,
             input_details_count: input_slice.len(),
             input_details: Box::into_raw(input_slice) as *mut FFIInputDetail,
             output_details_count: output_slice.len(),
@@ -2038,6 +2192,12 @@ mod tests {
             transaction_type: FFITransactionType::Standard,
             direction: FFITransactionDirection::Outgoing,
             fee: 0,
+            account_type: FFIAccountType::StandardBIP44,
+            account_index: 0,
+            account_index_secondary: -1,
+            account_identity_user: std::ptr::null(),
+            account_identity_friend: std::ptr::null(),
+            account_key_class: -1,
             input_details: std::ptr::null_mut(),
             input_details_count: 0,
             output_details: std::ptr::null_mut(),

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -7,8 +7,11 @@ use key_wallet::managed_account::transaction_record::{OutputRole, TransactionDir
 use key_wallet::transaction_checking::transaction_router::TransactionType;
 use key_wallet::transaction_checking::{BlockInfo, TransactionContext};
 use key_wallet::Wallet;
+use key_wallet_manager::{RecordAction, TransactionRecordUpdate};
 use std::os::raw::c_char;
 use std::sync::Arc;
+
+use crate::managed_account::FFITransactionRecord;
 
 /// FFI-compatible block metadata (height, hash, timestamp).
 #[repr(C)]
@@ -113,6 +116,51 @@ impl From<key_wallet::WalletCoreBalance> for FFIBalance {
             immature: balance.immature(),
             locked: balance.locked(),
             total: balance.total(),
+        }
+    }
+}
+
+/// Whether a record is newly stored or updates a previously stored record.
+///
+/// FFI mirror of [`key_wallet_manager::RecordAction`].
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FFIRecordAction {
+    /// The record is new (first time stored for this wallet).
+    Inserted = 0,
+    /// The record was already stored and has been updated (e.g. a previously
+    /// known mempool transaction was confirmed or InstantSend-locked).
+    Updated = 1,
+}
+
+impl From<RecordAction> for FFIRecordAction {
+    fn from(action: RecordAction) -> Self {
+        match action {
+            RecordAction::Inserted => FFIRecordAction::Inserted,
+            RecordAction::Updated => FFIRecordAction::Updated,
+        }
+    }
+}
+
+/// FFI mirror of [`key_wallet_manager::TransactionRecordUpdate`]: a transaction
+/// record paired with the action that just happened to it. Used as a single
+/// value by the off-chain wallet callback and as an array element by the
+/// per-block wallet callback. The owning account is encoded on `record`
+/// directly (`record.account_type` plus the auxiliary `account_*` fields on
+/// [`FFITransactionRecord`]).
+#[repr(C)]
+pub struct FFITransactionRecordUpdate {
+    /// Whether the record is new or an update to a previously stored one.
+    pub action: FFIRecordAction,
+    /// The transaction record.
+    pub record: FFITransactionRecord,
+}
+
+impl From<&TransactionRecordUpdate> for FFITransactionRecordUpdate {
+    fn from(update: &TransactionRecordUpdate) -> Self {
+        Self {
+            action: FFIRecordAction::from(update.action),
+            record: FFITransactionRecord::from(&update.record),
         }
     }
 }

--- a/key-wallet-ffi/src/wallet_manager_tests.rs
+++ b/key-wallet-ffi/src/wallet_manager_tests.rs
@@ -442,7 +442,7 @@ mod tests {
         let height = unsafe { wallet_manager::wallet_manager_current_height(manager, error) };
         assert_eq!(height, 0);
 
-        // Update height
+        // Updating last-processed height without wallets is a no-op
         let new_height = 12345;
         unsafe {
             let manager_ref = &*manager;
@@ -455,7 +455,7 @@ mod tests {
         // Get updated height
         let current_height =
             unsafe { wallet_manager::wallet_manager_current_height(manager, error) };
-        assert_eq!(current_height, new_height);
+        assert_eq!(current_height, 0);
 
         // Clean up
         unsafe {

--- a/key-wallet-manager/Cargo.toml
+++ b/key-wallet-manager/Cargo.toml
@@ -18,6 +18,7 @@ key-wallet = { path = "../key-wallet", default-features = false }
 dashcore = { path = "../dash" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
+tracing = "0.1"
 zeroize = { version = "1.8", features = ["derive"] }
 rayon = { version = "1.11", optional = true }
 bincode = { version = "2.0.1", optional = true }

--- a/key-wallet-manager/examples/wallet_creation.rs
+++ b/key-wallet-manager/examples/wallet_creation.rs
@@ -142,11 +142,11 @@ fn main() {
     // Example 7: Block height tracking
     println!("\n7. Block height tracking...");
 
-    println!("   Current height (Testnet): {:?}", manager.last_processed_height());
+    println!("   Current last-processed height (Testnet): {:?}", manager.last_processed_height());
 
-    // Update height
+    // Update last-processed height across all managed wallets
     manager.update_last_processed_height(850_000);
-    println!("   Updated height to: {:?}", manager.last_processed_height());
+    println!("   Updated last-processed height to: {:?}", manager.last_processed_height());
 
     println!("\n=== Summary ===");
     println!("Total wallets created: {}", manager.wallet_count());

--- a/key-wallet-manager/src/accessors.rs
+++ b/key-wallet-manager/src/accessors.rs
@@ -9,7 +9,7 @@ use key_wallet::{Account, Address, Network, Utxo, Wallet};
 use std::collections::{BTreeMap, BTreeSet};
 use tokio::sync::broadcast;
 
-impl<T: WalletInfoInterface> WalletManager<T> {
+impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
     /// Get a wallet by ID
     pub fn get_wallet(&self, wallet_id: &WalletId) -> Option<&Wallet> {
         self.wallets.get(wallet_id)

--- a/key-wallet-manager/src/accessors.rs
+++ b/key-wallet-manager/src/accessors.rs
@@ -178,27 +178,8 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
     }
 
     /// Snapshot the current balance of every managed wallet.
-    pub(crate) fn snapshot_balances(&self) -> Vec<(WalletId, WalletCoreBalance)> {
+    pub(crate) fn snapshot_balances(&self) -> BTreeMap<WalletId, WalletCoreBalance> {
         self.wallet_infos.iter().map(|(id, info)| (*id, info.balance())).collect()
-    }
-
-    /// Emit `BalanceUpdated` events for wallets whose balance differs from the snapshot.
-    pub(crate) fn emit_balance_changes(&self, old_balances: &[(WalletId, WalletCoreBalance)]) {
-        for (wallet_id, old_balance) in old_balances {
-            if let Some(info) = self.wallet_infos.get(wallet_id) {
-                let new_balance = info.balance();
-                if *old_balance != new_balance {
-                    let event = WalletEvent::BalanceUpdated {
-                        wallet_id: *wallet_id,
-                        confirmed: new_balance.confirmed(),
-                        unconfirmed: new_balance.unconfirmed(),
-                        immature: new_balance.immature(),
-                        locked: new_balance.locked(),
-                    };
-                    let _ = self.event_sender.send(event);
-                }
-            }
-        }
     }
 
     /// Get all outpoints from wallet UTXOs across all managed wallets.

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -1,529 +1,91 @@
 use super::test_helpers::*;
 use super::*;
 use crate::wallet_interface::WalletInterface;
+use dashcore::block::{Block, Header, Version};
+use dashcore::blockdata::script::Builder;
+use dashcore::blockdata::transaction::special_transaction::asset_lock::AssetLockPayload;
+use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
 use dashcore::bls_sig_utils::BLSSignature;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::hash_types::CycleHash;
 use dashcore::hashes::Hash;
-use dashcore::BlockHash;
-use key_wallet::transaction_checking::BlockInfo;
+use dashcore::opcodes;
+use dashcore::{
+    BlockHash, CompactTarget, OutPoint, ScriptBuf, TxIn, TxMerkleNode, TxOut, Txid, Witness,
+};
+use key_wallet::account::StandardAccountType;
+use key_wallet::{AccountType, Network};
+
+fn make_block(txdata: Vec<Transaction>, seed: u8, time: u32) -> Block {
+    Block {
+        header: Header {
+            version: Version::default(),
+            prev_blockhash: BlockHash::from_byte_array([seed; 32]),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time,
+            bits: CompactTarget::from_consensus(0x1d00ffff),
+            nonce: 0,
+        },
+        txdata,
+    }
+}
 
 // ---------------------------------------------------------------------------
-// Lifecycle flow tests
+// Mempool path
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_mempool_to_confirmed_event_flow() {
+async fn test_mempool_tx_emits_single_event_with_balance() {
     let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
     let tx = create_tx_paying_to(&addr, 0xaa);
 
-    // First time in mempool — validate all event fields
-    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true).await;
-    let event = assert_single_event(&mut rx);
-    match event {
-        WalletEvent::TransactionReceived {
-            wallet_id: ev_wid,
+    manager.process_mempool_transaction(&tx, None).await;
+
+    let events = drain_events(&mut rx);
+    assert_eq!(events.len(), 1, "exactly one event expected, got {:?}", events);
+    match &events[0] {
+        WalletEvent::MempoolTransactionReceived {
+            wallet_id: wid,
             record,
+            balance,
             ..
         } => {
-            assert_eq!(record.context, TransactionContext::Mempool);
+            assert_eq!(*wid, wallet_id);
             assert_eq!(record.txid, tx.txid());
-            assert_eq!(ev_wid, wallet_id);
+            assert_eq!(record.context, TransactionContext::Mempool);
             assert_eq!(record.net_amount, TX_AMOUNT as i64);
+            assert_eq!(balance.unconfirmed(), TX_AMOUNT);
+            assert_eq!(balance.confirmed(), 0);
         }
-        other => panic!("expected TransactionReceived, got {:?}", other),
-    }
-
-    // Same tx now confirmed in a block
-    let block_ctx = TransactionContext::InBlock(BlockInfo::new(
-        100,
-        BlockHash::from_byte_array([0xaa; 32]),
-        1000,
-    ));
-    manager.check_transaction_in_all_wallets(&tx, block_ctx, true, true).await;
-    let event = assert_single_event(&mut rx);
-    match event {
-        WalletEvent::TransactionStatusChanged {
-            wallet_id: ev_wid,
-            txid: ev_txid,
-            status,
-        } => {
-            assert_eq!(ev_wid, wallet_id);
-            assert_eq!(ev_txid, tx.txid());
-            assert!(
-                matches!(
-                                    status,
-                TransactionContext::InBlock(info) if info.height() == 100
-                                ),
-                "expected InBlock(100), got {:?}",
-                status
-            );
-        }
-        other => panic!("expected TransactionStatusChanged, got {:?}", other),
+        other => panic!("expected MempoolTransactionReceived, got {:?}", other),
     }
 }
 
 #[tokio::test]
-async fn test_mempool_to_instantsend_to_confirmed_event_flow() {
-    assert_lifecycle_flow(
-        &[
-            TransactionContext::Mempool,
-            TransactionContext::InstantSend(InstantLock::default()),
-            TransactionContext::InBlock(BlockInfo::new(
-                200,
-                BlockHash::from_byte_array([0xbb; 32]),
-                2000,
-            )),
-        ],
-        0xbb,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_first_seen_in_block_event_flow() {
-    assert_lifecycle_flow(
-        &[TransactionContext::InBlock(BlockInfo::new(
-            1000,
-            BlockHash::from_byte_array([0xdd; 32]),
-            10000,
-        ))],
-        0xdd,
-    )
-    .await;
-}
-
-// ---------------------------------------------------------------------------
-// Duplicate suppression tests
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_duplicate_mempool_emits_no_event() {
-    assert_context_suppressed(
-        &[TransactionContext::Mempool],
-        TransactionContext::Mempool,
-        None,
-        0x11,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_duplicate_instantsend_emits_no_event() {
-    assert_context_suppressed(
-        &[TransactionContext::Mempool, TransactionContext::InstantSend(InstantLock::default())],
-        TransactionContext::InstantSend(InstantLock::default()),
-        None,
-        0x22,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_duplicate_confirmed_emits_no_event() {
-    let block_ctx = TransactionContext::InBlock(BlockInfo::new(
-        300,
-        BlockHash::from_byte_array([0x33; 32]),
-        3000,
-    ));
-    let block_ctx2 = block_ctx.clone();
-    assert_context_suppressed(&[block_ctx], block_ctx2, Some(300), 0x33).await;
-}
-
-// ---------------------------------------------------------------------------
-// Edge case tests
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_first_seen_as_instantsend_then_duplicate() {
-    assert_context_suppressed(
-        &[TransactionContext::InstantSend(InstantLock::default())],
-        TransactionContext::InstantSend(InstantLock::default()),
-        None,
-        0x55,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_late_instantsend_after_confirmation_is_ignored() {
-    assert_context_suppressed(
-        &[
-            TransactionContext::Mempool,
-            TransactionContext::InBlock(BlockInfo::new(
-                800,
-                BlockHash::from_byte_array([0x77; 32]),
-                8000,
-            )),
-        ],
-        TransactionContext::InstantSend(InstantLock::default()),
-        Some(800),
-        0x77,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_mempool_after_instantsend_is_suppressed() {
-    assert_context_suppressed(
-        &[TransactionContext::Mempool, TransactionContext::InstantSend(InstantLock::default())],
-        TransactionContext::Mempool,
-        None,
-        0xab,
-    )
-    .await;
-}
-
-// ---------------------------------------------------------------------------
-// BalanceUpdated event tests
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_mempool_tx_emits_balance_updated() {
+async fn test_mempool_tx_with_instant_lock_emits_mempool_event_with_locked_balance() {
     let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xf1);
-
-    manager.process_mempool_transaction(&tx, None).await;
-
-    let events = drain_events(&mut rx);
-    let balance_events: Vec<_> =
-        events.iter().filter(|e| matches!(e, WalletEvent::BalanceUpdated { .. })).collect();
-    assert_eq!(balance_events.len(), 1, "expected exactly 1 BalanceUpdated, got {:?}", events);
-    assert!(
-        matches!(
-            balance_events[0],
-            WalletEvent::BalanceUpdated {
-                wallet_id: wid,
-                unconfirmed,
-                confirmed,
-                ..
-            } if *wid == wallet_id && *unconfirmed == TX_AMOUNT && *confirmed == 0
-        ),
-        "expected BalanceUpdated with unconfirmed={TX_AMOUNT}, confirmed=0, got {:?}",
-        balance_events[0]
-    );
-}
-
-#[tokio::test]
-async fn test_instantsend_tx_emits_balance_updated_spendable() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xf2);
+    let tx = create_tx_paying_to(&addr, 0xbb);
 
     manager.process_mempool_transaction(&tx, Some(dummy_instant_lock(tx.txid()))).await;
 
     let events = drain_events(&mut rx);
-    let balance_events: Vec<_> =
-        events.iter().filter(|e| matches!(e, WalletEvent::BalanceUpdated { .. })).collect();
-    assert_eq!(balance_events.len(), 1, "expected exactly 1 BalanceUpdated, got {:?}", events);
-    assert!(
-        matches!(
-            balance_events[0],
-            WalletEvent::BalanceUpdated {
-                wallet_id: wid,
-                confirmed,
-                unconfirmed,
-                ..
-            } if *wid == wallet_id && *confirmed == TX_AMOUNT && *unconfirmed == 0
-        ),
-        "expected BalanceUpdated with confirmed={TX_AMOUNT}, unconfirmed=0, got {:?}",
-        balance_events[0]
-    );
-}
-
-#[tokio::test]
-async fn test_mempool_to_instantsend_transitions_balance() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xf3);
-
-    // Mempool tx: balance should be unconfirmed
-    manager.process_mempool_transaction(&tx, None).await;
-    let events = drain_events(&mut rx);
-    assert!(
-        events.iter().any(|e| matches!(
-            e,
-            WalletEvent::BalanceUpdated {
-                wallet_id: wid,
-                unconfirmed,
-                confirmed,
-                ..
-            } if *wid == wallet_id && *unconfirmed == TX_AMOUNT && *confirmed == 0
-        )),
-        "expected unconfirmed balance after mempool, got {:?}",
-        events
-    );
-
-    // IS lock: balance should move from unconfirmed to confirmed
-    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
-    let events = drain_events(&mut rx);
-    assert!(
-        events.iter().any(|e| matches!(
-            e,
-            WalletEvent::BalanceUpdated {
-                wallet_id: wid,
-                confirmed,
-                unconfirmed,
-                ..
-            } if *wid == wallet_id && *confirmed == TX_AMOUNT && *unconfirmed == 0
-        )),
-        "expected confirmed balance after IS lock, got {:?}",
-        events
-    );
-}
-
-#[tokio::test]
-async fn test_process_instant_send_lock_updates_transaction_record_context() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let tx = create_tx_paying_to(&addr, 0xf4);
-
-    // Process as mempool transaction first
-    manager.process_mempool_transaction(&tx, None).await;
-
-    // Verify record starts with Mempool context
-    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
-    let record = history.iter().find(|r| r.txid == tx.txid()).unwrap();
-    assert_eq!(record.context, TransactionContext::Mempool);
-
-    // Create a rich InstantLock with a non-default cyclehash
-    let lock = InstantLock {
-        txid: tx.txid(),
-        cyclehash: CycleHash::from_byte_array([0xab; 32]),
-        signature: BLSSignature::from([0xcd; 96]),
-        ..InstantLock::default()
-    };
-
-    manager.process_instant_send_lock(lock.clone());
-
-    // Verify the transaction record context was updated to InstantSend
-    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
-    let record = history.iter().find(|r| r.txid == tx.txid()).unwrap();
-    assert_eq!(
-        record.context,
-        TransactionContext::InstantSend(lock),
-        "transaction record context should be updated to InstantSend with matching lock"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Production API tests
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_process_instant_send_lock_for_unknown_txid() {
-    let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-
-    let unknown_txid = dashcore::Txid::from_byte_array([0xee; 32]);
-    let balance_before = manager.wallet_infos.get(&wallet_id).unwrap().balance();
-
-    manager.process_instant_send_lock(dummy_instant_lock(unknown_txid));
-
-    assert_no_events(&mut rx);
-    let balance_after = manager.wallet_infos.get(&wallet_id).unwrap().balance();
-    assert_eq!(balance_before, balance_after);
-}
-
-#[tokio::test]
-async fn test_process_instant_send_lock_dedup() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let tx = create_tx_paying_to(&addr, 0xe1);
-
-    manager.process_mempool_transaction(&tx, None).await;
-    let mut rx = manager.subscribe_events();
-
-    // First IS lock should emit events
-    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
-    let events = drain_events(&mut rx);
-    assert!(
-        events.iter().any(|e| matches!(
-            e,
-            WalletEvent::TransactionStatusChanged {
-                wallet_id: wid,
-                status: TransactionContext::InstantSend(_),
-                ..
-            } if *wid == wallet_id
-        )),
-        "expected TransactionStatusChanged(InstantSend) with correct wallet_id, got {:?}",
-        events
-    );
-    assert!(
-        events.iter().any(
-            |e| matches!(e, WalletEvent::BalanceUpdated { wallet_id: wid, .. } if *wid == wallet_id)
-        ),
-        "expected BalanceUpdated for wallet, got {:?}",
-        events
-    );
-
-    // Second IS lock should be a no-op
-    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
-    assert_no_events(&mut rx);
-}
-
-#[tokio::test]
-async fn test_process_instant_send_lock_after_block_confirmation() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let tx = create_tx_paying_to(&addr, 0xe2);
-
-    // Process as IS mempool tx, then confirm in block
-    manager.process_mempool_transaction(&tx, Some(dummy_instant_lock(tx.txid()))).await;
-    let block_ctx = TransactionContext::InBlock(BlockInfo::new(
-        500,
-        BlockHash::from_byte_array([0xe2; 32]),
-        5000,
-    ));
-    manager.check_transaction_in_all_wallets(&tx, block_ctx, true, true).await;
-
-    // IS lock after block confirmation is a no-op (already tracked via mempool IS)
-    let mut rx = manager.subscribe_events();
-    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
-    assert_no_events(&mut rx);
-
-    // Confirm height preserved
-    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
-    let records: Vec<_> = history.iter().filter(|r| r.txid == tx.txid()).collect();
-    assert_eq!(records.len(), 1);
-    assert_eq!(records[0].height(), Some(500));
-}
-
-#[tokio::test]
-async fn test_mixed_instantsend_paths_no_duplicate_events() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xf0);
-
-    // Mempool first
-    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true).await;
-    drain_events(&mut rx);
-
-    // IS lock via process_instant_send_lock (network IS lock message)
-    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
-    let events = drain_events(&mut rx);
-    assert!(
-        events.iter().any(|e| matches!(
-            e,
-            WalletEvent::TransactionStatusChanged {
-                wallet_id: wid,
-                status: TransactionContext::InstantSend(_),
-                ..
-            } if *wid == wallet_id
-        )),
-        "expected TransactionStatusChanged(InstantSend) with correct wallet_id, got {:?}",
-        events
-    );
-
-    // Same IS lock via check_transaction_in_all_wallets (block/tx processing path)
-    // should be suppressed — no duplicate event
-    let is_lock = dummy_instant_lock(tx.txid());
-    manager
-        .check_transaction_in_all_wallets(&tx, TransactionContext::InstantSend(is_lock), true, true)
-        .await;
-    assert_no_events(&mut rx);
-}
-
-#[tokio::test]
-async fn test_mixed_instantsend_paths_reverse_no_duplicate_events() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xf1);
-
-    // Mempool first
-    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true).await;
-    drain_events(&mut rx);
-
-    // IS lock via check_transaction_in_all_wallets first
-    let is_lock = dummy_instant_lock(tx.txid());
-    manager
-        .check_transaction_in_all_wallets(
-            &tx,
-            TransactionContext::InstantSend(is_lock.clone()),
-            true,
-            true,
-        )
-        .await;
-    let events = drain_events(&mut rx);
-    assert!(
-        events.iter().any(|e| matches!(
-            e,
-            WalletEvent::TransactionStatusChanged {
-                wallet_id: wid,
-                status: TransactionContext::InstantSend(_),
-                ..
-            } if *wid == wallet_id
-        )),
-        "expected TransactionStatusChanged(InstantSend) with correct wallet_id, got {:?}",
-        events
-    );
-
-    // Same IS lock via process_instant_send_lock — should be suppressed
-    manager.process_instant_send_lock(is_lock);
-    assert_no_events(&mut rx);
-}
-
-#[tokio::test]
-async fn test_process_block_emits_events() {
-    use dashcore::blockdata::block::{Block, Header, Version};
-    use dashcore::hashes::Hash;
-    use dashcore::{BlockHash, CompactTarget, TxMerkleNode};
-
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xe3);
-
-    let block = Block {
-        header: Header {
-            version: Version::default(),
-            prev_blockhash: BlockHash::all_zeros(),
-            merkle_root: TxMerkleNode::all_zeros(),
-            time: 12345,
-            bits: CompactTarget::from_consensus(0x1d00ffff),
-            nonce: 0,
-        },
-        txdata: vec![tx],
-    };
-
-    let result = manager.process_block(&block, 1000).await;
-    assert_eq!(result.new_txids.len(), 1);
-
-    let events = drain_events(&mut rx);
-    let event = events
-        .iter()
-        .find(|e| matches!(e, WalletEvent::TransactionReceived { .. }))
-        .unwrap_or_else(|| {
-            panic!("expected TransactionReceived from process_block, got {:?}", events)
-        });
-
-    match event {
-        WalletEvent::TransactionReceived {
-            account_index,
+    assert_eq!(events.len(), 1, "one event expected for first-seen IS-locked tx, got {:?}", events);
+    match &events[0] {
+        WalletEvent::MempoolTransactionReceived {
+            wallet_id: wid,
             record,
+            balance,
             ..
         } => {
-            assert!(
-                matches!(
-                    record.context,
-                    TransactionContext::InBlock(info) if info.height() == 1000
-                ),
-                "expected InBlock at height 1000, got {:?}",
-                record.context
-            );
-            assert_eq!(*account_index, 0);
-            assert!(
-                !record.input_details.is_empty() || !record.output_details.is_empty(),
-                "expected non-empty details"
-            );
+            assert_eq!(*wid, wallet_id);
+            assert!(matches!(record.context, TransactionContext::InstantSend(_)));
+            assert_eq!(balance.confirmed(), TX_AMOUNT);
+            assert_eq!(balance.unconfirmed(), 0);
         }
-        _ => unreachable!(),
+        other => panic!("expected MempoolTransactionReceived with IS context, got {:?}", other),
     }
-    assert!(
-        events.iter().any(
-            |e| matches!(e, WalletEvent::BalanceUpdated { wallet_id: wid, .. } if *wid == wallet_id)
-        ),
-        "expected BalanceUpdated from process_block, got {:?}",
-        events
-    );
 }
 
 #[tokio::test]
@@ -533,7 +95,6 @@ async fn test_irrelevant_mempool_tx_emits_no_events() {
     let (mut manager, _wallet_id, _addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
 
-    // Create a tx paying to a random script that doesn't match any wallet address
     let random_script =
         ScriptBuf::new_p2pkh(&PublicKey::from_slice(&[2; 33]).unwrap().pubkey_hash());
     let tx = Transaction {
@@ -556,132 +117,342 @@ async fn test_irrelevant_mempool_tx_emits_no_events() {
     };
 
     let result = manager.process_mempool_transaction(&tx, None).await;
-
     assert!(!result.is_relevant);
-    assert_eq!(result.net_amount, 0);
     assert_no_events(&mut rx);
 }
 
 // ---------------------------------------------------------------------------
-// Edge case tests
+// InstantSend path
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_instantsend_to_chainlocked_event_flow() {
-    assert_lifecycle_flow(
-        &[
-            TransactionContext::InstantSend(InstantLock::default()),
-            TransactionContext::InChainLockedBlock(BlockInfo::new(
-                1600,
-                BlockHash::from_byte_array([0xc3; 32]),
-                16000,
-            )),
-        ],
-        0xc3,
-    )
-    .await;
+async fn test_instant_send_lock_on_known_mempool_tx_emits_is_locked_event() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let tx = create_tx_paying_to(&addr, 0xe1);
+
+    // First see the tx as plain mempool
+    manager.process_mempool_transaction(&tx, None).await;
+    let mut rx = manager.subscribe_events();
+
+    let lock = InstantLock {
+        txid: tx.txid(),
+        cyclehash: CycleHash::from_byte_array([0xab; 32]),
+        signature: BLSSignature::from([0xcd; 96]),
+        ..InstantLock::default()
+    };
+    manager.process_instant_send_lock(lock.clone());
+
+    let events = drain_events(&mut rx);
+    assert_eq!(events.len(), 1, "exactly one event expected, got {:?}", events);
+    match &events[0] {
+        WalletEvent::TransactionInstantSendLocked {
+            wallet_id: wid,
+            txid,
+            instant_send_lock,
+            balance,
+        } => {
+            assert_eq!(*wid, wallet_id);
+            assert_eq!(*txid, tx.txid());
+            assert_eq!(*instant_send_lock, lock);
+            assert_eq!(balance.confirmed(), TX_AMOUNT);
+            assert_eq!(balance.unconfirmed(), 0);
+        }
+        other => panic!("expected TransactionInstantSendLocked, got {:?}", other),
+    }
 }
 
 #[tokio::test]
-async fn test_mempool_to_block_to_chainlocked_event_flow() {
+async fn test_instant_send_lock_dedup_second_is_silent() {
     let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
+    let tx = create_tx_paying_to(&addr, 0xe2);
+
+    manager.process_mempool_transaction(&tx, None).await;
+    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
+
     let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xc4);
+    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
+    assert_no_events(&mut rx);
+}
 
-    // Step 1: mempool — emits TransactionReceived
-    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true).await;
-    let event = assert_single_event(&mut rx);
-    assert!(
-        matches!(
-            &event,
-            WalletEvent::TransactionReceived { record, .. }
-            if record.context == TransactionContext::Mempool
-        ),
-        "expected TransactionReceived(Mempool), got {:?}",
-        event
-    );
+#[tokio::test]
+async fn test_instant_send_lock_for_unknown_txid_is_silent() {
+    let (mut manager, _wallet_id, _addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let unknown_txid = Txid::from_byte_array([0xee; 32]);
 
-    // Step 2: block confirmation — emits TransactionStatusChanged
-    let block_ctx = TransactionContext::InBlock(BlockInfo::new(
-        1700,
-        BlockHash::from_byte_array([0xc4; 32]),
-        17000,
-    ));
-    manager.check_transaction_in_all_wallets(&tx, block_ctx, true, true).await;
-    let event = assert_single_event(&mut rx);
-    assert!(
-        matches!(
-            event,
-            WalletEvent::TransactionStatusChanged {
-                status: TransactionContext::InBlock(_),
-                ..
+    manager.process_instant_send_lock(dummy_instant_lock(unknown_txid));
+    assert_no_events(&mut rx);
+}
+
+// ---------------------------------------------------------------------------
+// Block path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_block_with_new_tx_emits_inserted_update() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0xcc);
+    let block = make_block(vec![tx.clone()], 0xcc, 1000);
+
+    let result = manager.process_block(&block, 100).await;
+    assert_eq!(result.new_txids.len(), 1);
+
+    let events = drain_events(&mut rx);
+    assert_eq!(events.len(), 1, "one event per affected wallet expected, got {:?}", events);
+    match &events[0] {
+        WalletEvent::BlockProcessChange {
+            wallet_id: wid,
+            height,
+            updates,
+            balance,
+        } => {
+            assert_eq!(*wid, wallet_id);
+            assert_eq!(*height, 100);
+            assert_eq!(updates.len(), 1);
+            let expected_account_path = AccountType::Standard {
+                index: 0,
+                standard_account_type: StandardAccountType::BIP44Account,
             }
-        ),
-        "expected TransactionStatusChanged(InBlock), got {:?}",
-        event
-    );
-
-    // Step 3: chain lock on already-confirmed tx — no event (wallet doesn't
-    // track chain lock state separately from block confirmation)
-    let cl_ctx = TransactionContext::InChainLockedBlock(BlockInfo::new(
-        1700,
-        BlockHash::from_byte_array([0xc4; 32]),
-        17000,
-    ));
-    manager.check_transaction_in_all_wallets(&tx, cl_ctx, true, true).await;
-    assert_no_events(&mut rx);
+            .derivation_path(Network::Testnet)
+            .expect("BIP44 derivation path should build");
+            assert_eq!(updates[0].account_path, expected_account_path);
+            assert_eq!(updates[0].action, RecordAction::Inserted);
+            assert_eq!(updates[0].record.txid, tx.txid());
+            assert!(matches!(
+                updates[0].record.context,
+                TransactionContext::InBlock(info) if info.height() == 100
+            ));
+            assert_eq!(balance.confirmed(), TX_AMOUNT);
+        }
+        other => panic!("expected BlockProcessChange, got {:?}", other),
+    }
 }
 
 #[tokio::test]
-async fn test_chainlocked_block_event_flow() {
+async fn test_block_confirming_known_mempool_tx_emits_updated_update() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let tx = create_tx_paying_to(&addr, 0xdd);
+
+    // Seen in mempool first
+    manager.process_mempool_transaction(&tx, None).await;
+
+    let mut rx = manager.subscribe_events();
+    let block = make_block(vec![tx.clone()], 0xdd, 2000);
+    manager.process_block(&block, 200).await;
+
+    let events = drain_events(&mut rx);
+    assert_eq!(events.len(), 1, "one BlockProcessChange expected, got {:?}", events);
+    match &events[0] {
+        WalletEvent::BlockProcessChange {
+            wallet_id: wid,
+            height,
+            updates,
+            balance,
+        } => {
+            assert_eq!(*wid, wallet_id);
+            assert_eq!(*height, 200);
+            assert_eq!(updates.len(), 1);
+            assert_eq!(updates[0].action, RecordAction::Updated);
+            assert_eq!(updates[0].record.txid, tx.txid());
+            // Confirmation moves balance from unconfirmed to confirmed
+            assert_eq!(balance.confirmed(), TX_AMOUNT);
+            assert_eq!(balance.unconfirmed(), 0);
+        }
+        other => panic!("expected BlockProcessChange with Updated action, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_block_with_index_less_account_tx_carries_account_path() {
+    // Index-less account variants (`IdentityRegistration`, `IdentityTopUpNotBound`,
+    // `IdentityInvitation`, `AssetLockAddressTopUp`, `AssetLockShieldedAddressTopUp`,
+    // `Provider*`) used to be silently dropped on the way out of `wallet_checker.rs`
+    // because the old emission code only kept matches whose `account_index()` was
+    // `Some(_)`. Verify they now flow through with the right derivation path.
+    let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
+
+    let xpub = manager
+        .get_wallet(&wallet_id)
+        .expect("wallet")
+        .accounts
+        .identity_registration
+        .as_ref()
+        .expect("default wallet should have an IdentityRegistration account")
+        .account_xpub;
+    let identity_address = manager
+        .get_wallet_info_mut(&wallet_id)
+        .expect("wallet info")
+        .identity_registration_managed_account_mut()
+        .expect("managed IdentityRegistration account")
+        .next_address(Some(&xpub), true)
+        .expect("identity registration address");
+
+    // Build a DIP-2 AssetLock transaction whose `credit_outputs` pay to the
+    // identity registration address. AssetLock funds aren't spendable on the
+    // Core chain, so balance does not shift, but the account does receive a
+    // record — which is exactly what we want to observe in `BlockProcessChange`.
+    let tx = Transaction {
+        version: 3,
+        lock_time: 0,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: Txid::from_byte_array([0xee; 32]),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: u32::MAX,
+            witness: Witness::default(),
+        }],
+        output: vec![TxOut {
+            value: 100_000_000,
+            script_pubkey: Builder::new()
+                .push_opcode(opcodes::all::OP_RETURN)
+                .push_slice([0u8; 20])
+                .into_script(),
+        }],
+        special_transaction_payload: Some(TransactionPayload::AssetLockPayloadType(
+            AssetLockPayload {
+                version: 1,
+                credit_outputs: vec![TxOut {
+                    value: 100_000_000,
+                    script_pubkey: identity_address.script_pubkey(),
+                }],
+            },
+        )),
+    };
+
+    let mut rx = manager.subscribe_events();
+    let block = make_block(vec![tx.clone()], 0xee, 9999);
+    manager.process_block(&block, 9000).await;
+
+    let events = drain_events(&mut rx);
+    let block_event = events
+        .iter()
+        .find(|e| matches!(e, WalletEvent::BlockProcessChange { .. }))
+        .unwrap_or_else(|| panic!("expected a BlockProcessChange event, got {:?}", events));
+
+    match block_event {
+        WalletEvent::BlockProcessChange {
+            wallet_id: wid,
+            updates,
+            ..
+        } => {
+            assert_eq!(*wid, wallet_id);
+            let expected_path = AccountType::IdentityRegistration
+                .derivation_path(Network::Testnet)
+                .expect("IdentityRegistration derivation path should build");
+            let identity_update =
+                updates.iter().find(|u| u.account_path == expected_path).unwrap_or_else(|| {
+                    panic!(
+                        "expected an update for IdentityRegistration path {}, got updates: {:?}",
+                        expected_path, updates
+                    )
+                });
+            assert_eq!(identity_update.action, RecordAction::Inserted);
+            assert_eq!(identity_update.record.txid, tx.txid());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[tokio::test]
+async fn test_empty_block_for_idle_wallet_emits_nothing() {
+    let (mut manager, _wallet_id, _addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let block = make_block(Vec::new(), 0x55, 3000);
+
+    manager.process_block(&block, 50).await;
+    assert_no_events(&mut rx);
+}
+
+// ---------------------------------------------------------------------------
+// SyncedHeightUpdated
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_update_synced_height_emits_event_per_wallet() {
+    let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+
+    manager.update_synced_height(1000);
+
+    let synced_events: Vec<_> = drain_events(&mut rx)
+        .into_iter()
+        .filter_map(|e| match e {
+            WalletEvent::SyncedHeightUpdated {
+                wallet_id,
+                height,
+            } => Some((wallet_id, height)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(synced_events, vec![(wallet_id, 1000)]);
+}
+
+#[tokio::test]
+async fn test_update_synced_height_does_not_re_emit_when_unchanged() {
+    let (mut manager, _wallet_id, _addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+
+    manager.update_synced_height(2000);
+    drain_events(&mut rx);
+
+    // Re-calling with the same height must not emit another SyncedHeightUpdated
+    manager.update_synced_height(2000);
+    let events = drain_events(&mut rx);
+    assert!(
+        !events.iter().any(|e| matches!(e, WalletEvent::SyncedHeightUpdated { .. })),
+        "no SyncedHeightUpdated should fire when height did not advance, got {:?}",
+        events
+    );
+
+    // Going backwards also must not emit
+    manager.update_synced_height(1500);
+    let events = drain_events(&mut rx);
+    assert!(
+        !events.iter().any(|e| matches!(e, WalletEvent::SyncedHeightUpdated { .. })),
+        "no SyncedHeightUpdated should fire when height went backwards, got {:?}",
+        events
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Dry run and irrelevant paths
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_check_transaction_does_not_emit_events_directly() {
+    // Event emission is the caller's responsibility; the low-level check
+    // function never emits so batch callers can defer emission until after
+    // their own balance refresh.
     let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xc1);
+    let tx = create_tx_paying_to(&addr, 0xd1);
 
-    let ctx = TransactionContext::InChainLockedBlock(BlockInfo::new(
-        2000,
-        BlockHash::from_byte_array([0xc1; 32]),
-        20000,
-    ));
-    manager.check_transaction_in_all_wallets(&tx, ctx, true, true).await;
-    let event = assert_single_event(&mut rx);
-    assert!(
-        matches!(
-            &event,
-            WalletEvent::TransactionReceived { record, .. }
-            if matches!(record.context, TransactionContext::InChainLockedBlock(info) if info.height() == 2000)
-        ),
-        "expected TransactionReceived(InChainLockedBlock at 2000), got {:?}",
-        event
-    );
+    let result = manager
+        .check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true)
+        .await;
+    assert!(!result.affected_wallets.is_empty());
+    assert!(!result.per_wallet_new_records.is_empty());
+    assert_no_events(&mut rx);
 }
 
 #[tokio::test]
 async fn test_check_transaction_dry_run_does_not_persist_state() {
     let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xd1);
+    let tx = create_tx_paying_to(&addr, 0xd2);
 
-    // Dry run: update_state_if_found = false
     let result = manager
         .check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, false, false)
         .await;
-
     assert!(!result.affected_wallets.is_empty());
-    assert_eq!(result.total_received, TX_AMOUNT);
     assert_no_events(&mut rx);
 
-    // Call again — should still report as relevant (state not persisted)
-    let result2 = manager
-        .check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, false, false)
-        .await;
-    assert!(!result2.affected_wallets.is_empty());
-    assert_eq!(result2.total_received, TX_AMOUNT);
-    assert_no_events(&mut rx);
-
-    // Now persist — should still report as new since dry runs didn't record it
-    let result3 = manager
+    // Subsequent persist should still see the tx as new
+    let result = manager
         .check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true)
         .await;
-    assert!(result3.is_new_transaction);
+    assert!(result.is_new_transaction);
 }

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -47,16 +47,16 @@ async fn test_mempool_tx_emits_single_event_with_balance() {
     match &events[0] {
         WalletEvent::TransactionReceived {
             wallet_id: wid,
-            change,
+            update,
             balance,
         } => {
             assert_eq!(*wid, wallet_id);
-            assert_eq!(change.record.txid, tx.txid());
-            assert_eq!(change.record.context, TransactionContext::Mempool);
-            assert_eq!(change.record.net_amount, TX_AMOUNT as i64);
-            assert_eq!(change.action, RecordAction::Inserted);
+            assert_eq!(update.record.txid, tx.txid());
+            assert_eq!(update.record.context, TransactionContext::Mempool);
+            assert_eq!(update.record.net_amount, TX_AMOUNT as i64);
+            assert_eq!(update.action, RecordAction::Inserted);
             assert!(matches!(
-                change.account_type,
+                update.record.account_type,
                 AccountType::Standard {
                     index: 0,
                     standard_account_type: StandardAccountType::BIP44Account
@@ -82,12 +82,12 @@ async fn test_mempool_tx_with_instant_lock_emits_received_event_with_locked_bala
     match &events[0] {
         WalletEvent::TransactionReceived {
             wallet_id: wid,
-            change,
+            update,
             balance,
         } => {
             assert_eq!(*wid, wallet_id);
-            assert!(matches!(change.record.context, TransactionContext::InstantSend(_)));
-            assert_eq!(change.action, RecordAction::Inserted);
+            assert!(matches!(update.record.context, TransactionContext::InstantSend(_)));
+            assert_eq!(update.action, RecordAction::Inserted);
             assert_eq!(balance.confirmed(), TX_AMOUNT);
             assert_eq!(balance.unconfirmed(), 0);
         }
@@ -261,23 +261,23 @@ async fn test_block_with_new_tx_emits_inserted_update() {
         WalletEvent::BlockProcessed {
             wallet_id: wid,
             height,
-            changes,
+            updates,
             balance,
         } => {
             assert_eq!(*wid, wallet_id);
             assert_eq!(*height, 100);
-            assert_eq!(changes.len(), 1);
+            assert_eq!(updates.len(), 1);
             assert!(matches!(
-                changes[0].account_type,
+                updates[0].record.account_type,
                 AccountType::Standard {
                     index: 0,
                     standard_account_type: StandardAccountType::BIP44Account
                 }
             ));
-            assert_eq!(changes[0].action, RecordAction::Inserted);
-            assert_eq!(changes[0].record.txid, tx.txid());
+            assert_eq!(updates[0].action, RecordAction::Inserted);
+            assert_eq!(updates[0].record.txid, tx.txid());
             assert!(matches!(
-                changes[0].record.context,
+                updates[0].record.context,
                 TransactionContext::InBlock(info) if info.height() == 100
             ));
             assert_eq!(balance.confirmed(), TX_AMOUNT);
@@ -304,14 +304,14 @@ async fn test_block_confirming_known_mempool_tx_emits_updated_update() {
         WalletEvent::BlockProcessed {
             wallet_id: wid,
             height,
-            changes,
+            updates,
             balance,
         } => {
             assert_eq!(*wid, wallet_id);
             assert_eq!(*height, 200);
-            assert_eq!(changes.len(), 1);
-            assert_eq!(changes[0].action, RecordAction::Updated);
-            assert_eq!(changes[0].record.txid, tx.txid());
+            assert_eq!(updates.len(), 1);
+            assert_eq!(updates[0].action, RecordAction::Updated);
+            assert_eq!(updates[0].record.txid, tx.txid());
             // Confirmation moves balance from unconfirmed to confirmed
             assert_eq!(balance.confirmed(), TX_AMOUNT);
             assert_eq!(balance.unconfirmed(), 0);
@@ -392,21 +392,21 @@ async fn test_block_with_index_less_account_tx_carries_account_type() {
     match block_event {
         WalletEvent::BlockProcessed {
             wallet_id: wid,
-            changes,
+            updates,
             ..
         } => {
             assert_eq!(*wid, wallet_id);
-            let identity_change = changes
+            let identity_update = updates
                 .iter()
-                .find(|c| matches!(c.account_type, AccountType::IdentityRegistration))
+                .find(|u| matches!(u.record.account_type, AccountType::IdentityRegistration))
                 .unwrap_or_else(|| {
                     panic!(
-                        "expected a change for AccountType::IdentityRegistration, got: {:?}",
-                        changes
+                        "expected an update for AccountType::IdentityRegistration, got: {:?}",
+                        updates
                     )
                 });
-            assert_eq!(identity_change.action, RecordAction::Inserted);
-            assert_eq!(identity_change.record.txid, tx.txid());
+            assert_eq!(identity_update.action, RecordAction::Inserted);
+            assert_eq!(identity_update.record.txid, tx.txid());
         }
         _ => unreachable!(),
     }

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -184,6 +184,56 @@ async fn test_instant_send_lock_for_unknown_txid_is_silent() {
     assert_no_events(&mut rx);
 }
 
+#[tokio::test]
+async fn test_late_instant_send_lock_after_block_confirmation_emits_event() {
+    // A late IS-lock for a transaction that was already confirmed in a block
+    // currently downgrades the record context from `InBlock(_)` back to
+    // `InstantSend(_)` and re-emits `TransactionInstantSendLocked`. This test
+    // pins down that observable behavior so any future change (silently
+    // ignoring the late lock, rejecting it at the record layer) shows up as a
+    // test failure rather than a silent semantic drift.
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let tx = create_tx_paying_to(&addr, 0xe3);
+
+    // Confirm the transaction in a block first.
+    let block = make_block(vec![tx.clone()], 0xe3, 4000);
+    manager.process_block(&block, 300).await;
+
+    let mut rx = manager.subscribe_events();
+    let lock = InstantLock {
+        txid: tx.txid(),
+        cyclehash: CycleHash::from_byte_array([0xab; 32]),
+        signature: BLSSignature::from([0xcd; 96]),
+        ..InstantLock::default()
+    };
+    manager.process_instant_send_lock(lock.clone());
+
+    let events = drain_events(&mut rx);
+    let is_locked = events
+        .iter()
+        .find(|e| matches!(e, WalletEvent::TransactionInstantSendLocked { .. }))
+        .unwrap_or_else(|| {
+            panic!(
+                "late IS-lock for an already-confirmed tx currently emits \
+                 TransactionInstantSendLocked, got: {:?}",
+                events
+            )
+        });
+    match is_locked {
+        WalletEvent::TransactionInstantSendLocked {
+            wallet_id: wid,
+            txid,
+            instant_send_lock,
+            ..
+        } => {
+            assert_eq!(*wid, wallet_id);
+            assert_eq!(*txid, tx.txid());
+            assert_eq!(*instant_send_lock, lock);
+        }
+        _ => unreachable!(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Block path
 // ---------------------------------------------------------------------------

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -14,7 +14,7 @@ use dashcore::{
     BlockHash, CompactTarget, OutPoint, ScriptBuf, TxIn, TxMerkleNode, TxOut, Txid, Witness,
 };
 use key_wallet::account::StandardAccountType;
-use key_wallet::{AccountType, Network};
+use key_wallet::AccountType;
 
 fn make_block(txdata: Vec<Transaction>, seed: u8, time: u32) -> Block {
     Block {
@@ -45,25 +45,32 @@ async fn test_mempool_tx_emits_single_event_with_balance() {
     let events = drain_events(&mut rx);
     assert_eq!(events.len(), 1, "exactly one event expected, got {:?}", events);
     match &events[0] {
-        WalletEvent::MempoolTransactionReceived {
+        WalletEvent::TransactionReceived {
             wallet_id: wid,
-            record,
+            change,
             balance,
-            ..
         } => {
             assert_eq!(*wid, wallet_id);
-            assert_eq!(record.txid, tx.txid());
-            assert_eq!(record.context, TransactionContext::Mempool);
-            assert_eq!(record.net_amount, TX_AMOUNT as i64);
+            assert_eq!(change.record.txid, tx.txid());
+            assert_eq!(change.record.context, TransactionContext::Mempool);
+            assert_eq!(change.record.net_amount, TX_AMOUNT as i64);
+            assert_eq!(change.action, RecordAction::Inserted);
+            assert!(matches!(
+                change.account_type,
+                AccountType::Standard {
+                    index: 0,
+                    standard_account_type: StandardAccountType::BIP44Account
+                }
+            ));
             assert_eq!(balance.unconfirmed(), TX_AMOUNT);
             assert_eq!(balance.confirmed(), 0);
         }
-        other => panic!("expected MempoolTransactionReceived, got {:?}", other),
+        other => panic!("expected TransactionReceived, got {:?}", other),
     }
 }
 
 #[tokio::test]
-async fn test_mempool_tx_with_instant_lock_emits_mempool_event_with_locked_balance() {
+async fn test_mempool_tx_with_instant_lock_emits_received_event_with_locked_balance() {
     let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
     let tx = create_tx_paying_to(&addr, 0xbb);
@@ -73,18 +80,18 @@ async fn test_mempool_tx_with_instant_lock_emits_mempool_event_with_locked_balan
     let events = drain_events(&mut rx);
     assert_eq!(events.len(), 1, "one event expected for first-seen IS-locked tx, got {:?}", events);
     match &events[0] {
-        WalletEvent::MempoolTransactionReceived {
+        WalletEvent::TransactionReceived {
             wallet_id: wid,
-            record,
+            change,
             balance,
-            ..
         } => {
             assert_eq!(*wid, wallet_id);
-            assert!(matches!(record.context, TransactionContext::InstantSend(_)));
+            assert!(matches!(change.record.context, TransactionContext::InstantSend(_)));
+            assert_eq!(change.action, RecordAction::Inserted);
             assert_eq!(balance.confirmed(), TX_AMOUNT);
             assert_eq!(balance.unconfirmed(), 0);
         }
-        other => panic!("expected MempoolTransactionReceived with IS context, got {:?}", other),
+        other => panic!("expected TransactionReceived with IS context, got {:?}", other),
     }
 }
 
@@ -251,31 +258,31 @@ async fn test_block_with_new_tx_emits_inserted_update() {
     let events = drain_events(&mut rx);
     assert_eq!(events.len(), 1, "one event per affected wallet expected, got {:?}", events);
     match &events[0] {
-        WalletEvent::BlockProcessChange {
+        WalletEvent::BlockProcessed {
             wallet_id: wid,
             height,
-            updates,
+            changes,
             balance,
         } => {
             assert_eq!(*wid, wallet_id);
             assert_eq!(*height, 100);
-            assert_eq!(updates.len(), 1);
-            let expected_account_path = AccountType::Standard {
-                index: 0,
-                standard_account_type: StandardAccountType::BIP44Account,
-            }
-            .derivation_path(Network::Testnet)
-            .expect("BIP44 derivation path should build");
-            assert_eq!(updates[0].account_path, expected_account_path);
-            assert_eq!(updates[0].action, RecordAction::Inserted);
-            assert_eq!(updates[0].record.txid, tx.txid());
+            assert_eq!(changes.len(), 1);
             assert!(matches!(
-                updates[0].record.context,
+                changes[0].account_type,
+                AccountType::Standard {
+                    index: 0,
+                    standard_account_type: StandardAccountType::BIP44Account
+                }
+            ));
+            assert_eq!(changes[0].action, RecordAction::Inserted);
+            assert_eq!(changes[0].record.txid, tx.txid());
+            assert!(matches!(
+                changes[0].record.context,
                 TransactionContext::InBlock(info) if info.height() == 100
             ));
             assert_eq!(balance.confirmed(), TX_AMOUNT);
         }
-        other => panic!("expected BlockProcessChange, got {:?}", other),
+        other => panic!("expected BlockProcessed, got {:?}", other),
     }
 }
 
@@ -292,34 +299,34 @@ async fn test_block_confirming_known_mempool_tx_emits_updated_update() {
     manager.process_block(&block, 200).await;
 
     let events = drain_events(&mut rx);
-    assert_eq!(events.len(), 1, "one BlockProcessChange expected, got {:?}", events);
+    assert_eq!(events.len(), 1, "one BlockProcessed expected, got {:?}", events);
     match &events[0] {
-        WalletEvent::BlockProcessChange {
+        WalletEvent::BlockProcessed {
             wallet_id: wid,
             height,
-            updates,
+            changes,
             balance,
         } => {
             assert_eq!(*wid, wallet_id);
             assert_eq!(*height, 200);
-            assert_eq!(updates.len(), 1);
-            assert_eq!(updates[0].action, RecordAction::Updated);
-            assert_eq!(updates[0].record.txid, tx.txid());
+            assert_eq!(changes.len(), 1);
+            assert_eq!(changes[0].action, RecordAction::Updated);
+            assert_eq!(changes[0].record.txid, tx.txid());
             // Confirmation moves balance from unconfirmed to confirmed
             assert_eq!(balance.confirmed(), TX_AMOUNT);
             assert_eq!(balance.unconfirmed(), 0);
         }
-        other => panic!("expected BlockProcessChange with Updated action, got {:?}", other),
+        other => panic!("expected BlockProcessed with Updated action, got {:?}", other),
     }
 }
 
 #[tokio::test]
-async fn test_block_with_index_less_account_tx_carries_account_path() {
+async fn test_block_with_index_less_account_tx_carries_account_type() {
     // Index-less account variants (`IdentityRegistration`, `IdentityTopUpNotBound`,
     // `IdentityInvitation`, `AssetLockAddressTopUp`, `AssetLockShieldedAddressTopUp`,
     // `Provider*`) used to be silently dropped on the way out of `wallet_checker.rs`
     // because the old emission code only kept matches whose `account_index()` was
-    // `Some(_)`. Verify they now flow through with the right derivation path.
+    // `Some(_)`. Verify they now flow through with the right `AccountType`.
     let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
 
     let xpub = manager
@@ -341,7 +348,7 @@ async fn test_block_with_index_less_account_tx_carries_account_path() {
     // Build a DIP-2 AssetLock transaction whose `credit_outputs` pay to the
     // identity registration address. AssetLock funds aren't spendable on the
     // Core chain, so balance does not shift, but the account does receive a
-    // record — which is exactly what we want to observe in `BlockProcessChange`.
+    // record — which is exactly what we want to observe in `BlockProcessed`.
     let tx = Transaction {
         version: 3,
         lock_time: 0,
@@ -379,28 +386,27 @@ async fn test_block_with_index_less_account_tx_carries_account_path() {
     let events = drain_events(&mut rx);
     let block_event = events
         .iter()
-        .find(|e| matches!(e, WalletEvent::BlockProcessChange { .. }))
-        .unwrap_or_else(|| panic!("expected a BlockProcessChange event, got {:?}", events));
+        .find(|e| matches!(e, WalletEvent::BlockProcessed { .. }))
+        .unwrap_or_else(|| panic!("expected a BlockProcessed event, got {:?}", events));
 
     match block_event {
-        WalletEvent::BlockProcessChange {
+        WalletEvent::BlockProcessed {
             wallet_id: wid,
-            updates,
+            changes,
             ..
         } => {
             assert_eq!(*wid, wallet_id);
-            let expected_path = AccountType::IdentityRegistration
-                .derivation_path(Network::Testnet)
-                .expect("IdentityRegistration derivation path should build");
-            let identity_update =
-                updates.iter().find(|u| u.account_path == expected_path).unwrap_or_else(|| {
+            let identity_change = changes
+                .iter()
+                .find(|c| matches!(c.account_type, AccountType::IdentityRegistration))
+                .unwrap_or_else(|| {
                     panic!(
-                        "expected an update for IdentityRegistration path {}, got updates: {:?}",
-                        expected_path, updates
+                        "expected a change for AccountType::IdentityRegistration, got: {:?}",
+                        changes
                     )
                 });
-            assert_eq!(identity_update.action, RecordAction::Inserted);
-            assert_eq!(identity_update.record.txid, tx.txid());
+            assert_eq!(identity_change.action, RecordAction::Inserted);
+            assert_eq!(identity_change.record.txid, tx.txid());
         }
         _ => unreachable!(),
     }

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -7,7 +7,7 @@
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::Txid;
-use key_wallet::bip32::DerivationPath;
+use key_wallet::account::AccountType;
 use key_wallet::managed_account::transaction_record::TransactionRecord;
 use key_wallet::WalletCoreBalance;
 
@@ -23,12 +23,18 @@ pub enum RecordAction {
     Updated,
 }
 
-/// A transaction record affected by a block, with its account context.
+/// A single transaction record delivered by a wallet event, paired with the
+/// account it belongs to and whether it is a fresh insertion or an update to
+/// a previously stored record.
+///
+/// Used as a single value by `TransactionReceived` and as a `Vec` by
+/// `BlockProcessed`, so consumers can share a single record-handling code
+/// path across both events.
 #[derive(Debug, Clone)]
-pub struct BlockRecordUpdate {
-    /// BIP-32 derivation path identifying the account within the wallet that
-    /// the record belongs to.
-    pub account_path: DerivationPath,
+pub struct RecordChange {
+    /// Account within the wallet that the record belongs to. The full BIP-32
+    /// derivation path is recoverable via `account_type.derivation_path(network)`.
+    pub account_type: AccountType,
     /// Whether the record is new or an update to a previously stored one.
     pub action: RecordAction,
     /// The full transaction record.
@@ -42,20 +48,17 @@ pub struct BlockRecordUpdate {
 /// consumers can persist the record(s) and balance atomically.
 #[derive(Debug, Clone)]
 pub enum WalletEvent {
-    /// A wallet-relevant transaction was first seen in the mempool
-    /// (optionally with an InstantSend lock — in that case the record's
-    /// `context` is `InstantSend(..)`).
-    MempoolTransactionReceived {
+    /// A wallet-relevant transaction was first seen off-chain (mempool, or
+    /// directly via an InstantSend lock — in that case `change.record.context`
+    /// is `InstantSend(..)`).
+    TransactionReceived {
         /// ID of the affected wallet.
         wallet_id: WalletId,
-        /// BIP-32 derivation path identifying the account that matched the
-        /// transaction.
-        account_path: DerivationPath,
-        /// The full transaction record.
+        /// The newly-recorded transaction with its account context.
         ///
-        /// Boxed to keep the enum compact: `TransactionRecord` is large
-        /// and would otherwise inflate every variant to its size.
-        record: Box<TransactionRecord>,
+        /// Boxed to keep the enum compact: `TransactionRecord` is large and
+        /// would otherwise inflate every variant to its size.
+        change: Box<RecordChange>,
         /// Wallet balance after the transaction was recorded.
         balance: WalletCoreBalance,
     },
@@ -72,15 +75,15 @@ pub enum WalletEvent {
     },
     /// A block was processed for a wallet. Carries the newly-recorded and
     /// state-modified transaction records plus the post-block balance.
-    /// `updates` may be empty when only the balance shifted (e.g. a
+    /// `changes` may be empty when only the balance shifted (e.g. a
     /// coinbase maturing as the scanned height advanced past its threshold).
-    BlockProcessChange {
+    BlockProcessed {
         /// ID of the affected wallet.
         wallet_id: WalletId,
         /// Height of the block that was processed.
         height: CoreBlockHeight,
         /// Transaction records recorded or updated by this block.
-        updates: Vec<BlockRecordUpdate>,
+        changes: Vec<RecordChange>,
         /// Wallet balance after the block was processed.
         balance: WalletCoreBalance,
     },
@@ -88,7 +91,7 @@ pub enum WalletEvent {
     /// committed a batch covering blocks up to `height`. No new records or
     /// balance are carried — consumers can persist this as a checkpoint
     /// atomically with any records/balance already persisted from prior
-    /// `BlockProcessChange` events inside the batch.
+    /// `BlockProcessed` events inside the batch.
     SyncedHeightUpdated {
         /// ID of the affected wallet.
         wallet_id: WalletId,
@@ -101,7 +104,7 @@ impl WalletEvent {
     /// ID of the wallet this event pertains to.
     pub fn wallet_id(&self) -> WalletId {
         match self {
-            WalletEvent::MempoolTransactionReceived {
+            WalletEvent::TransactionReceived {
                 wallet_id,
                 ..
             }
@@ -109,7 +112,7 @@ impl WalletEvent {
                 wallet_id,
                 ..
             }
-            | WalletEvent::BlockProcessChange {
+            | WalletEvent::BlockProcessed {
                 wallet_id,
                 ..
             }
@@ -123,14 +126,14 @@ impl WalletEvent {
     /// Short description for logging.
     pub fn description(&self) -> String {
         match self {
-            WalletEvent::MempoolTransactionReceived {
-                record,
+            WalletEvent::TransactionReceived {
+                change,
                 balance,
                 ..
             } => {
                 format!(
-                    "MempoolTransactionReceived(txid={}, context={}, balance={})",
-                    record.txid, record.context, balance
+                    "TransactionReceived(txid={}, context={}, balance={})",
+                    change.record.txid, change.record.context, balance
                 )
             }
             WalletEvent::TransactionInstantSendLocked {
@@ -140,16 +143,16 @@ impl WalletEvent {
             } => {
                 format!("TransactionInstantSendLocked(txid={}, balance={})", txid, balance)
             }
-            WalletEvent::BlockProcessChange {
+            WalletEvent::BlockProcessed {
                 height,
-                updates,
+                changes,
                 balance,
                 ..
             } => {
                 format!(
-                    "BlockProcessChange(height={}, updates={}, balance={})",
+                    "BlockProcessed(height={}, changes={}, balance={})",
                     height,
-                    updates.len(),
+                    changes.len(),
                     balance
                 )
             }

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -1,89 +1,163 @@
 //! Wallet events for notifying consumers of wallet state changes.
 //!
-//! These events are emitted by the WalletManager when significant wallet
-//! operations occur, allowing consumers to receive push-based notifications.
+//! Each variant is self-contained: it carries the transaction record(s) that
+//! triggered it and the wallet's new balance after the change. Consumers can
+//! persist the transaction(s) and balance atomically off a single event.
 
-use dashcore::{Amount, SignedAmount, Txid};
+use dashcore::ephemerealdata::instant_lock::InstantLock;
+use dashcore::prelude::CoreBlockHeight;
+use dashcore::Txid;
+use key_wallet::bip32::DerivationPath;
 use key_wallet::managed_account::transaction_record::TransactionRecord;
-use key_wallet::transaction_checking::TransactionContext;
+use key_wallet::WalletCoreBalance;
 
 use crate::WalletId;
 
+/// Whether a record is newly stored or updates a previously stored record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordAction {
+    /// The record is new (first time stored for this wallet).
+    Inserted,
+    /// The record was already stored and has been updated (e.g. confirmation
+    /// or InstantSend lock applied to a known mempool tx).
+    Updated,
+}
+
+/// A transaction record affected by a block, with its account context.
+#[derive(Debug, Clone)]
+pub struct BlockRecordUpdate {
+    /// BIP-32 derivation path identifying the account within the wallet that
+    /// the record belongs to.
+    pub account_path: DerivationPath,
+    /// Whether the record is new or an update to a previously stored one.
+    pub action: RecordAction,
+    /// The full transaction record.
+    pub record: TransactionRecord,
+}
+
 /// Events emitted by the wallet manager.
 ///
-/// Each event represents a meaningful wallet state change that consumers
-/// may want to react to.
+/// Each event represents a meaningful wallet state change. Events that
+/// modify balance carry the wallet's balance *after* the change so
+/// consumers can persist the record(s) and balance atomically.
 #[derive(Debug, Clone)]
 pub enum WalletEvent {
-    /// A transaction relevant to the wallet was received for the first time.
-    TransactionReceived {
+    /// A wallet-relevant transaction was first seen in the mempool
+    /// (optionally with an InstantSend lock — in that case the record's
+    /// `context` is `InstantSend(..)`).
+    MempoolTransactionReceived {
         /// ID of the affected wallet.
         wallet_id: WalletId,
-        /// Account index within the wallet.
-        account_index: u32,
-        /// The full transaction record with all details.
+        /// BIP-32 derivation path identifying the account that matched the
+        /// transaction.
+        account_path: DerivationPath,
+        /// The full transaction record.
+        ///
+        /// Boxed to keep the enum compact: `TransactionRecord` is large
+        /// and would otherwise inflate every variant to its size.
         record: Box<TransactionRecord>,
+        /// Wallet balance after the transaction was recorded.
+        balance: WalletCoreBalance,
     },
-    /// The confirmation status of a previously seen transaction has changed.
-    TransactionStatusChanged {
+    /// A previously-seen wallet-relevant transaction was InstantSend-locked.
+    TransactionInstantSendLocked {
         /// ID of the affected wallet.
         wallet_id: WalletId,
-        /// Transaction ID.
+        /// Transaction ID that was locked.
         txid: Txid,
-        /// New transaction context.
-        status: TransactionContext,
+        /// The InstantSend lock that locked the transaction.
+        instant_send_lock: InstantLock,
+        /// Wallet balance after the lock was applied.
+        balance: WalletCoreBalance,
     },
-    /// The wallet balance has changed.
-    BalanceUpdated {
+    /// A block was processed for a wallet. Carries the newly-recorded and
+    /// state-modified transaction records plus the post-block balance.
+    /// `updates` may be empty when only the balance shifted (e.g. a
+    /// coinbase maturing as the scanned height advanced past its threshold).
+    BlockProcessChange {
         /// ID of the affected wallet.
         wallet_id: WalletId,
-        /// New confirmed balance in duffs (mature, in a block or InstantSend-locked).
-        confirmed: u64,
-        /// New unconfirmed balance in duffs (mature, mempool-only). Also spendable.
-        unconfirmed: u64,
-        /// New immature balance (coinbase UTXOs not yet mature).
-        immature: u64,
-        /// New locked balance (UTXOs reserved for specific purposes like CoinJoin)
-        locked: u64,
+        /// Height of the block that was processed.
+        height: CoreBlockHeight,
+        /// Transaction records recorded or updated by this block.
+        updates: Vec<BlockRecordUpdate>,
+        /// Wallet balance after the block was processed.
+        balance: WalletCoreBalance,
+    },
+    /// The wallet's scan cursor advanced because the filter pipeline
+    /// committed a batch covering blocks up to `height`. No new records or
+    /// balance are carried — consumers can persist this as a checkpoint
+    /// atomically with any records/balance already persisted from prior
+    /// `BlockProcessChange` events inside the batch.
+    SyncedHeightUpdated {
+        /// ID of the affected wallet.
+        wallet_id: WalletId,
+        /// New scanned height for the wallet.
+        height: CoreBlockHeight,
     },
 }
 
 impl WalletEvent {
-    /// Get a short description of this event for logging.
+    /// ID of the wallet this event pertains to.
+    pub fn wallet_id(&self) -> WalletId {
+        match self {
+            WalletEvent::MempoolTransactionReceived {
+                wallet_id,
+                ..
+            }
+            | WalletEvent::TransactionInstantSendLocked {
+                wallet_id,
+                ..
+            }
+            | WalletEvent::BlockProcessChange {
+                wallet_id,
+                ..
+            }
+            | WalletEvent::SyncedHeightUpdated {
+                wallet_id,
+                ..
+            } => *wallet_id,
+        }
+    }
+
+    /// Short description for logging.
     pub fn description(&self) -> String {
         match self {
-            WalletEvent::TransactionReceived {
+            WalletEvent::MempoolTransactionReceived {
                 record,
+                balance,
                 ..
             } => {
                 format!(
-                    "TransactionReceived(txid={}, amount={}, status={})",
-                    record.txid,
-                    SignedAmount::from_sat(record.net_amount),
-                    record.context
+                    "MempoolTransactionReceived(txid={}, context={}, balance={})",
+                    record.txid, record.context, balance
                 )
             }
-            WalletEvent::TransactionStatusChanged {
+            WalletEvent::TransactionInstantSendLocked {
                 txid,
-                status,
+                balance,
                 ..
             } => {
-                format!("TransactionStatusChanged(txid={}, status={})", txid, status)
+                format!("TransactionInstantSendLocked(txid={}, balance={})", txid, balance)
             }
-            WalletEvent::BalanceUpdated {
-                confirmed,
-                unconfirmed,
-                immature,
-                locked,
+            WalletEvent::BlockProcessChange {
+                height,
+                updates,
+                balance,
                 ..
             } => {
                 format!(
-                    "BalanceUpdated(confirmed={}, unconfirmed={}, immature={}, locked={})",
-                    Amount::from_sat(*confirmed),
-                    Amount::from_sat(*unconfirmed),
-                    Amount::from_sat(*immature),
-                    Amount::from_sat(*locked)
+                    "BlockProcessChange(height={}, updates={}, balance={})",
+                    height,
+                    updates.len(),
+                    balance
                 )
+            }
+            WalletEvent::SyncedHeightUpdated {
+                height,
+                ..
+            } => {
+                format!("SyncedHeightUpdated(height={})", height)
             }
         }
     }

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -7,7 +7,6 @@
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::Txid;
-use key_wallet::account::AccountType;
 use key_wallet::managed_account::transaction_record::TransactionRecord;
 use key_wallet::WalletCoreBalance;
 
@@ -23,18 +22,15 @@ pub enum RecordAction {
     Updated,
 }
 
-/// A single transaction record delivered by a wallet event, paired with the
-/// account it belongs to and whether it is a fresh insertion or an update to
-/// a previously stored record.
+/// A transaction record paired with the action that just happened to it
+/// (`Inserted` for a fresh record, `Updated` for a record whose state changed).
 ///
 /// Used as a single value by `TransactionReceived` and as a `Vec` by
 /// `BlockProcessed`, so consumers can share a single record-handling code
-/// path across both events.
+/// path across both events. The owning account is available on
+/// `record.account_type`.
 #[derive(Debug, Clone)]
-pub struct RecordChange {
-    /// Account within the wallet that the record belongs to. The full BIP-32
-    /// derivation path is recoverable via `account_type.derivation_path(network)`.
-    pub account_type: AccountType,
+pub struct TransactionRecordUpdate {
     /// Whether the record is new or an update to a previously stored one.
     pub action: RecordAction,
     /// The full transaction record.
@@ -49,7 +45,7 @@ pub struct RecordChange {
 #[derive(Debug, Clone)]
 pub enum WalletEvent {
     /// A wallet-relevant transaction was first seen off-chain (mempool, or
-    /// directly via an InstantSend lock — in that case `change.record.context`
+    /// directly via an InstantSend lock — in that case `update.record.context`
     /// is `InstantSend(..)`).
     TransactionReceived {
         /// ID of the affected wallet.
@@ -58,7 +54,7 @@ pub enum WalletEvent {
         ///
         /// Boxed to keep the enum compact: `TransactionRecord` is large and
         /// would otherwise inflate every variant to its size.
-        change: Box<RecordChange>,
+        update: Box<TransactionRecordUpdate>,
         /// Wallet balance after the transaction was recorded.
         balance: WalletCoreBalance,
     },
@@ -75,7 +71,7 @@ pub enum WalletEvent {
     },
     /// A block was processed for a wallet. Carries the newly-recorded and
     /// state-modified transaction records plus the post-block balance.
-    /// `changes` may be empty when only the balance shifted (e.g. a
+    /// `updates` may be empty when only the balance shifted (e.g. a
     /// coinbase maturing as the scanned height advanced past its threshold).
     BlockProcessed {
         /// ID of the affected wallet.
@@ -83,7 +79,7 @@ pub enum WalletEvent {
         /// Height of the block that was processed.
         height: CoreBlockHeight,
         /// Transaction records recorded or updated by this block.
-        changes: Vec<RecordChange>,
+        updates: Vec<TransactionRecordUpdate>,
         /// Wallet balance after the block was processed.
         balance: WalletCoreBalance,
     },
@@ -127,13 +123,13 @@ impl WalletEvent {
     pub fn description(&self) -> String {
         match self {
             WalletEvent::TransactionReceived {
-                change,
+                update,
                 balance,
                 ..
             } => {
                 format!(
                     "TransactionReceived(txid={}, context={}, balance={})",
-                    change.record.txid, change.record.context, balance
+                    update.record.txid, update.record.context, balance
                 )
             }
             WalletEvent::TransactionInstantSendLocked {
@@ -145,14 +141,14 @@ impl WalletEvent {
             }
             WalletEvent::BlockProcessed {
                 height,
-                changes,
+                updates,
                 balance,
                 ..
             } => {
                 format!(
-                    "BlockProcessed(height={}, changes={}, balance={})",
+                    "BlockProcessed(height={}, updates={}, balance={})",
                     height,
-                    changes.len(),
+                    updates.len(),
                     balance
                 )
             }

--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -20,7 +20,7 @@ mod process_block;
 mod wallet_interface;
 
 pub use error::WalletError;
-pub use events::{RecordAction, RecordChange, WalletEvent};
+pub use events::{RecordAction, TransactionRecordUpdate, WalletEvent};
 pub use matching::{check_compact_filters_for_addresses, FilterMatchKey};
 pub use wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
 

--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -20,13 +20,15 @@ mod process_block;
 mod wallet_interface;
 
 pub use error::WalletError;
-pub use events::WalletEvent;
+pub use events::{BlockRecordUpdate, RecordAction, WalletEvent};
 pub use matching::{check_compact_filters_for_addresses, FilterMatchKey};
 pub use wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
 
 use dashcore::blockdata::transaction::Transaction;
 use dashcore::prelude::CoreBlockHeight;
 use key_wallet::account::AccountCollection;
+use key_wallet::bip32::DerivationPath;
+use key_wallet::managed_account::transaction_record::TransactionRecord;
 use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::wallet::managed_wallet_info::transaction_building::AccountTypePreference;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
@@ -80,6 +82,13 @@ pub struct CheckTransactionsResult {
     pub total_sent: u64,
     /// Addresses involved across all wallets
     pub involved_addresses: Vec<Address>,
+    /// Records newly recorded by this check, grouped by wallet. Each entry
+    /// pairs the BIP-32 derivation path identifying the source account with
+    /// the full record.
+    pub per_wallet_new_records: BTreeMap<WalletId, Vec<(DerivationPath, TransactionRecord)>>,
+    /// Records whose state was updated by this check (confirmation or
+    /// InstantSend lock on a previously stored record), grouped by wallet.
+    pub per_wallet_updated_records: BTreeMap<WalletId, Vec<(DerivationPath, TransactionRecord)>>,
 }
 
 /// High-level wallet manager that manages multiple wallets
@@ -442,7 +451,11 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
     }
 
     /// Check a transaction against all wallets and update their states if relevant.
-    /// Returns affected wallets and any new addresses generated during gap limit maintenance.
+    ///
+    /// Collects — but does not emit — the per-wallet records affected by the
+    /// check. Callers are responsible for emitting the appropriate
+    /// `WalletEvent` *after* refreshing wallet balances so events never
+    /// carry a stale balance.
     pub async fn check_transaction_in_all_wallets(
         &mut self,
         tx: &Transaction,
@@ -490,23 +503,41 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
                         }
                     }
 
-                    if check_result.is_new_transaction {
-                        for (account_index, record) in check_result.new_records {
-                            let event = WalletEvent::TransactionReceived {
-                                wallet_id,
-                                account_index,
-                                record: Box::new(record),
-                            };
-                            let _ = self.event_sender.send(event);
-                        }
-                    } else if check_result.state_modified {
-                        // Known transaction whose state was modified (confirmation or IS-lock).
-                        let event = WalletEvent::TransactionStatusChanged {
-                            wallet_id,
-                            txid: tx.txid(),
-                            status: context.clone(),
-                        };
-                        let _ = self.event_sender.send(event);
+                    let network = self.network;
+                    let to_path_pairs = |records: Vec<(AccountType, TransactionRecord)>| {
+                        records
+                            .into_iter()
+                            .filter_map(|(account_type, record)| {
+                                match account_type.derivation_path(network) {
+                                    Ok(path) => Some((path, record)),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            account_type = ?account_type,
+                                            error = %e,
+                                            "Skipping wallet event: failed to derive account path"
+                                        );
+                                        None
+                                    }
+                                }
+                            })
+                            .collect::<Vec<(DerivationPath, TransactionRecord)>>()
+                    };
+
+                    let new_records_with_path = to_path_pairs(check_result.new_records);
+                    if !new_records_with_path.is_empty() {
+                        result
+                            .per_wallet_new_records
+                            .entry(wallet_id)
+                            .or_default()
+                            .extend(new_records_with_path);
+                    }
+                    let updated_records_with_path = to_path_pairs(check_result.updated_records);
+                    if !updated_records_with_path.is_empty() {
+                        result
+                            .per_wallet_updated_records
+                            .entry(wallet_id)
+                            .or_default()
+                            .extend(updated_records_with_path);
                     }
                 }
 

--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -89,6 +89,9 @@ pub struct CheckTransactionsResult {
     /// Records whose state was updated by this check (confirmation or
     /// InstantSend lock on a previously stored record), grouped by wallet.
     pub per_wallet_updated_records: BTreeMap<WalletId, Vec<(DerivationPath, TransactionRecord)>>,
+    /// Number of records dropped because `AccountType::derivation_path` failed.
+    /// Tests can assert this remains zero to catch silent record loss.
+    pub dropped_records_missing_path: u32,
 }
 
 /// High-level wallet manager that manages multiple wallets
@@ -504,7 +507,8 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
                     }
 
                     let network = self.network;
-                    let to_path_pairs = |records: Vec<(AccountType, TransactionRecord)>| {
+                    let mut dropped = 0u32;
+                    let mut to_path_pairs = |records: Vec<(AccountType, TransactionRecord)>| {
                         records
                             .into_iter()
                             .filter_map(|(account_type, record)| {
@@ -516,6 +520,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
                                             error = %e,
                                             "Skipping wallet event: failed to derive account path"
                                         );
+                                        dropped += 1;
                                         None
                                     }
                                 }
@@ -539,6 +544,8 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
                             .or_default()
                             .extend(updated_records_with_path);
                     }
+                    result.dropped_records_missing_path =
+                        result.dropped_records_missing_path.saturating_add(dropped);
                 }
 
                 result.new_addresses.extend(check_result.new_addresses);

--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -81,12 +81,13 @@ pub struct CheckTransactionsResult {
     pub total_sent: u64,
     /// Addresses involved across all wallets
     pub involved_addresses: Vec<Address>,
-    /// Records newly recorded by this check, grouped by wallet. Each entry
-    /// pairs the source `AccountType` with the full record.
-    pub per_wallet_new_records: BTreeMap<WalletId, Vec<(AccountType, TransactionRecord)>>,
+    /// Records newly recorded by this check, grouped by wallet. Each record
+    /// carries its owning `AccountType` on `record.account_type`.
+    pub per_wallet_new_records: BTreeMap<WalletId, Vec<TransactionRecord>>,
     /// Records whose state was updated by this check (confirmation or
     /// InstantSend lock on a previously stored record), grouped by wallet.
-    pub per_wallet_updated_records: BTreeMap<WalletId, Vec<(AccountType, TransactionRecord)>>,
+    /// Each record carries its owning `AccountType` on `record.account_type`.
+    pub per_wallet_updated_records: BTreeMap<WalletId, Vec<TransactionRecord>>,
 }
 
 /// High-level wallet manager that manages multiple wallets

--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -20,14 +20,13 @@ mod process_block;
 mod wallet_interface;
 
 pub use error::WalletError;
-pub use events::{BlockRecordUpdate, RecordAction, WalletEvent};
+pub use events::{RecordAction, RecordChange, WalletEvent};
 pub use matching::{check_compact_filters_for_addresses, FilterMatchKey};
 pub use wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
 
 use dashcore::blockdata::transaction::Transaction;
 use dashcore::prelude::CoreBlockHeight;
 use key_wallet::account::AccountCollection;
-use key_wallet::bip32::DerivationPath;
 use key_wallet::managed_account::transaction_record::TransactionRecord;
 use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::wallet::managed_wallet_info::transaction_building::AccountTypePreference;
@@ -83,15 +82,11 @@ pub struct CheckTransactionsResult {
     /// Addresses involved across all wallets
     pub involved_addresses: Vec<Address>,
     /// Records newly recorded by this check, grouped by wallet. Each entry
-    /// pairs the BIP-32 derivation path identifying the source account with
-    /// the full record.
-    pub per_wallet_new_records: BTreeMap<WalletId, Vec<(DerivationPath, TransactionRecord)>>,
+    /// pairs the source `AccountType` with the full record.
+    pub per_wallet_new_records: BTreeMap<WalletId, Vec<(AccountType, TransactionRecord)>>,
     /// Records whose state was updated by this check (confirmation or
     /// InstantSend lock on a previously stored record), grouped by wallet.
-    pub per_wallet_updated_records: BTreeMap<WalletId, Vec<(DerivationPath, TransactionRecord)>>,
-    /// Number of records dropped because `AccountType::derivation_path` failed.
-    /// Tests can assert this remains zero to catch silent record loss.
-    pub dropped_records_missing_path: u32,
+    pub per_wallet_updated_records: BTreeMap<WalletId, Vec<(AccountType, TransactionRecord)>>,
 }
 
 /// High-level wallet manager that manages multiple wallets
@@ -506,46 +501,20 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
                         }
                     }
 
-                    let network = self.network;
-                    let mut dropped = 0u32;
-                    let mut to_path_pairs = |records: Vec<(AccountType, TransactionRecord)>| {
-                        records
-                            .into_iter()
-                            .filter_map(|(account_type, record)| {
-                                match account_type.derivation_path(network) {
-                                    Ok(path) => Some((path, record)),
-                                    Err(e) => {
-                                        tracing::warn!(
-                                            account_type = ?account_type,
-                                            error = %e,
-                                            "Skipping wallet event: failed to derive account path"
-                                        );
-                                        dropped += 1;
-                                        None
-                                    }
-                                }
-                            })
-                            .collect::<Vec<(DerivationPath, TransactionRecord)>>()
-                    };
-
-                    let new_records_with_path = to_path_pairs(check_result.new_records);
-                    if !new_records_with_path.is_empty() {
+                    if !check_result.new_records.is_empty() {
                         result
                             .per_wallet_new_records
                             .entry(wallet_id)
                             .or_default()
-                            .extend(new_records_with_path);
+                            .extend(check_result.new_records);
                     }
-                    let updated_records_with_path = to_path_pairs(check_result.updated_records);
-                    if !updated_records_with_path.is_empty() {
+                    if !check_result.updated_records.is_empty() {
                         result
                             .per_wallet_updated_records
                             .entry(wallet_id)
                             .or_default()
-                            .extend(updated_records_with_path);
+                            .extend(check_result.updated_records);
                     }
-                    result.dropped_records_missing_path =
-                        result.dropped_records_missing_path.saturating_add(dropped);
                 }
 
                 result.new_addresses.extend(check_result.new_addresses);

--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -87,13 +87,9 @@ pub struct CheckTransactionsResult {
 /// Each wallet can contain multiple accounts following BIP44 standard.
 /// This is the main entry point for wallet operations.
 #[derive(Debug)]
-pub struct WalletManager<T: WalletInfoInterface = ManagedWalletInfo> {
+pub struct WalletManager<T: WalletInfoInterface + Send + Sync + 'static = ManagedWalletInfo> {
     /// Network the managed wallets are used for
     network: Network,
-    /// Last fully processed block height.
-    last_processed_height: CoreBlockHeight,
-    /// Height at which filter scanning was last committed.
-    synced_height: CoreBlockHeight,
     /// Immutable wallets indexed by wallet ID
     wallets: BTreeMap<WalletId, Wallet>,
     /// Mutable wallet info indexed by wallet ID
@@ -106,13 +102,11 @@ pub struct WalletManager<T: WalletInfoInterface = ManagedWalletInfo> {
     event_sender: broadcast::Sender<WalletEvent>,
 }
 
-impl<T: WalletInfoInterface> WalletManager<T> {
+impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
     /// Create a new wallet manager
     pub fn new(network: Network) -> Self {
         Self {
             network,
-            last_processed_height: 0,
-            synced_height: 0,
             wallets: BTreeMap::new(),
             wallet_infos: BTreeMap::new(),
             structural_revision: 0,
@@ -304,7 +298,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
 
         // Create managed wallet info
         let mut managed_info = T::from_wallet(&wallet);
-        managed_info.set_birth_height(self.last_processed_height);
+        managed_info.set_birth_height(self.last_processed_height());
         managed_info.set_first_loaded_at(current_timestamp());
 
         self.wallets.insert(wallet_id, wallet);
@@ -345,7 +339,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
 
         // Create managed wallet info
         let mut managed_info = T::from_wallet(&wallet);
-        managed_info.set_birth_height(self.last_processed_height);
+        managed_info.set_birth_height(self.last_processed_height());
         managed_info.set_first_loaded_at(current_timestamp());
 
         self.wallets.insert(wallet_id, wallet);
@@ -393,7 +387,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
 
         // Create managed wallet info
         let mut managed_info = T::from_wallet(&wallet);
-        managed_info.set_birth_height(self.last_processed_height);
+        managed_info.set_birth_height(self.last_processed_height());
         managed_info.set_first_loaded_at(current_timestamp());
 
         self.wallets.insert(wallet_id, wallet);
@@ -438,7 +432,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         let mut managed_info = T::from_wallet(&wallet);
 
         // Use the current height as the birth height since we don't know when it was originally created
-        managed_info.set_birth_height(self.last_processed_height);
+        managed_info.set_birth_height(self.last_processed_height());
         managed_info.set_first_loaded_at(current_timestamp());
 
         self.wallets.insert(wallet_id, wallet);

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -1,5 +1,5 @@
 use crate::wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
-use crate::{RecordAction, RecordChange, WalletEvent, WalletId, WalletManager};
+use crate::{RecordAction, TransactionRecordUpdate, WalletEvent, WalletId, WalletManager};
 use async_trait::async_trait;
 use core::fmt::Write as _;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
@@ -21,7 +21,8 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         let info = BlockInfo::new(height, block.block_hash(), block.header.time);
 
         let snapshot = self.snapshot_balances();
-        let mut per_wallet_changes: BTreeMap<WalletId, Vec<RecordChange>> = BTreeMap::new();
+        let mut per_wallet_updates: BTreeMap<WalletId, Vec<TransactionRecordUpdate>> =
+            BTreeMap::new();
 
         for tx in &block.txdata {
             let context = TransactionContext::InBlock(info);
@@ -40,20 +41,18 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             result.new_addresses.extend(check_result.new_addresses);
 
             for (wallet_id, records) in check_result.per_wallet_new_records {
-                let entry = per_wallet_changes.entry(wallet_id).or_default();
+                let entry = per_wallet_updates.entry(wallet_id).or_default();
                 for record in records {
-                    entry.push(RecordChange {
-                        account_type: record.account_type,
+                    entry.push(TransactionRecordUpdate {
                         action: RecordAction::Inserted,
                         record,
                     });
                 }
             }
             for (wallet_id, records) in check_result.per_wallet_updated_records {
-                let entry = per_wallet_changes.entry(wallet_id).or_default();
+                let entry = per_wallet_updates.entry(wallet_id).or_default();
                 for record in records {
-                    entry.push(RecordChange {
-                        account_type: record.account_type,
+                    entry.push(TransactionRecordUpdate {
                         action: RecordAction::Updated,
                         record,
                     });
@@ -70,14 +69,14 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
         for (wallet_id, info) in &self.wallet_infos {
             let new_balance = info.balance();
-            let changes = per_wallet_changes.remove(wallet_id).unwrap_or_default();
+            let updates = per_wallet_updates.remove(wallet_id).unwrap_or_default();
             let balance_changed = snapshot.get(wallet_id).copied() != Some(new_balance);
 
-            if !changes.is_empty() || balance_changed {
+            if !updates.is_empty() || balance_changed {
                 let event = WalletEvent::BlockProcessed {
                     wallet_id: *wallet_id,
                     height,
-                    changes,
+                    updates,
                     balance: new_balance,
                 };
                 let _ = self.event_sender.send(event);
@@ -124,8 +123,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             for record in records {
                 let event = WalletEvent::TransactionReceived {
                     wallet_id,
-                    change: Box::new(RecordChange {
-                        account_type: record.account_type,
+                    update: Box::new(TransactionRecordUpdate {
                         action: RecordAction::Inserted,
                         record,
                     }),
@@ -198,7 +196,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
                 let event = WalletEvent::BlockProcessed {
                     wallet_id: *wallet_id,
                     height,
-                    changes: Vec::new(),
+                    updates: Vec::new(),
                     balance: new_balance,
                 };
                 let _ = self.event_sender.send(event);
@@ -347,12 +345,12 @@ mod tests {
         while let Ok(event) = rx.try_recv() {
             if let WalletEvent::TransactionReceived {
                 balance,
-                change,
+                update,
                 ..
             } = event
             {
-                assert_eq!(change.record.txid, tx.txid(), "event should carry the mempool tx");
-                assert_eq!(change.action, RecordAction::Inserted);
+                assert_eq!(update.record.txid, tx.txid(), "event should carry the mempool tx");
+                assert_eq!(update.action, RecordAction::Inserted);
                 assert!(balance.unconfirmed() > 0, "unconfirmed balance should increase");
                 found = true;
                 break;
@@ -398,16 +396,16 @@ mod tests {
         while let Ok(event) = rx.try_recv() {
             if let WalletEvent::BlockProcessed {
                 height,
-                changes,
+                updates,
                 balance,
                 ..
             } = event
             {
                 assert_eq!(height, 100);
                 assert!(balance.confirmed() > 0, "confirmed balance should increase after block");
-                assert_eq!(changes.len(), 1);
-                assert_eq!(changes[0].action, RecordAction::Inserted);
-                assert_eq!(changes[0].record.txid, tx.txid());
+                assert_eq!(updates.len(), 1);
+                assert_eq!(updates[0].action, RecordAction::Inserted);
+                assert_eq!(updates[0].record.txid, tx.txid());
                 found = true;
                 break;
             }

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -1,5 +1,5 @@
 use crate::wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
-use crate::{WalletEvent, WalletManager};
+use crate::{BlockRecordUpdate, RecordAction, WalletEvent, WalletId, WalletManager};
 use async_trait::async_trait;
 use core::fmt::Write as _;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
@@ -7,6 +7,7 @@ use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, Block, Transaction};
 use key_wallet::transaction_checking::{BlockInfo, TransactionContext};
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+use std::collections::BTreeMap;
 use tokio::sync::broadcast;
 
 #[async_trait]
@@ -19,7 +20,9 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         let mut result = BlockProcessingResult::default();
         let info = BlockInfo::new(height, block.block_hash(), block.header.time);
 
-        // Process each transaction using the base manager
+        let snapshot = self.snapshot_balances();
+        let mut per_wallet_updates: BTreeMap<WalletId, Vec<BlockRecordUpdate>> = BTreeMap::new();
+
         for tx in &block.txdata {
             let context = TransactionContext::InBlock(info);
 
@@ -35,9 +38,51 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             }
 
             result.new_addresses.extend(check_result.new_addresses);
+
+            for (wallet_id, records) in check_result.per_wallet_new_records {
+                let entry = per_wallet_updates.entry(wallet_id).or_default();
+                for (account_path, record) in records {
+                    entry.push(BlockRecordUpdate {
+                        account_path,
+                        action: RecordAction::Inserted,
+                        record,
+                    });
+                }
+            }
+            for (wallet_id, records) in check_result.per_wallet_updated_records {
+                let entry = per_wallet_updates.entry(wallet_id).or_default();
+                for (account_path, record) in records {
+                    entry.push(BlockRecordUpdate {
+                        account_path,
+                        action: RecordAction::Updated,
+                        record,
+                    });
+                }
+            }
         }
 
-        self.update_last_processed_height(height);
+        // Advance heights and refresh balances. Event emission happens below
+        // so each wallet's event carries the post-advance balance — the
+        // source of truth for atomic persistence.
+        for info in self.wallet_infos.values_mut() {
+            info.update_last_processed_height(height);
+        }
+
+        for (wallet_id, info) in &self.wallet_infos {
+            let new_balance = info.balance();
+            let updates = per_wallet_updates.remove(wallet_id).unwrap_or_default();
+            let balance_changed = snapshot.get(wallet_id).copied() != Some(new_balance);
+
+            if !updates.is_empty() || balance_changed {
+                let event = WalletEvent::BlockProcessChange {
+                    wallet_id: *wallet_id,
+                    height,
+                    updates,
+                    balance: new_balance,
+                };
+                let _ = self.event_sender.send(event);
+            }
+        }
 
         result
     }
@@ -47,14 +92,13 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         tx: &Transaction,
         instant_lock: Option<InstantLock>,
     ) -> MempoolTransactionResult {
-        let context = match instant_lock {
+        let context = match instant_lock.clone() {
             Some(lock) => {
                 debug_assert_eq!(lock.txid, tx.txid(), "InstantLock txid must match transaction");
                 TransactionContext::InstantSend(lock)
             }
             None => TransactionContext::Mempool,
         };
-        let snapshot = self.snapshot_balances();
         let check_result = self.check_transaction_in_all_wallets(tx, context, true, false).await;
 
         let is_relevant = !check_result.affected_wallets.is_empty();
@@ -64,13 +108,48 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             0
         };
 
-        // Refresh cached balances only for affected wallets
+        // Refresh cached balances for affected wallets before emitting so
+        // every event carries a post-change balance.
         for wallet_id in &check_result.affected_wallets {
             if let Some(info) = self.wallet_infos.get_mut(wallet_id) {
                 info.update_balance();
             }
         }
-        self.emit_balance_changes(&snapshot);
+
+        for (wallet_id, records) in check_result.per_wallet_new_records {
+            let Some(info) = self.wallet_infos.get(&wallet_id) else {
+                continue;
+            };
+            let balance = info.balance();
+            for (account_path, record) in records {
+                let event = WalletEvent::MempoolTransactionReceived {
+                    wallet_id,
+                    account_path,
+                    record: Box::new(record),
+                    balance,
+                };
+                let _ = self.event_sender.send(event);
+            }
+        }
+
+        if let Some(lock) = instant_lock {
+            for (wallet_id, records) in check_result.per_wallet_updated_records {
+                if records.is_empty() {
+                    continue;
+                }
+                let Some(info) = self.wallet_infos.get(&wallet_id) else {
+                    continue;
+                };
+                let balance = info.balance();
+                let event = WalletEvent::TransactionInstantSendLocked {
+                    wallet_id,
+                    txid: tx.txid(),
+                    instant_send_lock: lock.clone(),
+                    balance,
+                };
+                let _ = self.event_sender.send(event);
+            }
+        }
 
         MempoolTransactionResult {
             is_relevant,
@@ -104,11 +183,24 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
     fn update_last_processed_height(&mut self, height: CoreBlockHeight) {
         let snapshot = self.snapshot_balances();
 
-        for (_wallet_id, info) in self.wallet_infos.iter_mut() {
+        for info in self.wallet_infos.values_mut() {
             info.update_last_processed_height(height);
         }
 
-        self.emit_balance_changes(&snapshot);
+        // Emit balance-only BlockProcessChange per wallet whose balance
+        // drifted (e.g. coinbase maturing as the scanned height advanced).
+        for (wallet_id, info) in &self.wallet_infos {
+            let new_balance = info.balance();
+            if snapshot.get(wallet_id).copied() != Some(new_balance) {
+                let event = WalletEvent::BlockProcessChange {
+                    wallet_id: *wallet_id,
+                    height,
+                    updates: Vec::new(),
+                    balance: new_balance,
+                };
+                let _ = self.event_sender.send(event);
+            }
+        }
     }
 
     fn synced_height(&self) -> CoreBlockHeight {
@@ -116,8 +208,24 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
     }
 
     fn update_synced_height(&mut self, height: CoreBlockHeight) {
-        for (_wallet_id, info) in self.wallet_infos.iter_mut() {
+        let mut advanced_wallets = Vec::new();
+        for (wallet_id, info) in self.wallet_infos.iter_mut() {
+            if height > info.synced_height() {
+                advanced_wallets.push(*wallet_id);
+            }
             info.update_synced_height(height);
+        }
+
+        if height > self.last_processed_height() {
+            self.update_last_processed_height(height);
+        }
+
+        for wallet_id in advanced_wallets {
+            let event = WalletEvent::SyncedHeightUpdated {
+                wallet_id,
+                height,
+            };
+            let _ = self.event_sender.send(event);
         }
     }
 
@@ -127,7 +235,6 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
     fn process_instant_send_lock(&mut self, instant_lock: InstantLock) {
         let txid = instant_lock.txid;
-        let snapshot = self.snapshot_balances();
 
         let mut affected_wallets = Vec::new();
         for (wallet_id, info) in self.wallet_infos.iter_mut() {
@@ -141,15 +248,16 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         }
 
         for wallet_id in &affected_wallets {
-            let event = WalletEvent::TransactionStatusChanged {
+            let balance =
+                self.wallet_infos.get(wallet_id).map(|info| info.balance()).unwrap_or_default();
+            let event = WalletEvent::TransactionInstantSendLocked {
                 wallet_id: *wallet_id,
                 txid,
-                status: TransactionContext::InstantSend(instant_lock.clone()),
+                instant_send_lock: instant_lock.clone(),
+                balance,
             };
             let _ = self.event_sender().send(event);
         }
-
-        self.emit_balance_changes(&snapshot);
     }
 
     async fn describe(&self) -> String {
@@ -228,27 +336,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_process_mempool_transaction_balance_events() {
+    async fn test_process_mempool_transaction_emits_event() {
         let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
         let mut rx = manager.subscribe_events();
 
-        // Relevant tx should emit BalanceUpdated
+        // Relevant tx should emit MempoolTransactionReceived carrying the balance
         let tx = create_tx_paying_to(&addr, 0xaa);
         manager.process_mempool_transaction(&tx, None).await;
 
         let mut found = false;
         while let Ok(event) = rx.try_recv() {
-            if let WalletEvent::BalanceUpdated {
-                unconfirmed,
+            if let WalletEvent::MempoolTransactionReceived {
+                balance,
+                record,
                 ..
             } = event
             {
-                assert!(unconfirmed > 0, "unconfirmed balance should increase");
+                assert_eq!(record.txid, tx.txid(), "event should carry the mempool tx");
+                assert!(balance.unconfirmed() > 0, "unconfirmed balance should increase");
                 found = true;
                 break;
             }
         }
-        assert!(found, "should emit BalanceUpdated for mempool transaction");
+        assert!(found, "should emit MempoolTransactionReceived for mempool transaction");
 
         // Irrelevant tx should not emit any events
         let unrelated_tx = Transaction {
@@ -276,27 +386,55 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_process_block_emits_balance_updated() {
+    async fn test_process_block_emits_block_process_change() {
         let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
         let tx = create_tx_paying_to(&addr, 0xcc);
-        let block = make_block(vec![tx]);
+        let block = make_block(vec![tx.clone()]);
 
         let mut rx = manager.subscribe_events();
         manager.process_block(&block, 100).await;
 
         let mut found = false;
         while let Ok(event) = rx.try_recv() {
-            if let WalletEvent::BalanceUpdated {
-                confirmed,
+            if let WalletEvent::BlockProcessChange {
+                height,
+                updates,
+                balance,
                 ..
             } = event
             {
-                assert!(confirmed > 0, "confirmed balance should increase after block");
+                assert_eq!(height, 100);
+                assert!(balance.confirmed() > 0, "confirmed balance should increase after block");
+                assert_eq!(updates.len(), 1);
+                assert_eq!(updates[0].action, RecordAction::Inserted);
+                assert_eq!(updates[0].record.txid, tx.txid());
                 found = true;
                 break;
             }
         }
-        assert!(found, "should emit BalanceUpdated for block processing");
+        assert!(found, "should emit BlockProcessChange for block processing");
+    }
+
+    #[tokio::test]
+    async fn test_update_synced_height_emits_synced_height_updated() {
+        let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
+        let mut rx = manager.subscribe_events();
+
+        manager.update_synced_height(500);
+
+        let mut found = false;
+        while let Ok(event) = rx.try_recv() {
+            if let WalletEvent::SyncedHeightUpdated {
+                wallet_id: evt_wallet_id,
+                height,
+            } = event
+            {
+                assert_eq!(evt_wallet_id, wallet_id);
+                assert_eq!(height, 500);
+                found = true;
+            }
+        }
+        assert!(found, "should emit SyncedHeightUpdated on update_synced_height");
     }
 
     #[tokio::test]

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -1,5 +1,5 @@
 use crate::wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
-use crate::{BlockRecordUpdate, RecordAction, WalletEvent, WalletId, WalletManager};
+use crate::{RecordAction, RecordChange, WalletEvent, WalletId, WalletManager};
 use async_trait::async_trait;
 use core::fmt::Write as _;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
@@ -21,7 +21,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         let info = BlockInfo::new(height, block.block_hash(), block.header.time);
 
         let snapshot = self.snapshot_balances();
-        let mut per_wallet_updates: BTreeMap<WalletId, Vec<BlockRecordUpdate>> = BTreeMap::new();
+        let mut per_wallet_changes: BTreeMap<WalletId, Vec<RecordChange>> = BTreeMap::new();
 
         for tx in &block.txdata {
             let context = TransactionContext::InBlock(info);
@@ -40,20 +40,20 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             result.new_addresses.extend(check_result.new_addresses);
 
             for (wallet_id, records) in check_result.per_wallet_new_records {
-                let entry = per_wallet_updates.entry(wallet_id).or_default();
-                for (account_path, record) in records {
-                    entry.push(BlockRecordUpdate {
-                        account_path,
+                let entry = per_wallet_changes.entry(wallet_id).or_default();
+                for (account_type, record) in records {
+                    entry.push(RecordChange {
+                        account_type,
                         action: RecordAction::Inserted,
                         record,
                     });
                 }
             }
             for (wallet_id, records) in check_result.per_wallet_updated_records {
-                let entry = per_wallet_updates.entry(wallet_id).or_default();
-                for (account_path, record) in records {
-                    entry.push(BlockRecordUpdate {
-                        account_path,
+                let entry = per_wallet_changes.entry(wallet_id).or_default();
+                for (account_type, record) in records {
+                    entry.push(RecordChange {
+                        account_type,
                         action: RecordAction::Updated,
                         record,
                     });
@@ -70,14 +70,14 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
         for (wallet_id, info) in &self.wallet_infos {
             let new_balance = info.balance();
-            let updates = per_wallet_updates.remove(wallet_id).unwrap_or_default();
+            let changes = per_wallet_changes.remove(wallet_id).unwrap_or_default();
             let balance_changed = snapshot.get(wallet_id).copied() != Some(new_balance);
 
-            if !updates.is_empty() || balance_changed {
-                let event = WalletEvent::BlockProcessChange {
+            if !changes.is_empty() || balance_changed {
+                let event = WalletEvent::BlockProcessed {
                     wallet_id: *wallet_id,
                     height,
-                    updates,
+                    changes,
                     balance: new_balance,
                 };
                 let _ = self.event_sender.send(event);
@@ -121,11 +121,14 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
                 continue;
             };
             let balance = info.balance();
-            for (account_path, record) in records {
-                let event = WalletEvent::MempoolTransactionReceived {
+            for (account_type, record) in records {
+                let event = WalletEvent::TransactionReceived {
                     wallet_id,
-                    account_path,
-                    record: Box::new(record),
+                    change: Box::new(RecordChange {
+                        account_type,
+                        action: RecordAction::Inserted,
+                        record,
+                    }),
                     balance,
                 };
                 let _ = self.event_sender.send(event);
@@ -187,15 +190,15 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             info.update_last_processed_height(height);
         }
 
-        // Emit balance-only BlockProcessChange per wallet whose balance
-        // drifted (e.g. coinbase maturing as the scanned height advanced).
+        // Emit balance-only BlockProcessed per wallet whose balance drifted
+        // (e.g. coinbase maturing as the scanned height advanced).
         for (wallet_id, info) in &self.wallet_infos {
             let new_balance = info.balance();
             if snapshot.get(wallet_id).copied() != Some(new_balance) {
-                let event = WalletEvent::BlockProcessChange {
+                let event = WalletEvent::BlockProcessed {
                     wallet_id: *wallet_id,
                     height,
-                    updates: Vec::new(),
+                    changes: Vec::new(),
                     balance: new_balance,
                 };
                 let _ = self.event_sender.send(event);
@@ -336,25 +339,26 @@ mod tests {
         let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
         let mut rx = manager.subscribe_events();
 
-        // Relevant tx should emit MempoolTransactionReceived carrying the balance
+        // Relevant tx should emit TransactionReceived carrying the balance
         let tx = create_tx_paying_to(&addr, 0xaa);
         manager.process_mempool_transaction(&tx, None).await;
 
         let mut found = false;
         while let Ok(event) = rx.try_recv() {
-            if let WalletEvent::MempoolTransactionReceived {
+            if let WalletEvent::TransactionReceived {
                 balance,
-                record,
+                change,
                 ..
             } = event
             {
-                assert_eq!(record.txid, tx.txid(), "event should carry the mempool tx");
+                assert_eq!(change.record.txid, tx.txid(), "event should carry the mempool tx");
+                assert_eq!(change.action, RecordAction::Inserted);
                 assert!(balance.unconfirmed() > 0, "unconfirmed balance should increase");
                 found = true;
                 break;
             }
         }
-        assert!(found, "should emit MempoolTransactionReceived for mempool transaction");
+        assert!(found, "should emit TransactionReceived for mempool transaction");
 
         // Irrelevant tx should not emit any events
         let unrelated_tx = Transaction {
@@ -382,7 +386,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_process_block_emits_block_process_change() {
+    async fn test_process_block_emits_block_processed() {
         let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
         let tx = create_tx_paying_to(&addr, 0xcc);
         let block = make_block(vec![tx.clone()]);
@@ -392,23 +396,23 @@ mod tests {
 
         let mut found = false;
         while let Ok(event) = rx.try_recv() {
-            if let WalletEvent::BlockProcessChange {
+            if let WalletEvent::BlockProcessed {
                 height,
-                updates,
+                changes,
                 balance,
                 ..
             } = event
             {
                 assert_eq!(height, 100);
                 assert!(balance.confirmed() > 0, "confirmed balance should increase after block");
-                assert_eq!(updates.len(), 1);
-                assert_eq!(updates[0].action, RecordAction::Inserted);
-                assert_eq!(updates[0].record.txid, tx.txid());
+                assert_eq!(changes.len(), 1);
+                assert_eq!(changes[0].action, RecordAction::Inserted);
+                assert_eq!(changes[0].record.txid, tx.txid());
                 found = true;
                 break;
             }
         }
-        assert!(found, "should emit BlockProcessChange for block processing");
+        assert!(found, "should emit BlockProcessed for block processing");
     }
 
     #[tokio::test]

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -41,9 +41,9 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
             for (wallet_id, records) in check_result.per_wallet_new_records {
                 let entry = per_wallet_changes.entry(wallet_id).or_default();
-                for (account_type, record) in records {
+                for record in records {
                     entry.push(RecordChange {
-                        account_type,
+                        account_type: record.account_type,
                         action: RecordAction::Inserted,
                         record,
                     });
@@ -51,9 +51,9 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             }
             for (wallet_id, records) in check_result.per_wallet_updated_records {
                 let entry = per_wallet_changes.entry(wallet_id).or_default();
-                for (account_type, record) in records {
+                for record in records {
                     entry.push(RecordChange {
-                        account_type,
+                        account_type: record.account_type,
                         action: RecordAction::Updated,
                         record,
                     });
@@ -121,11 +121,11 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
                 continue;
             };
             let balance = info.balance();
-            for (account_type, record) in records {
+            for record in records {
                 let event = WalletEvent::TransactionReceived {
                     wallet_id,
                     change: Box::new(RecordChange {
-                        account_type,
+                        account_type: record.account_type,
                         action: RecordAction::Inserted,
                         record,
                     }),

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -98,12 +98,10 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
     }
 
     fn last_processed_height(&self) -> CoreBlockHeight {
-        self.last_processed_height
+        self.wallet_infos.values().map(|info| info.last_processed_height()).max().unwrap_or(0)
     }
 
     fn update_last_processed_height(&mut self, height: CoreBlockHeight) {
-        self.last_processed_height = height;
-
         let snapshot = self.snapshot_balances();
 
         for (_wallet_id, info) in self.wallet_infos.iter_mut() {
@@ -114,13 +112,12 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
     }
 
     fn synced_height(&self) -> CoreBlockHeight {
-        self.synced_height
+        self.wallet_infos.values().map(|info| info.synced_height()).min().unwrap_or(0)
     }
 
     fn update_synced_height(&mut self, height: CoreBlockHeight) {
-        self.synced_height = height;
-        if height > self.last_processed_height {
-            self.update_last_processed_height(height);
+        for (_wallet_id, info) in self.wallet_infos.iter_mut() {
+            info.update_synced_height(height);
         }
     }
 
@@ -220,15 +217,14 @@ mod tests {
         let mut manager: WalletManager<ManagedWalletInfo> = WalletManager::new(Network::Testnet);
         // Initial state
         assert_eq!(manager.last_processed_height(), 0);
-        // Increase last processed height
+        // Updating last-processed height without wallets is a no-op
         manager.update_last_processed_height(1000);
-        assert_eq!(manager.last_processed_height(), 1000);
-        // Increase last processed height again
+        assert_eq!(manager.last_processed_height(), 0);
+        // Still a no-op without wallets
         manager.update_last_processed_height(5000);
-        assert_eq!(manager.last_processed_height(), 5000);
-        // Decrease last processed height
+        assert_eq!(manager.last_processed_height(), 0);
         manager.update_last_processed_height(10);
-        assert_eq!(manager.last_processed_height(), 10);
+        assert_eq!(manager.last_processed_height(), 0);
     }
 
     #[tokio::test]

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -216,10 +216,6 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             info.update_synced_height(height);
         }
 
-        if height > self.last_processed_height() {
-            self.update_last_processed_height(height);
-        }
-
         for wallet_id in advanced_wallets {
             let event = WalletEvent::SyncedHeightUpdated {
                 wallet_id,

--- a/key-wallet-manager/src/test_helpers.rs
+++ b/key-wallet-manager/src/test_helpers.rs
@@ -59,79 +59,8 @@ pub(crate) fn drain_events(rx: &mut broadcast::Receiver<WalletEvent>) -> Vec<Wal
     events
 }
 
-/// Drain events from the receiver, assert exactly one was emitted, and return it.
-pub(crate) fn assert_single_event(rx: &mut broadcast::Receiver<WalletEvent>) -> WalletEvent {
-    let events = drain_events(rx);
-    assert_eq!(events.len(), 1, "expected 1 event, got {}: {:?}", events.len(), events);
-    events.into_iter().next().unwrap()
-}
-
 /// Drain events and assert none were emitted.
 pub(crate) fn assert_no_events(rx: &mut broadcast::Receiver<WalletEvent>) {
     let events = drain_events(rx);
     assert!(events.is_empty(), "expected no events, got {}: {:?}", events.len(), events);
-}
-
-/// Submit a transaction through a sequence of contexts and verify the event flow.
-///
-/// The first context produces a `TransactionReceived` event; each subsequent
-/// context produces a `TransactionStatusChanged` event.
-pub(crate) async fn assert_lifecycle_flow(contexts: &[TransactionContext], input_seed: u8) {
-    assert!(!contexts.is_empty(), "at least one context required");
-
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, input_seed);
-
-    for (i, ctx) in contexts.iter().enumerate() {
-        manager.check_transaction_in_all_wallets(&tx, ctx.clone(), true, true).await;
-        let event = assert_single_event(&mut rx);
-
-        if i == 0 {
-            assert!(
-                matches!(&event, WalletEvent::TransactionReceived { wallet_id: wid, record, .. } if *wid == wallet_id && record.context == *ctx),
-                "context[{}]: expected TransactionReceived with wallet_id and status {:?}, got {:?}",
-                i,
-                ctx,
-                event
-            );
-        } else {
-            assert!(
-                matches!(&event, WalletEvent::TransactionStatusChanged { wallet_id: wid, status, .. } if *wid == wallet_id && status == ctx),
-                "context[{}]: expected TransactionStatusChanged with wallet_id and status {:?}, got {:?}",
-                i,
-                ctx,
-                event
-            );
-        }
-    }
-}
-
-/// Submit a transaction through `setup_contexts`, drain events, then submit with
-/// `suppressed_context` and assert no event is emitted. Optionally verify
-/// the stored height.
-pub(crate) async fn assert_context_suppressed(
-    setup_contexts: &[TransactionContext],
-    suppressed_context: TransactionContext,
-    expected_height: Option<u32>,
-    input_seed: u8,
-) {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, input_seed);
-
-    for ctx in setup_contexts {
-        manager.check_transaction_in_all_wallets(&tx, ctx.clone(), true, true).await;
-        drain_events(&mut rx);
-    }
-
-    manager.check_transaction_in_all_wallets(&tx, suppressed_context, true, true).await;
-    assert_no_events(&mut rx);
-
-    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
-    let records: Vec<_> = history.iter().filter(|r| r.txid == tx.txid()).collect();
-    assert_eq!(records.len(), 1);
-    if let Some(height) = expected_height {
-        assert_eq!(records[0].height(), Some(height));
-    }
 }

--- a/key-wallet-manager/tests/integration_test.rs
+++ b/key-wallet-manager/tests/integration_test.rs
@@ -164,10 +164,13 @@ fn test_block_height_tracking() {
 
     // Initial state
     assert_eq!(manager.last_processed_height(), 0);
+    assert_eq!(manager.synced_height(), 0);
 
-    // Set height before adding wallets
+    // Updating heights before adding wallets is a no-op
     manager.update_last_processed_height(1000);
-    assert_eq!(manager.last_processed_height(), 1000);
+    manager.update_synced_height(500);
+    assert_eq!(manager.last_processed_height(), 0);
+    assert_eq!(manager.synced_height(), 0);
 
     let mnemonic1 = Mnemonic::generate(12, Language::English).unwrap();
     let wallet_id1 = manager
@@ -191,46 +194,53 @@ fn test_block_height_tracking() {
 
     assert_eq!(manager.wallet_count(), 2);
 
-    // Verify both wallets have last_processed_height of 0 initially
+    // Verify both wallets have last_processed_height and synced_height of 0 initially
     for wallet_info in manager.get_all_wallet_infos().values() {
         assert_eq!(wallet_info.last_processed_height(), 0);
+        assert_eq!(wallet_info.synced_height(), 0);
     }
 
-    // Update height - should propagate to all wallets
+    // Update last-processed height - should propagate to all wallets
     manager.update_last_processed_height(12345);
     assert_eq!(manager.last_processed_height(), 12345);
 
-    // Verify all wallets got updated
+    // Verify all wallets got updated while synced_height stays at 0
     let wallet_info1 = manager.get_wallet_info(&wallet_id1).unwrap();
     let wallet_info2 = manager.get_wallet_info(&wallet_id2).unwrap();
     assert_eq!(wallet_info1.last_processed_height(), 12345);
     assert_eq!(wallet_info2.last_processed_height(), 12345);
+    assert_eq!(wallet_info1.synced_height(), 0);
+    assert_eq!(wallet_info2.synced_height(), 0);
 
-    // Update again - verify subsequent updates work
-    manager.update_last_processed_height(20000);
-    assert_eq!(manager.last_processed_height(), 20000);
+    // Update synced height - should propagate to all wallets without touching last_processed_height
+    manager.update_synced_height(20000);
+    assert_eq!(manager.synced_height(), 20000);
 
     for wallet_info in manager.get_all_wallet_infos().values() {
-        assert_eq!(wallet_info.last_processed_height(), 20000);
+        assert_eq!(wallet_info.last_processed_height(), 12345);
+        assert_eq!(wallet_info.synced_height(), 20000);
     }
 
-    // Update wallets individually to different heights
+    // Update wallets individually to different last-processed heights
     let wallet_info1 = manager.get_wallet_info_mut(&wallet_id1).unwrap();
     wallet_info1.update_last_processed_height(30000);
 
     let wallet_info2 = manager.get_wallet_info_mut(&wallet_id2).unwrap();
     wallet_info2.update_last_processed_height(25000);
 
-    // Verify each wallet has its own last_processed_height
+    // Verify each wallet has its own last_processed_height and manager reports the max
     let wallet_info1 = manager.get_wallet_info(&wallet_id1).unwrap();
     let wallet_info2 = manager.get_wallet_info(&wallet_id2).unwrap();
     assert_eq!(wallet_info1.last_processed_height(), 30000);
     assert_eq!(wallet_info2.last_processed_height(), 25000);
+    assert_eq!(manager.last_processed_height(), 30000);
 
-    // Manager update_height still syncs all wallets
-    manager.update_last_processed_height(40000);
+    // Manager synced-height update syncs across all wallets
+    manager.update_synced_height(40000);
     let wallet_info1 = manager.get_wallet_info(&wallet_id1).unwrap();
     let wallet_info2 = manager.get_wallet_info(&wallet_id2).unwrap();
-    assert_eq!(wallet_info1.last_processed_height(), 40000);
-    assert_eq!(wallet_info2.last_processed_height(), 40000);
+    assert_eq!(wallet_info1.last_processed_height(), 30000);
+    assert_eq!(wallet_info2.last_processed_height(), 25000);
+    assert_eq!(wallet_info1.synced_height(), 40000);
+    assert_eq!(wallet_info2.synced_height(), 40000);
 }

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -526,6 +526,7 @@ impl ManagedCoreAccount {
 
         let tx_record = TransactionRecord::new(
             tx.clone(),
+            self.account_type.to_account_type(),
             context.clone(),
             transaction_type,
             direction,
@@ -1324,7 +1325,7 @@ impl<'de> Deserialize<'de> for ManagedCoreAccount {
             utxos: BTreeMap<OutPoint, Utxo>,
         }
 
-        let helper = Helper::deserialize(deserializer)?;
+        let mut helper = Helper::deserialize(deserializer)?;
 
         let spent_outpoints = helper
             .transactions
@@ -1332,6 +1333,14 @@ impl<'de> Deserialize<'de> for ManagedCoreAccount {
             .flat_map(|record| &record.transaction.input)
             .map(|input| input.previous_output)
             .collect();
+
+        // `TransactionRecord::account_type` is transient (skipped during
+        // serialization, defaulted on load). Repopulate it from the owning
+        // account so consumers see the correct account on every record.
+        let account_type = helper.account_type.to_account_type();
+        for record in helper.transactions.values_mut() {
+            record.account_type = account_type;
+        }
 
         Ok(ManagedCoreAccount {
             account_type: helper.account_type,

--- a/key-wallet/src/managed_account/transaction_record.rs
+++ b/key-wallet/src/managed_account/transaction_record.rs
@@ -3,6 +3,7 @@
 //! This module contains the transaction record structure used to track
 //! transactions associated with accounts.
 
+use crate::account::AccountType;
 use crate::error::Error;
 use crate::transaction_checking::transaction_router::TransactionType;
 use crate::transaction_checking::{BlockInfo, TransactionContext};
@@ -11,6 +12,18 @@ use dashcore::blockdata::transaction::Transaction;
 use dashcore::Txid;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+/// Sentinel `AccountType` used as the deserialization default for
+/// [`TransactionRecord::account_type`]. Records always live inside a
+/// [`ManagedCoreAccount`](crate::managed_account::ManagedCoreAccount), and the
+/// owning account overwrites this sentinel after deserialization with its
+/// own `account_type`. The on-disk format therefore does not need to encode
+/// this field. The variant chosen here has no associated data so it is cheap
+/// to construct and serializes/encodes deterministically.
+#[cfg(feature = "serde")]
+fn default_account_type() -> AccountType {
+    AccountType::IdentityRegistration
+}
 
 /// Maximum length of a transaction label in bytes.
 pub const MAX_LABEL_LENGTH: usize = 256;
@@ -72,6 +85,12 @@ pub enum TransactionDirection {
 }
 
 /// Transaction record with full details
+///
+/// The `account_type` field identifies the owning account and is *not*
+/// persisted: records are always stored inside a
+/// [`ManagedCoreAccount`](crate::managed_account::ManagedCoreAccount), and the
+/// owning account repopulates the field after deserialization with its own
+/// `account_type`. See [`default_account_type`] for the serde default sentinel.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TransactionRecord {
@@ -79,6 +98,10 @@ pub struct TransactionRecord {
     pub transaction: Transaction,
     /// Transaction ID
     pub txid: Txid,
+    /// Account this record belongs to. Transient: skipped during
+    /// (de)serialization and repopulated by the owning account on load.
+    #[cfg_attr(feature = "serde", serde(skip, default = "default_account_type"))]
+    pub account_type: AccountType,
     /// The context in which this transaction was last seen
     pub context: TransactionContext,
     /// Classification of the transaction type
@@ -98,9 +121,16 @@ pub struct TransactionRecord {
 }
 
 impl TransactionRecord {
-    /// Create a new transaction record with the given context
+    /// Create a new transaction record with the given context.
+    ///
+    /// `account_type` identifies the owning account. The record stores it
+    /// in-memory only — it is not persisted, since records always live inside
+    /// a [`ManagedCoreAccount`](crate::managed_account::ManagedCoreAccount)
+    /// that re-populates the field on load.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         transaction: Transaction,
+        account_type: AccountType,
         context: TransactionContext,
         transaction_type: TransactionType,
         direction: TransactionDirection,
@@ -111,6 +141,7 @@ impl TransactionRecord {
         let txid = transaction.txid();
         Self {
             txid,
+            account_type,
             transaction,
             context,
             transaction_type,
@@ -194,8 +225,16 @@ impl TransactionRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::account::StandardAccountType;
     use dashcore::hashes::Hash;
     use dashcore::BlockHash;
+
+    fn test_account_type() -> AccountType {
+        AccountType::Standard {
+            index: 0,
+            standard_account_type: StandardAccountType::BIP44Account,
+        }
+    }
 
     fn test_block_context(height: u32) -> TransactionContext {
         TransactionContext::InBlock(BlockInfo::new(height, BlockHash::all_zeros(), 1234567890))
@@ -208,6 +247,7 @@ mod tests {
     ) -> TransactionRecord {
         TransactionRecord::new(
             tx,
+            test_account_type(),
             context,
             TransactionType::Standard,
             TransactionDirection::Incoming,
@@ -264,6 +304,7 @@ mod tests {
 
         let outgoing = TransactionRecord::new(
             tx.clone(),
+            test_account_type(),
             TransactionContext::Mempool,
             TransactionType::Standard,
             TransactionDirection::Outgoing,
@@ -277,6 +318,7 @@ mod tests {
 
         let internal = TransactionRecord::new(
             tx.clone(),
+            test_account_type(),
             TransactionContext::Mempool,
             TransactionType::Standard,
             TransactionDirection::Internal,
@@ -289,6 +331,7 @@ mod tests {
 
         let coinjoin = TransactionRecord::new(
             tx,
+            test_account_type(),
             TransactionContext::Mempool,
             TransactionType::CoinJoin,
             TransactionDirection::CoinJoin,

--- a/key-wallet/src/tests/spent_outpoints_tests.rs
+++ b/key-wallet/src/tests/spent_outpoints_tests.rs
@@ -3,7 +3,7 @@
 use dashcore::blockdata::transaction::{OutPoint, Transaction};
 use dashcore::{TxIn, Txid};
 
-use crate::account::TransactionRecord;
+use crate::account::{AccountType, StandardAccountType, TransactionRecord};
 use crate::managed_account::transaction_record::TransactionDirection;
 use crate::managed_account::ManagedCoreAccount;
 use crate::transaction_checking::{TransactionContext, TransactionType};
@@ -39,6 +39,10 @@ fn receive_only_tx() -> Transaction {
 fn record_from_tx(tx: &Transaction) -> TransactionRecord {
     TransactionRecord::new(
         tx.clone(),
+        AccountType::Standard {
+            index: 0,
+            standard_account_type: StandardAccountType::BIP44Account,
+        },
         TransactionContext::Mempool,
         TransactionType::Standard,
         TransactionDirection::Incoming,

--- a/key-wallet/src/transaction_checking/account_checker.rs
+++ b/key-wallet/src/transaction_checking/account_checker.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 
 use super::transaction_router::AccountTypeToCheck;
-use crate::account::{ManagedAccountCollection, ManagedCoreAccount};
+use crate::account::{AccountType, ManagedAccountCollection, ManagedCoreAccount};
 use crate::managed_account::address_pool::{AddressInfo, PublicKeyType};
 use crate::managed_account::managed_account_type::ManagedAccountType;
 use crate::managed_account::transaction_record::TransactionRecord;
@@ -46,8 +46,14 @@ pub struct TransactionCheckResult {
     pub total_received_for_credit_conversion: u64,
     /// New addresses generated during gap limit maintenance
     pub new_addresses: Vec<Address>,
-    /// Transaction records created for new transactions, paired with their account index
-    pub new_records: Vec<(u32, TransactionRecord)>,
+    /// Transaction records created for new transactions, paired with the
+    /// `AccountType` they belong to. Conversion to a `DerivationPath` is
+    /// performed by the consumer (e.g. `key-wallet-manager`) where the network
+    /// is known.
+    pub new_records: Vec<(AccountType, TransactionRecord)>,
+    /// Transaction records updated by this check (confirmation or IS-lock
+    /// applied to a previously stored record), paired with their `AccountType`.
+    pub updated_records: Vec<(AccountType, TransactionRecord)>,
 }
 
 /// Enum representing the type of Core account that matched with embedded data
@@ -376,6 +382,7 @@ impl ManagedAccountCollection {
             total_received_for_credit_conversion: 0,
             new_addresses: Vec::new(),
             new_records: Vec::new(),
+            updated_records: Vec::new(),
         };
 
         for account_type in account_types {

--- a/key-wallet/src/transaction_checking/account_checker.rs
+++ b/key-wallet/src/transaction_checking/account_checker.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 
 use super::transaction_router::AccountTypeToCheck;
-use crate::account::{AccountType, ManagedAccountCollection, ManagedCoreAccount};
+use crate::account::{ManagedAccountCollection, ManagedCoreAccount};
 use crate::managed_account::address_pool::{AddressInfo, PublicKeyType};
 use crate::managed_account::managed_account_type::ManagedAccountType;
 use crate::managed_account::transaction_record::TransactionRecord;
@@ -46,14 +46,15 @@ pub struct TransactionCheckResult {
     pub total_received_for_credit_conversion: u64,
     /// New addresses generated during gap limit maintenance
     pub new_addresses: Vec<Address>,
-    /// Transaction records created for new transactions, paired with the
-    /// `AccountType` they belong to. Conversion to a `DerivationPath` is
-    /// performed by the consumer (e.g. `key-wallet-manager`) where the network
-    /// is known.
-    pub new_records: Vec<(AccountType, TransactionRecord)>,
+    /// Transaction records created for new transactions. Each record carries
+    /// its owning [`AccountType`](crate::account::AccountType) on
+    /// `record.account_type`, so consumers can recover it without an external
+    /// pairing.
+    pub new_records: Vec<TransactionRecord>,
     /// Transaction records updated by this check (confirmation or IS-lock
-    /// applied to a previously stored record), paired with their `AccountType`.
-    pub updated_records: Vec<(AccountType, TransactionRecord)>,
+    /// applied to a previously stored record). Each record carries its owning
+    /// `AccountType` on `record.account_type`.
+    pub updated_records: Vec<TransactionRecord>,
 }
 
 /// Enum representing the type of Core account that matched with embedded data

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -100,11 +100,10 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                         .accounts
                         .get_by_account_type_match_mut(&account_match.account_type_match)
                     {
-                        let account_type = account.account_type.to_account_type();
                         account.mark_utxos_instant_send(&txid);
                         if let Some(record) = account.transactions.get_mut(&txid) {
                             record.update_context(context.clone());
-                            result.updated_records.push((account_type, record.clone()));
+                            result.updated_records.push(record.clone());
                         }
                     }
                 }
@@ -128,17 +127,15 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                 continue;
             };
 
-            let account_type = account.account_type.to_account_type();
-
             if is_new {
                 let record =
                     account.record_transaction(tx, &account_match, context.clone(), tx_type);
-                result.new_records.push((account_type, record));
+                result.new_records.push(record);
                 result.state_modified = true;
             } else if account.confirm_transaction(tx, &account_match, context.clone(), tx_type) {
                 result.state_modified = true;
                 if let Some(record) = account.transactions.get(&tx.txid()) {
-                    result.updated_records.push((account_type, record.clone()));
+                    result.updated_records.push(record.clone());
                 }
             }
 

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -100,9 +100,11 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                         .accounts
                         .get_by_account_type_match_mut(&account_match.account_type_match)
                     {
+                        let account_type = account.account_type.to_account_type();
                         account.mark_utxos_instant_send(&txid);
                         if let Some(record) = account.transactions.get_mut(&txid) {
                             record.update_context(context.clone());
+                            result.updated_records.push((account_type, record.clone()));
                         }
                     }
                 }
@@ -126,15 +128,18 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                 continue;
             };
 
+            let account_type = account.account_type.to_account_type();
+
             if is_new {
                 let record =
                     account.record_transaction(tx, &account_match, context.clone(), tx_type);
-                if let Some(account_index) = account_match.account_type_match.account_index() {
-                    result.new_records.push((account_index, record));
-                }
+                result.new_records.push((account_type, record));
                 result.state_modified = true;
             } else if account.confirm_transaction(tx, &account_match, context.clone(), tx_type) {
                 result.state_modified = true;
+                if let Some(record) = account.transactions.get(&tx.txid()) {
+                    result.updated_records.push((account_type, record.clone()));
+                }
             }
 
             for address_info in account_match.account_type_match.all_involved_addresses() {

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -89,9 +89,15 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Return the last fully processed height of the wallet.
     fn last_processed_height(&self) -> CoreBlockHeight;
 
+    /// Return the durable wallet sync checkpoint height.
+    fn synced_height(&self) -> CoreBlockHeight;
+
     /// Update chain state and process any matured transactions
     /// This should be called when the chain tip advances to a new height
     fn update_last_processed_height(&mut self, current_height: u32);
+
+    /// Record that the durable wallet sync checkpoint has advanced to `current_height`.
+    fn update_synced_height(&mut self, current_height: u32);
 
     /// Mark UTXOs for a transaction as InstantSend-locked across all accounts
     /// and update the corresponding transaction record context.
@@ -149,6 +155,10 @@ impl WalletInfoInterface for ManagedWalletInfo {
 
     fn last_processed_height(&self) -> CoreBlockHeight {
         self.metadata.last_processed_height
+    }
+
+    fn synced_height(&self) -> CoreBlockHeight {
+        self.metadata.synced_height
     }
 
     fn first_loaded_at(&self) -> u64 {
@@ -243,6 +253,10 @@ impl WalletInfoInterface for ManagedWalletInfo {
         self.metadata.last_processed_height = current_height;
         // Update cached balance
         self.update_balance();
+    }
+
+    fn update_synced_height(&mut self, current_height: u32) {
+        self.metadata.synced_height = current_height;
     }
 
     fn mark_instant_send_utxos(&mut self, txid: &Txid, lock: &InstantLock) -> bool {

--- a/key-wallet/src/wallet/metadata.rs
+++ b/key-wallet/src/wallet/metadata.rs
@@ -18,6 +18,8 @@ pub struct WalletMetadata {
     pub birth_height: CoreBlockHeight,
     /// Last processed block height
     pub last_processed_height: CoreBlockHeight,
+    /// Sync checkpoint height
+    pub synced_height: CoreBlockHeight,
     /// Last sync timestamp
     pub last_synced: Option<u64>,
     /// Total transactions


### PR DESCRIPTION
Reshape `WalletEvent` so each variant carries the records and post-change balance needed to persist a wallet update atomically off a single event. Replaces `TransactionReceived` / `TransactionStatusChanged` / `BalanceUpdated` with `MempoolTransactionReceived`, `TransactionInstantSendLocked`, and `BlockProcessChange`, adds `RecordAction` and `BlockRecordUpdate` for per-record context, and identifies accounts by `DerivationPath` instead of `account_index: u32`.