### PR TITLE
feat(dash-spv): cover gap-extension blind spot in filter sync via per-range backfill

### DIFF
--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -1068,8 +1068,86 @@ impl FFIWalletEventCallbacks {
                 ..
             } => {}
             WalletEvent::RescanBlockProcessed {
+                wallet_id,
+                height,
+                inserted,
+                updated,
+                matured,
+                balance,
+                account_balances,
+                addresses_derived,
                 ..
-            } => {}
+            } => {
+                // Forward to the BlockProcessed callback so FFI consumers'
+                // persisters see backfill records and balance via the
+                // same atomic dispatch path. The pool/indexes/advance_to
+                // fields are dropped at the FFI boundary because the
+                // existing BlockProcessed callback shape can't carry
+                // them; the persister still gets the records and balance
+                // it needs to write atomically per backfill block.
+                if let Some(cb) = self.on_block_processed {
+                    let wallet_id_hex = hex::encode(wallet_id);
+                    let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
+                    let ffi_inserted: Vec<FFITransactionRecord> =
+                        inserted.iter().map(FFITransactionRecord::from).collect();
+                    let ffi_updated: Vec<FFITransactionRecord> =
+                        updated.iter().map(FFITransactionRecord::from).collect();
+                    let ffi_matured: Vec<FFITransactionRecord> =
+                        matured.iter().map(FFITransactionRecord::from).collect();
+                    let ffi_balance = FFIBalance::from(*balance);
+                    let ffi_account_balances = FFIAccountBalance::from_map(account_balances);
+                    let ffi_addresses_derived = FFIDerivedAddress::from_slice(addresses_derived);
+
+                    let inserted_ptr = if ffi_inserted.is_empty() {
+                        ptr::null()
+                    } else {
+                        ffi_inserted.as_ptr()
+                    };
+                    let updated_ptr = if ffi_updated.is_empty() {
+                        ptr::null()
+                    } else {
+                        ffi_updated.as_ptr()
+                    };
+                    let matured_ptr = if ffi_matured.is_empty() {
+                        ptr::null()
+                    } else {
+                        ffi_matured.as_ptr()
+                    };
+                    let account_balances_ptr = if ffi_account_balances.is_empty() {
+                        ptr::null()
+                    } else {
+                        ffi_account_balances.as_ptr()
+                    };
+                    let addresses_derived_ptr = if ffi_addresses_derived.is_empty() {
+                        ptr::null()
+                    } else {
+                        ffi_addresses_derived.as_ptr()
+                    };
+
+                    cb(
+                        c_wallet_id.as_ptr(),
+                        *height,
+                        inserted_ptr,
+                        ffi_inserted.len() as u32,
+                        updated_ptr,
+                        ffi_updated.len() as u32,
+                        matured_ptr,
+                        ffi_matured.len() as u32,
+                        &ffi_balance as *const FFIBalance,
+                        account_balances_ptr,
+                        ffi_account_balances.len() as u32,
+                        addresses_derived_ptr,
+                        ffi_addresses_derived.len() as u32,
+                        self.user_data,
+                    );
+
+                    drop(ffi_inserted);
+                    drop(ffi_updated);
+                    drop(ffi_matured);
+                    drop(ffi_account_balances);
+                    drop(ffi_addresses_derived);
+                }
+            }
         }
     }
 }

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -438,6 +438,9 @@ impl FFISyncEventCallbacks {
                     cb(*header_tip, *cycle, self.user_data);
                 }
             }
+            SyncEvent::BackfillBlocksNeeded {
+                ..
+            } => {}
         }
     }
 }
@@ -1058,6 +1061,15 @@ impl FFIWalletEventCallbacks {
                     cb(c_wallet_id.as_ptr(), *height, self.user_data);
                 }
             }
+            WalletEvent::ConvergenceChanged {
+                ..
+            } => {}
+            WalletEvent::RescanProgressed {
+                ..
+            } => {}
+            WalletEvent::RescanBlockProcessed {
+                ..
+            } => {}
         }
     }
 }

--- a/dash-spv/src/sync/blocks/manager.rs
+++ b/dash-spv/src/sync/blocks/manager.rs
@@ -3,6 +3,7 @@
 //! Downloads blocks that matched wallet filters and processes them in height order.
 //! Subscribes to BlockNeeded events and emits BlockProcessed events.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -12,7 +13,8 @@ use crate::error::SyncResult;
 use crate::network::RequestSender;
 use crate::storage::{BlockHeaderStorage, BlockStorage};
 use crate::sync::{BlocksProgress, SyncEvent, SyncManager, SyncState};
-use key_wallet_manager::WalletInterface;
+use dashcore::BlockHash;
+use key_wallet_manager::{BackfillAdvance, WalletInterface};
 
 /// Blocks manager for downloading and processing matching blocks.
 ///
@@ -39,6 +41,11 @@ pub struct BlocksManager<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterf
     pub(super) pipeline: BlocksPipeline,
     /// Whether FiltersSyncComplete has been received.
     pub(super) filters_sync_complete: bool,
+    /// Per-block backfill obligations carried alongside the pipeline. A
+    /// block whose hash is keyed here is processed via
+    /// `process_backfill_block_for_wallets`, which emits
+    /// `WalletEvent::RescanBlockProcessed` and calls `advance_rescan`.
+    pub(super) backfill_advances: HashMap<BlockHash, Vec<BackfillAdvance>>,
 }
 
 impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H, B, W> {
@@ -60,6 +67,7 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
             wallet,
             pipeline: BlocksPipeline::new(),
             filters_sync_complete: false,
+            backfill_advances: HashMap::new(),
         }
     }
 
@@ -74,7 +82,11 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
     /// Process buffered blocks in height order.
     ///
     /// Uses the pipeline's height-ordering logic to ensure blocks are processed
-    /// in the correct sequence.
+    /// in the correct sequence. A block whose hash is recorded in
+    /// `backfill_advances` is processed via the backfill path (one
+    /// `RescanBlockProcessed` event per advance, atomic with
+    /// `advance_rescan`); other blocks take the forward-sync path
+    /// (`BlockProcessed`).
     pub(super) async fn process_buffered_blocks(&mut self) -> SyncResult<Vec<SyncEvent>> {
         let mut events = Vec::new();
 
@@ -82,11 +94,19 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
         while let Some((block, height, interested)) = self.pipeline.take_next_ordered_block() {
             let hash = block.block_hash();
 
-            // Process the block only for the wallets whose filter matched it.
-            // Already-synced wallets that did not match are not touched.
-            let mut wallet = self.wallet.write().await;
-            let result = wallet.process_block_for_wallets(&block, height, &interested).await;
-            drop(wallet);
+            let backfill_advances = self.backfill_advances.remove(&hash);
+
+            let result = if let Some(advances) = backfill_advances.as_ref() {
+                let mut wallet = self.wallet.write().await;
+                let r = wallet.process_backfill_block_for_wallets(&block, height, advances).await;
+                drop(wallet);
+                r
+            } else {
+                let mut wallet = self.wallet.write().await;
+                let r = wallet.process_block_for_wallets(&block, height, &interested).await;
+                drop(wallet);
+                r
+            };
 
             let total_relevant = result.relevant_tx_count();
             let new_addresses_total: usize = result.new_addresses.values().map(|v| v.len()).sum();
@@ -122,8 +142,17 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
             }
             // Only count new transactions to avoid double-counting during rescans
             self.progress.add_transactions(result.new_txids.len() as u32);
-            self.progress.update_last_processed(height);
+            // Backfill blocks live below the forward edge — do not bump
+            // last_processed_height backwards.
+            if backfill_advances.is_none() {
+                self.progress.update_last_processed(height);
+            }
 
+            // Forward sync emits BlockProcessed for downstream consumers
+            // (FiltersManager tracks in-flight, etc.). Backfill blocks emit
+            // BlockProcessed too so FiltersManager's BlockMatchTracker can
+            // clear its in-flight state — they're distinguishable by
+            // FiltersManager via the worker's pending_advances.
             events.push(SyncEvent::BlockProcessed {
                 block_hash: hash,
                 height,

--- a/dash-spv/src/sync/blocks/manager.rs
+++ b/dash-spv/src/sync/blocks/manager.rs
@@ -3,7 +3,7 @@
 //! Downloads blocks that matched wallet filters and processes them in height order.
 //! Subscribes to BlockNeeded events and emits BlockProcessed events.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -71,6 +71,23 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
         }
     }
 
+    /// Drop entries from `backfill_advances` whose block hash is no longer
+    /// claimed by any live pending advance in the worker. Without this
+    /// cleanup, a block that was queued via `BackfillBlocksNeeded` but
+    /// then cancelled (peer disconnect, range completed elsewhere, reorg
+    /// invalidation) would sit in the map forever, leaking memory and
+    /// shadowing future forward-sync routing for the same hash.
+    ///
+    /// `live_hashes` is the set of block hashes the
+    /// [`super::super::filters::backfill::BackfillWorker`] still considers
+    /// in-flight; everything else is stale.
+    pub(super) fn prune_stale_backfill_advances(&mut self, live_hashes: &HashSet<BlockHash>) {
+        if self.backfill_advances.is_empty() {
+            return;
+        }
+        self.backfill_advances.retain(|hash, _| live_hashes.contains(hash));
+    }
+
     pub(super) async fn send_pending(&mut self, requests: &RequestSender) -> SyncResult<()> {
         let sent = self.pipeline.send_pending(requests).await?;
         if sent > 0 {
@@ -82,12 +99,17 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
     /// Process buffered blocks in height order.
     ///
     /// Uses the pipeline's height-ordering logic to ensure blocks are processed
-    /// in the correct sequence. A block whose hash is recorded in
-    /// `backfill_advances` is processed via the backfill path (one
-    /// `RescanBlockProcessed` event per advance, atomic with
-    /// `advance_rescan`); other blocks take the forward-sync path
-    /// (`BlockProcessed`).
+    /// in the correct sequence. A block hash recorded in `backfill_advances`
+    /// is processed via the backfill path (one `RescanBlockProcessed` event
+    /// per advance, atomic with `advance_rescan`). When the same block hash
+    /// is also in the pipeline's `interested` set (forward-sync wallets that
+    /// matched the block too), the forward-sync wallets are processed
+    /// alongside via `process_block_for_wallets` so neither side is silently
+    /// skipped.
     pub(super) async fn process_buffered_blocks(&mut self) -> SyncResult<Vec<SyncEvent>> {
+        use key_wallet_manager::WalletId;
+        use std::collections::BTreeSet;
+
         let mut events = Vec::new();
 
         // Process blocks in height order using pipeline's ordering logic
@@ -96,17 +118,43 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
 
             let backfill_advances = self.backfill_advances.remove(&hash);
 
-            let result = if let Some(advances) = backfill_advances.as_ref() {
+            // Forward-sync wallets that this block was queued for, minus
+            // any wallet already covered by a backfill advance. The two
+            // sets normally don't overlap, but if they do (a wallet
+            // catching up via forward sync also has a pending sync range
+            // matched at this height) the backfill path takes precedence
+            // because it carries the per-range `advance_to` obligation.
+            let backfill_wallets: BTreeSet<WalletId> = backfill_advances
+                .as_ref()
+                .map(|advs| advs.iter().map(|a| a.wallet_id).collect())
+                .unwrap_or_default();
+            let forward_only: BTreeSet<WalletId> =
+                interested.difference(&backfill_wallets).cloned().collect();
+            let has_forward = !forward_only.is_empty();
+
+            let mut result = if has_forward {
                 let mut wallet = self.wallet.write().await;
-                let r = wallet.process_backfill_block_for_wallets(&block, height, advances).await;
+                let r = wallet.process_block_for_wallets(&block, height, &forward_only).await;
                 drop(wallet);
                 r
             } else {
-                let mut wallet = self.wallet.write().await;
-                let r = wallet.process_block_for_wallets(&block, height, &interested).await;
-                drop(wallet);
-                r
+                key_wallet_manager::BlockProcessingResult::default()
             };
+
+            if let Some(advances) = backfill_advances.as_ref() {
+                let mut wallet = self.wallet.write().await;
+                let bf = wallet.process_backfill_block_for_wallets(&block, height, advances).await;
+                drop(wallet);
+                // Merge backfill stats into the forward-sync result so the
+                // logging and progress counters below reflect the full
+                // block. `BlockProcessingResult` exposes additive
+                // accessors via the existing fields; merge by extending.
+                result.new_txids.extend(bf.new_txids);
+                result.existing_txids.extend(bf.existing_txids);
+                for (wid, addrs) in bf.new_addresses {
+                    result.new_addresses.entry(wid).or_default().extend(addrs);
+                }
+            }
 
             let total_relevant = result.relevant_tx_count();
             let new_addresses_total: usize = result.new_addresses.values().map(|v| v.len()).sum();
@@ -142,9 +190,12 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
             }
             // Only count new transactions to avoid double-counting during rescans
             self.progress.add_transactions(result.new_txids.len() as u32);
-            // Backfill blocks live below the forward edge — do not bump
-            // last_processed_height backwards.
-            if backfill_advances.is_none() {
+            // Backfill-only blocks live below the forward edge and must not
+            // bump `last_processed_height` backwards. A mixed block (some
+            // forward-sync wallets, some backfill wallets) DOES advance the
+            // forward edge for the forward-sync wallets, so the bump is
+            // gated on the forward path having actually run.
+            if has_forward {
                 self.progress.update_last_processed(height);
             }
 

--- a/dash-spv/src/sync/blocks/sync_manager.rs
+++ b/dash-spv/src/sync/blocks/sync_manager.rs
@@ -110,8 +110,17 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface + 'static> SyncM
         // the wallet processing path forks to the backfill flow.
         if let SyncEvent::BackfillBlocksNeeded {
             blocks,
+            live_hashes,
         } = event
         {
+            // Prune entries the worker no longer tracks before inserting
+            // any new advances. This is the BlocksManager's leak guard:
+            // a backfill block whose download was cancelled, whose range
+            // completed elsewhere, or whose range was clamped by a reorg
+            // disappears from the worker's in-flight set, and the mirror
+            // here must drop accordingly.
+            self.prune_stale_backfill_advances(live_hashes);
+
             if blocks.is_empty() {
                 return Ok(vec![]);
             }

--- a/dash-spv/src/sync/blocks/sync_manager.rs
+++ b/dash-spv/src/sync/blocks/sync_manager.rs
@@ -105,6 +105,50 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface + 'static> SyncM
         event: &SyncEvent,
         requests: &RequestSender,
     ) -> SyncResult<Vec<SyncEvent>> {
+        // React to BackfillBlocksNeeded events: queue the blocks like
+        // forward sync but record the per-block advance obligations so
+        // the wallet processing path forks to the backfill flow.
+        if let SyncEvent::BackfillBlocksNeeded {
+            blocks,
+        } = event
+        {
+            if blocks.is_empty() {
+                return Ok(vec![]);
+            }
+
+            tracing::debug!("Backfill blocks needed: {} blocks", blocks.len());
+
+            let mut to_queue: Vec<(FilterMatchKey, BTreeSet<WalletId>)> =
+                Vec::with_capacity(blocks.len());
+            let block_storage = self.block_storage.read().await;
+            for (key, advances) in blocks {
+                let interested: BTreeSet<WalletId> =
+                    advances.iter().map(|a| a.wallet_id).collect();
+                self.backfill_advances.insert(*key.hash(), advances.clone());
+
+                if let Ok(Some(hashed_block)) = block_storage.load_block(key.height()).await {
+                    if hashed_block.hash() == key.hash() {
+                        self.pipeline.add_from_storage(
+                            hashed_block.block().clone(),
+                            key.height(),
+                            interested,
+                        );
+                        self.progress.add_from_storage(1);
+                        continue;
+                    }
+                }
+                to_queue.push((key.clone(), interested));
+            }
+            drop(block_storage);
+
+            self.pipeline.queue(to_queue);
+            self.progress.set_state(SyncState::Syncing);
+            if self.pipeline.has_pending_requests() {
+                self.send_pending(requests).await?;
+            }
+            return self.process_buffered_blocks().await;
+        }
+
         // React to BlocksNeeded events
         if let SyncEvent::BlocksNeeded {
             blocks,

--- a/dash-spv/src/sync/blocks/sync_manager.rs
+++ b/dash-spv/src/sync/blocks/sync_manager.rs
@@ -122,8 +122,7 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface + 'static> SyncM
                 Vec::with_capacity(blocks.len());
             let block_storage = self.block_storage.read().await;
             for (key, advances) in blocks {
-                let interested: BTreeSet<WalletId> =
-                    advances.iter().map(|a| a.wallet_id).collect();
+                let interested: BTreeSet<WalletId> = advances.iter().map(|a| a.wallet_id).collect();
                 self.backfill_advances.insert(*key.hash(), advances.clone());
 
                 if let Ok(Some(hashed_block)) = block_storage.load_block(key.height()).await {

--- a/dash-spv/src/sync/events.rs
+++ b/dash-spv/src/sync/events.rs
@@ -107,6 +107,12 @@ pub enum SyncEvent {
         /// Blocks to download, each with the per-sync-range advances that
         /// the block's processing must satisfy.
         blocks: BTreeMap<FilterMatchKey, Vec<BackfillAdvance>>,
+        /// Snapshot of every block hash the backfill worker still
+        /// considers in-flight at the time of this event. The BlocksManager
+        /// uses this to prune its mirror `backfill_advances` map of
+        /// entries the worker no longer tracks (cancelled downloads,
+        /// completed ranges, reorg-clamped ranges) so neither side leaks.
+        live_hashes: std::collections::HashSet<BlockHash>,
     },
 
     /// Block downloaded and processed through wallet.
@@ -243,9 +249,15 @@ impl SyncEvent {
             }
             SyncEvent::BackfillBlocksNeeded {
                 blocks,
+                live_hashes,
             } => {
                 let advances: usize = blocks.values().map(|v| v.len()).sum();
-                format!("BackfillBlocksNeeded(blocks={}, advances={})", blocks.len(), advances)
+                format!(
+                    "BackfillBlocksNeeded(blocks={}, advances={}, live={})",
+                    blocks.len(),
+                    advances,
+                    live_hashes.len(),
+                )
             }
             SyncEvent::BlockProcessed {
                 height,

--- a/dash-spv/src/sync/events.rs
+++ b/dash-spv/src/sync/events.rs
@@ -3,7 +3,7 @@ use dashcore::ephemerealdata::chain_lock::ChainLock;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::sml::masternode_list_engine::QRInfoFeedResult;
 use dashcore::{Address, BlockHash, Txid};
-use key_wallet_manager::{FilterMatchKey, WalletId};
+use key_wallet_manager::{BackfillAdvance, FilterMatchKey, WalletId};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Events that managers can emit and subscribe to.
@@ -90,6 +90,23 @@ pub enum SyncEvent {
         /// Blocks to download (height-ordered by `FilterMatchKey`), each
         /// associated with the wallet ids that need it.
         blocks: BTreeMap<FilterMatchKey, BTreeSet<WalletId>>,
+    },
+
+    /// Backfill worker matched filters below a wallet's `synced_height` and
+    /// needs the corresponding blocks downloaded. Each block carries the
+    /// per-sync-range advance obligations so the block-processing path can
+    /// emit `WalletEvent::RescanBlockProcessed` and call `advance_rescan`
+    /// atomically once the block is processed.
+    ///
+    /// Routes through the same `BlocksManager` pipeline as `BlocksNeeded`,
+    /// deduplicating against forward sync via `BlockMatchTracker`.
+    ///
+    /// Emitted by: `FiltersManager`
+    /// Consumed by: `BlocksManager`
+    BackfillBlocksNeeded {
+        /// Blocks to download, each with the per-sync-range advances that
+        /// the block's processing must satisfy.
+        blocks: BTreeMap<FilterMatchKey, Vec<BackfillAdvance>>,
     },
 
     /// Block downloaded and processed through wallet.
@@ -223,6 +240,12 @@ impl SyncEvent {
                 blocks,
             } => {
                 format!("BlocksNeeded(count={})", blocks.len())
+            }
+            SyncEvent::BackfillBlocksNeeded {
+                blocks,
+            } => {
+                let advances: usize = blocks.values().map(|v| v.len()).sum();
+                format!("BackfillBlocksNeeded(blocks={}, advances={})", blocks.len(), advances)
             }
             SyncEvent::BlockProcessed {
                 height,

--- a/dash-spv/src/sync/filters/backfill.rs
+++ b/dash-spv/src/sync/filters/backfill.rs
@@ -153,11 +153,12 @@ where
                 continue;
             }
 
-            // `check_compact_filters_for_addresses` takes the height *before*
-            // the chunk's first filter. When `chunk_start == 0` we want the
-            // matched `FilterMatchKey.height()` to equal the block height, so
-            // we pass `u32::MAX` (the result of `0u32.saturating_sub(1)`),
-            // which the matcher treats as "begin from height 0".
+            // `check_compact_filters_for_addresses` includes a filter when
+            // `key.height() > min_height`, so we pass `chunk_start - 1` to
+            // include the chunk's first height. For `chunk_start == 0`,
+            // `0u32.saturating_sub(1) == 0`, which means filters at height
+            // 0 (genesis) are skipped — acceptable in practice because the
+            // genesis block has no spendable wallet outputs.
             let matches = check_compact_filters_for_addresses(
                 &filters,
                 address_vec,
@@ -186,10 +187,14 @@ where
                             && p.pool == advance.pool
                             && p.indexes == advance.indexes
                     });
-                    if already_pending {
-                        continue;
+                    if !already_pending {
+                        pending.push(advance.clone());
                     }
-                    pending.push(advance.clone());
+                    // Always re-emit the request so a previously-failed
+                    // download is retried. The BlocksManager pipeline will
+                    // dedup the actual network request via its own
+                    // bookkeeping, but a backfill match must never fail to
+                    // surface a request when a download was lost.
                     new_requests.entry(key.clone()).or_default().push(advance);
                 }
             }
@@ -228,14 +233,23 @@ where
     /// pending or has already advanced past the matched block's height.
     /// Keeps `pending_advances` bounded across reorgs, gap-extension churn,
     /// and download failures.
+    ///
+    /// Builds the live-key index by folding rather than collecting so two
+    /// `PendingRescan` entries that hash to the same key (same wallet, pool,
+    /// and indexes) keep the most conservative `resume_from` (the lowest)
+    /// rather than silently dropping one. In a healthy wallet the key is
+    /// already unique because pools collapse adjacent ranges; the fold makes
+    /// the prune robust against a future regression in that invariant.
     fn prune_pending_advances(&mut self, rescans: &[PendingRescan]) {
         if self.pending_advances.is_empty() {
             return;
         }
-        let live: HashMap<(WalletId, AddressPoolType, u32, u32), CoreBlockHeight> = rescans
-            .iter()
-            .map(|r| ((r.wallet_id, r.pool, r.indexes.start, r.indexes.end), r.resume_from))
-            .collect();
+        let mut live: HashMap<(WalletId, AddressPoolType, u32, u32), CoreBlockHeight> =
+            HashMap::new();
+        for r in rescans {
+            let key = (r.wallet_id, r.pool, r.indexes.start, r.indexes.end);
+            live.entry(key).and_modify(|v| *v = (*v).min(r.resume_from)).or_insert(r.resume_from);
+        }
         self.pending_advances.retain(|_hash, advances| {
             advances.retain(|adv| {
                 live.get(&(adv.wallet_id, adv.pool, adv.indexes.start, adv.indexes.end))
@@ -258,6 +272,14 @@ where
     /// [`WalletInterface::process_backfill_block_for_wallets`]: key_wallet_manager::WalletInterface::process_backfill_block_for_wallets
     pub(crate) async fn on_block_processed(&mut self, hash: &BlockHash) -> bool {
         self.pending_advances.remove(hash).is_some()
+    }
+
+    /// Snapshot the set of block hashes this worker still considers
+    /// in-flight. Used by the orchestrator to prune stale entries from
+    /// the BlocksManager's parallel `backfill_advances` map after each
+    /// tick, so cancelled or completed advances don't leak there either.
+    pub(crate) fn live_block_hashes(&self) -> HashSet<BlockHash> {
+        self.pending_advances.keys().copied().collect()
     }
 
     async fn load_filters(

--- a/dash-spv/src/sync/filters/backfill.rs
+++ b/dash-spv/src/sync/filters/backfill.rs
@@ -43,31 +43,6 @@ use crate::storage::{BlockHeaderStorage, FilterStorage};
 /// Matches the forward-sync batch size so disk reads stay cache-friendly.
 const BACKFILL_CHUNK_SIZE: u32 = 5000;
 
-/// Per-block obligation tracked while waiting for a backfill block to be
-/// downloaded and processed. Held in [`BackfillWorker::pending_advances`]
-/// keyed by block hash. Multiple obligations can attach to the same block
-/// when several sync ranges share an address that matched the same filter,
-/// so the value is a `Vec`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct PendingAdvance {
-    pub wallet_id: WalletId,
-    pub pool: AddressPoolType,
-    pub indexes: Range<u32>,
-    pub height: CoreBlockHeight,
-    pub advance_to: CoreBlockHeight,
-}
-
-impl PendingAdvance {
-    fn to_backfill_advance(&self) -> BackfillAdvance {
-        BackfillAdvance {
-            wallet_id: self.wallet_id,
-            pool: self.pool,
-            indexes: self.indexes.clone(),
-            advance_to: self.advance_to,
-        }
-    }
-}
-
 /// Sweep-line backfill worker over pending sync ranges.
 ///
 /// Owns short-lived state (`pending_advances`) plus shared references to
@@ -75,11 +50,18 @@ impl PendingAdvance {
 /// wake channel signalled when `pending_rescans` becomes non-empty) and
 /// `on_block_processed` (when a block we requested has been downloaded
 /// through the existing block path).
+///
+/// `pending_advances` is keyed by block hash because several sync ranges
+/// can share an address that matched the same filter, so the value is a
+/// `Vec<BackfillAdvance>`. Entries that no longer correspond to a live
+/// pending sync range (range completed, range advanced past `height`, or
+/// range removed by reorg clamp) are pruned at the top of every `tick`,
+/// keeping the map bounded under repeated polling and download failures.
 pub(crate) struct BackfillWorker<F, H, W> {
     filter_storage: Arc<RwLock<F>>,
     header_storage: Arc<RwLock<H>>,
     wallet: Arc<RwLock<W>>,
-    pending_advances: HashMap<BlockHash, Vec<PendingAdvance>>,
+    pending_advances: HashMap<BlockHash, Vec<BackfillAdvance>>,
 }
 
 impl<F, H, W> BackfillWorker<F, H, W>
@@ -115,6 +97,7 @@ where
         &mut self,
     ) -> SyncResult<BTreeMap<FilterMatchKey, Vec<BackfillAdvance>>> {
         let rescans = self.wallet.read().await.pending_rescans();
+        self.prune_pending_advances(&rescans);
         if rescans.is_empty() {
             return Ok(BTreeMap::new());
         }
@@ -133,6 +116,11 @@ where
         }
 
         let mut new_requests: BTreeMap<FilterMatchKey, Vec<BackfillAdvance>> = BTreeMap::new();
+        // Ranges that match in any chunk are excluded from no-match advance
+        // for every later chunk too: a range with an in-flight matched block
+        // must not have its `caught_up_to` advanced past that block's height
+        // until the block is processed and `RescanBlockProcessed` fires.
+        let mut matched_range_keys: HashSet<(WalletId, AddressPoolType, u32, u32)> = HashSet::new();
         let mut chunk_start = global_min;
         while chunk_start <= global_max {
             let chunk_end =
@@ -140,7 +128,11 @@ where
 
             let active: Vec<&PendingRescan> = rescans
                 .iter()
-                .filter(|r| r.resume_from <= chunk_end && r.ceiling >= chunk_start)
+                .filter(|r| {
+                    r.resume_from <= r.ceiling
+                        && r.resume_from <= chunk_end
+                        && r.ceiling >= chunk_start
+                })
                 .collect();
             if active.is_empty() {
                 chunk_start = chunk_end.saturating_add(1);
@@ -161,14 +153,17 @@ where
                 continue;
             }
 
+            // `check_compact_filters_for_addresses` takes the height *before*
+            // the chunk's first filter. When `chunk_start == 0` we want the
+            // matched `FilterMatchKey.height()` to equal the block height, so
+            // we pass `u32::MAX` (the result of `0u32.saturating_sub(1)`),
+            // which the matcher treats as "begin from height 0".
             let matches = check_compact_filters_for_addresses(
                 &filters,
                 address_vec,
                 chunk_start.saturating_sub(1),
             );
 
-            let mut matched_range_keys: HashSet<(WalletId, AddressPoolType, u32, u32)> =
-                HashSet::new();
             for key in &matches {
                 let height = key.height();
                 let hash = *key.hash();
@@ -176,28 +171,33 @@ where
                     if r.resume_from > height || r.ceiling < height {
                         continue;
                     }
-                    matched_range_keys.insert((
-                        r.wallet_id,
-                        r.pool,
-                        r.indexes.start,
-                        r.indexes.end,
-                    ));
-                    let pending = PendingAdvance {
+                    let range_key = (r.wallet_id, r.pool, r.indexes.start, r.indexes.end);
+                    matched_range_keys.insert(range_key);
+                    let advance = BackfillAdvance {
                         wallet_id: r.wallet_id,
                         pool: r.pool,
                         indexes: r.indexes.clone(),
                         height,
                         advance_to: chunk_end,
                     };
-                    let advance = pending.to_backfill_advance();
-                    self.pending_advances.entry(hash).or_default().push(pending);
+                    let pending = self.pending_advances.entry(hash).or_default();
+                    let already_pending = pending.iter().any(|p| {
+                        p.wallet_id == advance.wallet_id
+                            && p.pool == advance.pool
+                            && p.indexes == advance.indexes
+                    });
+                    if already_pending {
+                        continue;
+                    }
+                    pending.push(advance.clone());
                     new_requests.entry(key.clone()).or_default().push(advance);
                 }
             }
 
-            // Active ranges that did NOT match anything in this chunk advance
-            // straight to `chunk_end`. Ranges that matched defer the advance
-            // until the block actually arrives so persistence stays atomic.
+            // Active ranges that did NOT match anything in *any* chunk so far
+            // advance straight to `chunk_end`. Ranges that matched anywhere
+            // defer the advance until their matched block is processed so
+            // persistence stays atomic.
             let no_match: Vec<(WalletId, AddressPoolType, Range<u32>)> = active
                 .iter()
                 .filter(|r| {
@@ -224,6 +224,28 @@ where
         Ok(new_requests)
     }
 
+    /// Drop pending advances whose corresponding sync range is no longer
+    /// pending or has already advanced past the matched block's height.
+    /// Keeps `pending_advances` bounded across reorgs, gap-extension churn,
+    /// and download failures.
+    fn prune_pending_advances(&mut self, rescans: &[PendingRescan]) {
+        if self.pending_advances.is_empty() {
+            return;
+        }
+        let live: HashMap<(WalletId, AddressPoolType, u32, u32), CoreBlockHeight> = rescans
+            .iter()
+            .map(|r| ((r.wallet_id, r.pool, r.indexes.start, r.indexes.end), r.resume_from))
+            .collect();
+        self.pending_advances.retain(|_hash, advances| {
+            advances.retain(|adv| {
+                live.get(&(adv.wallet_id, adv.pool, adv.indexes.start, adv.indexes.end))
+                    .map(|resume| adv.height >= *resume)
+                    .unwrap_or(false)
+            });
+            !advances.is_empty()
+        });
+    }
+
     /// Called by the orchestrator after a backfill block has been processed
     /// via [`WalletInterface::process_backfill_block_for_wallets`], which
     /// already advanced `caught_up_to` and emitted
@@ -245,6 +267,20 @@ where
     ) -> SyncResult<HashMap<FilterMatchKey, BlockFilter>> {
         let filter_data = self.filter_storage.read().await.load_filters(start..end + 1).await?;
         let headers = self.header_storage.read().await.load_headers(start..end + 1).await?;
+
+        // A length mismatch means the storage layer returned a partial view
+        // for the chunk: filters truncated, headers truncated, or both. Pairing
+        // by `zip` would silently drop the tail and the caller would advance
+        // `caught_up_to` past heights that were never actually scanned,
+        // permanently masking any transactions there. Surface the
+        // inconsistency so the caller can recover.
+        if filter_data.len() != headers.len() {
+            return Err(crate::error::SyncError::Storage(format!(
+                "backfill load_filters length mismatch for range {start}..={end}: filters={}, headers={}",
+                filter_data.len(),
+                headers.len(),
+            )));
+        }
 
         let mut out = HashMap::new();
         for (idx, (data, header)) in filter_data.iter().zip(headers.iter()).enumerate() {
@@ -469,6 +505,7 @@ mod tests {
                     wallet_id,
                     pool,
                     indexes: 5..10,
+                    height: 50,
                     advance_to: 49,
                 }],
             )

--- a/dash-spv/src/sync/filters/backfill.rs
+++ b/dash-spv/src/sync/filters/backfill.rs
@@ -22,7 +22,7 @@
 //!
 //! [`AddressSyncRange`]: key_wallet::managed_account::address_pool::AddressSyncRange
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -31,7 +31,8 @@ use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, BlockHash};
 use key_wallet::managed_account::address_pool::AddressPoolType;
 use key_wallet_manager::{
-    check_compact_filters_for_addresses, FilterMatchKey, PendingRescan, WalletId, WalletInterface,
+    check_compact_filters_for_addresses, BackfillAdvance, FilterMatchKey, PendingRescan, WalletId,
+    WalletInterface,
 };
 use tokio::sync::RwLock;
 
@@ -44,7 +45,9 @@ const BACKFILL_CHUNK_SIZE: u32 = 5000;
 
 /// Per-block obligation tracked while waiting for a backfill block to be
 /// downloaded and processed. Held in [`BackfillWorker::pending_advances`]
-/// keyed by block hash.
+/// keyed by block hash. Multiple obligations can attach to the same block
+/// when several sync ranges share an address that matched the same filter,
+/// so the value is a `Vec`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PendingAdvance {
     pub wallet_id: WalletId,
@@ -52,6 +55,17 @@ pub(crate) struct PendingAdvance {
     pub indexes: Range<u32>,
     pub height: CoreBlockHeight,
     pub advance_to: CoreBlockHeight,
+}
+
+impl PendingAdvance {
+    fn to_backfill_advance(&self) -> BackfillAdvance {
+        BackfillAdvance {
+            wallet_id: self.wallet_id,
+            pool: self.pool,
+            indexes: self.indexes.clone(),
+            advance_to: self.advance_to,
+        }
+    }
 }
 
 /// Sweep-line backfill worker over pending sync ranges.
@@ -65,7 +79,7 @@ pub(crate) struct BackfillWorker<F, H, W> {
     filter_storage: Arc<RwLock<F>>,
     header_storage: Arc<RwLock<H>>,
     wallet: Arc<RwLock<W>>,
-    pending_advances: HashMap<BlockHash, PendingAdvance>,
+    pending_advances: HashMap<BlockHash, Vec<PendingAdvance>>,
 }
 
 impl<F, H, W> BackfillWorker<F, H, W>
@@ -92,14 +106,17 @@ where
     /// For each chunk: load filters once, scan against the union of every
     /// active range's address set, and either advance `caught_up_to`
     /// directly (if no matches) or record per-block obligations and return
-    /// the matched block hashes for download.
+    /// them keyed by `FilterMatchKey` for the caller to dispatch via the
+    /// existing block-needed channel.
     ///
     /// Yields between chunks via `tokio::task::yield_now()` so forward sync
     /// continues to make progress.
-    pub(crate) async fn tick(&mut self) -> SyncResult<Vec<BlockHash>> {
+    pub(crate) async fn tick(
+        &mut self,
+    ) -> SyncResult<BTreeMap<FilterMatchKey, Vec<BackfillAdvance>>> {
         let rescans = self.wallet.read().await.pending_rescans();
         if rescans.is_empty() {
-            return Ok(Vec::new());
+            return Ok(BTreeMap::new());
         }
 
         let mut global_min = u32::MAX;
@@ -112,10 +129,10 @@ where
             global_max = global_max.max(r.ceiling);
         }
         if global_min == u32::MAX {
-            return Ok(Vec::new());
+            return Ok(BTreeMap::new());
         }
 
-        let mut new_requests: Vec<BlockHash> = Vec::new();
+        let mut new_requests: BTreeMap<FilterMatchKey, Vec<BackfillAdvance>> = BTreeMap::new();
         let mut chunk_start = global_min;
         while chunk_start <= global_max {
             let chunk_end = chunk_start
@@ -161,17 +178,16 @@ where
                         continue;
                     }
                     matched_range_keys.insert((r.wallet_id, r.pool, r.indexes.start, r.indexes.end));
-                    self.pending_advances.insert(
-                        hash,
-                        PendingAdvance {
-                            wallet_id: r.wallet_id,
-                            pool: r.pool,
-                            indexes: r.indexes.clone(),
-                            height,
-                            advance_to: chunk_end,
-                        },
-                    );
-                    new_requests.push(hash);
+                    let pending = PendingAdvance {
+                        wallet_id: r.wallet_id,
+                        pool: r.pool,
+                        indexes: r.indexes.clone(),
+                        height,
+                        advance_to: chunk_end,
+                    };
+                    let advance = pending.to_backfill_advance();
+                    self.pending_advances.entry(hash).or_default().push(pending);
+                    new_requests.entry(key.clone()).or_default().push(advance);
                 }
             }
 
@@ -204,24 +220,18 @@ where
         Ok(new_requests)
     }
 
-    /// Called by the orchestrator when a block requested via [`tick`] has
-    /// been downloaded and processed by the existing block-handling path.
+    /// Called by the orchestrator after a backfill block has been processed
+    /// via [`WalletInterface::process_backfill_block_for_wallets`], which
+    /// already advanced `caught_up_to` and emitted
+    /// `WalletEvent::RescanBlockProcessed`. Removes the block from the
+    /// pending set.
     ///
-    /// Advances `caught_up_to` for the corresponding sync range and returns
-    /// the obligation so the caller can emit
-    /// `WalletEvent::RescanBlockProcessed` with the tx records the block
-    /// produced (the worker does not see those records itself).
+    /// Returns `true` when the hash was in the worker's pending set — i.e.
+    /// the block was backfill's, not forward sync's.
     ///
-    /// Returns `None` when the hash was not in the worker's pending set —
-    /// e.g. the block was forward sync's, not ours.
-    pub(crate) async fn on_block_processed(
-        &mut self,
-        hash: &BlockHash,
-    ) -> Option<PendingAdvance> {
-        let entry = self.pending_advances.remove(hash)?;
-        let mut wallet = self.wallet.write().await;
-        wallet.advance_rescan(&entry.wallet_id, entry.pool, entry.indexes.clone(), entry.advance_to);
-        Some(entry)
+    /// [`WalletInterface::process_backfill_block_for_wallets`]: key_wallet_manager::WalletInterface::process_backfill_block_for_wallets
+    pub(crate) async fn on_block_processed(&mut self, hash: &BlockHash) -> bool {
+        self.pending_advances.remove(hash).is_some()
     }
 
     async fn load_filters(
@@ -239,6 +249,96 @@ where
             out.insert(key, BlockFilter::new(data));
         }
         Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{DiskStorageManager, StorageManager};
+    use dashcore::block::Header;
+    use dashcore::Network;
+    use dashcore::{Block, Transaction};
+    use key_wallet_manager::test_utils::{MockWalletState, MultiMockWallet};
+
+    /// Backfill matched-block dispatch path: a sync range pending below the
+    /// wallet's `synced_height` produces a matched filter at height H, the
+    /// worker returns the obligation keyed by `FilterMatchKey`, and a
+    /// follow-up call to `on_block_processed` after wallet processing
+    /// clears the pending entry.
+    #[tokio::test]
+    async fn backfill_worker_returns_matched_block_obligations() {
+        let storage = DiskStorageManager::with_temp_dir().await.unwrap();
+        let wallet_id: WalletId = [0xAA; 32];
+        let pool = AddressPoolType::External;
+        let address = Address::dummy(Network::Regtest, 7);
+
+        let multi = MultiMockWallet::new();
+        let multi = Arc::new(RwLock::new(multi));
+        {
+            let mut w = multi.write().await;
+            w.insert_wallet(
+                wallet_id,
+                MockWalletState {
+                    addresses: vec![address.clone()],
+                    synced_height: 200,
+                    last_processed_height: 200,
+                },
+            );
+            w.set_birth_height(wallet_id, 0);
+            w.push_sync_range_for_test(wallet_id, pool, 5..10, 80, vec![address.clone()]);
+        }
+
+        // Real matching block at height 50; dummy elsewhere. Headers
+        // populate offsets 0..=100 so the storage segment is fully filled.
+        let match_height: u32 = 50;
+        let tx = Transaction::dummy(&address, 0..0, &[match_height as u64]);
+        let match_block = Block::dummy(match_height, vec![tx]);
+        let match_block_hash = match_block.block_hash();
+        let match_filter = BlockFilter::dummy(&match_block);
+
+        let mut headers: Vec<Header> = Header::dummy_batch(0..101);
+        headers[match_height as usize] = match_block.header;
+        storage.block_headers().write().await.store_headers(&headers).await.unwrap();
+
+        let dummy_filter = BlockFilter::new(&[0u8; 32]);
+        let filter_store = storage.filters();
+        {
+            let mut fs = filter_store.write().await;
+            for h in 0..=100u32 {
+                let bytes = if h == match_height {
+                    match_filter.content.clone()
+                } else {
+                    dummy_filter.content.clone()
+                };
+                fs.store_filter(h, &bytes).await.unwrap();
+            }
+        }
+
+        let mut worker: BackfillWorker<_, _, MultiMockWallet> = BackfillWorker::new(
+            storage.filters(),
+            storage.block_headers(),
+            multi.clone(),
+        );
+
+        let matched = worker.tick().await.unwrap();
+
+        assert_eq!(matched.len(), 1, "expected one matched block: {:?}", matched);
+        let (key, advances) = matched.iter().next().unwrap();
+        assert_eq!(key.height(), match_height);
+        assert_eq!(key.hash(), &match_block_hash);
+        assert_eq!(advances.len(), 1);
+        let adv = &advances[0];
+        assert_eq!(adv.wallet_id, wallet_id);
+        assert_eq!(adv.pool, pool);
+        assert_eq!(adv.indexes, 5..10);
+        assert!(adv.advance_to <= 79, "advance_to must not exceed since-1=79");
+
+        assert!(worker.pending_advances.contains_key(&match_block_hash));
+        let cleared = worker.on_block_processed(&match_block_hash).await;
+        assert!(cleared);
+        assert!(!worker.pending_advances.contains_key(&match_block_hash));
+        assert!(!worker.on_block_processed(&match_block_hash).await);
     }
 }
 

--- a/dash-spv/src/sync/filters/backfill.rs
+++ b/dash-spv/src/sync/filters/backfill.rs
@@ -563,4 +563,67 @@ mod tests {
             pending,
         );
     }
+
+    /// A range whose backfill window straddles the chunk boundary must
+    /// take more than one iteration of `tick`'s inner loop. The first chunk
+    /// covers `[0..=BACKFILL_CHUNK_SIZE-1]` and advances `caught_up_to` to
+    /// `chunk_end`; the second covers `[BACKFILL_CHUNK_SIZE..=ceiling]`.
+    /// Verifies the loop's `chunk_start = chunk_end + 1` step, exercising
+    /// the cross-chunk advance the existing single-chunk tests do not.
+    #[tokio::test]
+    async fn backfill_worker_walks_multiple_chunks_for_a_long_range() {
+        let storage = DiskStorageManager::with_temp_dir().await.unwrap();
+        let wallet_id: WalletId = [0xEE; 32];
+        let pool = AddressPoolType::External;
+        let address = Address::dummy(Network::Regtest, 200);
+
+        // since=BACKFILL_CHUNK_SIZE+2 → ceiling=BACKFILL_CHUNK_SIZE+1, well
+        // past the first chunk's end at BACKFILL_CHUNK_SIZE-1.
+        let since: u32 = BACKFILL_CHUNK_SIZE + 2;
+        let ceiling: u32 = since - 1;
+
+        let multi = Arc::new(RwLock::new(MultiMockWallet::new()));
+        {
+            let mut w = multi.write().await;
+            w.insert_wallet(
+                wallet_id,
+                MockWalletState {
+                    addresses: vec![address.clone()],
+                    synced_height: since + 100,
+                    last_processed_height: since + 100,
+                },
+            );
+            w.set_birth_height(wallet_id, 0);
+            w.push_sync_range_for_test(wallet_id, pool, 5..10, since, vec![address.clone()]);
+        }
+
+        // No matching filters anywhere — every chunk hits the no-match
+        // advance path, so the range completes and drops.
+        let dummy_filter = BlockFilter::new(&[0u8; 32]);
+        let header_end = ceiling + 1;
+        let headers: Vec<Header> = Header::dummy_batch(0..header_end);
+        storage.block_headers().write().await.store_headers(&headers).await.unwrap();
+        let filter_store = storage.filters();
+        {
+            let mut fs = filter_store.write().await;
+            for h in 0..=ceiling {
+                fs.store_filter(h, &dummy_filter.content).await.unwrap();
+            }
+        }
+
+        let mut worker: BackfillWorker<_, _, MultiMockWallet> =
+            BackfillWorker::new(storage.filters(), storage.block_headers(), multi.clone());
+
+        let matched = worker.tick().await.unwrap();
+        assert!(matched.is_empty(), "no filter matches expected, got {:?}", matched);
+
+        // After two chunk iterations the no-match advance pushed
+        // `caught_up_to` to `ceiling`, completing the range.
+        let pending = multi.read().await.pending_rescans();
+        assert!(
+            pending.is_empty(),
+            "multi-chunk no-match sweep must complete and drop the range, got {:?}",
+            pending,
+        );
+    }
 }

--- a/dash-spv/src/sync/filters/backfill.rs
+++ b/dash-spv/src/sync/filters/backfill.rs
@@ -135,9 +135,8 @@ where
         let mut new_requests: BTreeMap<FilterMatchKey, Vec<BackfillAdvance>> = BTreeMap::new();
         let mut chunk_start = global_min;
         while chunk_start <= global_max {
-            let chunk_end = chunk_start
-                .saturating_add(BACKFILL_CHUNK_SIZE.saturating_sub(1))
-                .min(global_max);
+            let chunk_end =
+                chunk_start.saturating_add(BACKFILL_CHUNK_SIZE.saturating_sub(1)).min(global_max);
 
             let active: Vec<&PendingRescan> = rescans
                 .iter()
@@ -177,7 +176,12 @@ where
                     if r.resume_from > height || r.ceiling < height {
                         continue;
                     }
-                    matched_range_keys.insert((r.wallet_id, r.pool, r.indexes.start, r.indexes.end));
+                    matched_range_keys.insert((
+                        r.wallet_id,
+                        r.pool,
+                        r.indexes.start,
+                        r.indexes.end,
+                    ));
                     let pending = PendingAdvance {
                         wallet_id: r.wallet_id,
                         pool: r.pool,
@@ -315,11 +319,8 @@ mod tests {
             }
         }
 
-        let mut worker: BackfillWorker<_, _, MultiMockWallet> = BackfillWorker::new(
-            storage.filters(),
-            storage.block_headers(),
-            multi.clone(),
-        );
+        let mut worker: BackfillWorker<_, _, MultiMockWallet> =
+            BackfillWorker::new(storage.filters(), storage.block_headers(), multi.clone());
 
         let matched = worker.tick().await.unwrap();
 
@@ -405,11 +406,8 @@ mod tests {
             }
         }
 
-        let mut worker: BackfillWorker<_, _, MultiMockWallet> = BackfillWorker::new(
-            storage.filters(),
-            storage.block_headers(),
-            multi.clone(),
-        );
+        let mut worker: BackfillWorker<_, _, MultiMockWallet> =
+            BackfillWorker::new(storage.filters(), storage.block_headers(), multi.clone());
 
         let matched = worker.tick().await.unwrap();
 
@@ -510,12 +508,9 @@ mod tests {
             _ => unreachable!(),
         }
 
-        let block_processed_for_hash = events.iter().any(|e| {
-            matches!(
-                e,
-                key_wallet_manager::WalletEvent::BlockProcessed { .. },
-            )
-        });
+        let block_processed_for_hash = events
+            .iter()
+            .any(|e| matches!(e, key_wallet_manager::WalletEvent::BlockProcessed { .. },));
         assert!(
             !block_processed_for_hash,
             "backfill block must not also fire BlockProcessed: {:?}",
@@ -532,4 +527,3 @@ mod tests {
         );
     }
 }
-

--- a/dash-spv/src/sync/filters/backfill.rs
+++ b/dash-spv/src/sync/filters/backfill.rs
@@ -115,6 +115,17 @@ where
             return Ok(BTreeMap::new());
         }
 
+        // Clip to what's actually stored. During initial sync (or any time
+        // forward filter sync is still downloading) the storage may not yet
+        // hold filters past `filter_tip`; requesting them would panic in
+        // segments::get_items. The next tick re-evaluates as forward sync
+        // catches up.
+        let filter_tip = self.filter_storage.read().await.filter_tip_height().await?;
+        if global_min > filter_tip {
+            return Ok(BTreeMap::new());
+        }
+        global_max = global_max.min(filter_tip);
+
         let mut new_requests: BTreeMap<FilterMatchKey, Vec<BackfillAdvance>> = BTreeMap::new();
         // Ranges that match in any chunk are excluded from no-match advance
         // for every later chunk too: a range with an in-flight matched block
@@ -647,5 +658,64 @@ mod tests {
             "multi-chunk no-match sweep must complete and drop the range, got {:?}",
             pending,
         );
+    }
+
+    /// During initial sync the storage may hold filters only up to some
+    /// `filter_tip` while a pending sync range's `ceiling` extends beyond.
+    /// `tick` must clip its scan window to the available tip so it does not
+    /// request out-of-range offsets and panic in `segments::get_items`. The
+    /// next tick will re-evaluate as forward sync downloads more filters.
+    #[tokio::test]
+    async fn backfill_tick_skips_chunks_past_available_filter_tip() {
+        let storage = DiskStorageManager::with_temp_dir().await.unwrap();
+        let wallet_id: WalletId = [0xDD; 32];
+        let pool = AddressPoolType::External;
+        let address = Address::dummy(Network::Regtest, 300);
+
+        // Sync range expects backfill through ceiling 9_999, but only the
+        // first 100 filters are stored locally so far.
+        let since: u32 = 10_000;
+        let stored_through: u32 = 99;
+
+        let multi = Arc::new(RwLock::new(MultiMockWallet::new()));
+        {
+            let mut w = multi.write().await;
+            w.insert_wallet(
+                wallet_id,
+                MockWalletState {
+                    addresses: vec![address.clone()],
+                    synced_height: since + 100,
+                    last_processed_height: since + 100,
+                },
+            );
+            w.set_birth_height(wallet_id, 0);
+            w.push_sync_range_for_test(wallet_id, pool, 5..10, since, vec![address.clone()]);
+        }
+
+        let dummy_filter = BlockFilter::new(&[0u8; 32]);
+        let headers: Vec<Header> = Header::dummy_batch(0..(stored_through + 1));
+        storage.block_headers().write().await.store_headers(&headers).await.unwrap();
+        let filter_store = storage.filters();
+        {
+            let mut fs = filter_store.write().await;
+            for h in 0..=stored_through {
+                fs.store_filter(h, &dummy_filter.content).await.unwrap();
+            }
+        }
+
+        let mut worker: BackfillWorker<_, _, MultiMockWallet> =
+            BackfillWorker::new(storage.filters(), storage.block_headers(), multi.clone());
+
+        // The bug: this used to panic in segments::get_items when the
+        // chunk extended past stored_through.
+        let matched = worker.tick().await.unwrap();
+        assert!(matched.is_empty(), "no matches expected, got {:?}", matched);
+
+        // The clipped chunk had no filter matches, so the active range's
+        // caught_up_to advanced to filter_tip; range stays pending until
+        // forward sync downloads the rest.
+        let pending = multi.read().await.pending_rescans();
+        assert_eq!(pending.len(), 1, "range still pending past filter_tip");
+        assert_eq!(pending[0].resume_from, stored_through + 1);
     }
 }

--- a/dash-spv/src/sync/filters/backfill.rs
+++ b/dash-spv/src/sync/filters/backfill.rs
@@ -340,5 +340,196 @@ mod tests {
         assert!(!worker.pending_advances.contains_key(&match_block_hash));
         assert!(!worker.on_block_processed(&match_block_hash).await);
     }
+
+    /// Regression for the original `crazy-task` blind spot: a block at H1
+    /// pays addresses at indexes the wallet hadn't derived yet, so forward
+    /// sync at H1 only matched the in-gap-limit address. A later tx at H2
+    /// extends the gap; backfill must revisit H1 and recover the missed
+    /// outputs by scanning against the post-extension address set.
+    #[tokio::test]
+    async fn backfill_recovers_missed_outputs_after_gap_limit_extension() {
+        let storage = DiskStorageManager::with_temp_dir().await.unwrap();
+        let wallet_id: WalletId = [0xCC; 32];
+        let pool = AddressPoolType::External;
+
+        // Index 0 was inside the original gap limit; 32..41 weren't.
+        let addr_zero = Address::dummy(Network::Regtest, 100);
+        let high_addrs: Vec<Address> =
+            (32..41).map(|i| Address::dummy(Network::Regtest, 100 + i as usize)).collect();
+
+        let multi = Arc::new(RwLock::new(MultiMockWallet::new()));
+        {
+            let mut w = multi.write().await;
+            // The wallet's monitored set today still only contains index 0;
+            // the post-extension addresses live on the pending sync range.
+            w.insert_wallet(
+                wallet_id,
+                MockWalletState {
+                    addresses: vec![addr_zero.clone()],
+                    synced_height: 200,
+                    last_processed_height: 200,
+                },
+            );
+            w.set_birth_height(wallet_id, 0);
+            w.push_sync_range_for_test(wallet_id, pool, 32..41, 200, high_addrs.clone());
+        }
+
+        // Block at H1=50 pays all 10 outputs (index 0 plus 32..41), so its
+        // filter matches every address. Forward sync would have only checked
+        // index 0; backfill scans against the post-extension slice and must
+        // discover the high indexes.
+        let h1: u32 = 50;
+        let mut txs = vec![Transaction::dummy(&addr_zero, 0..0, &[1u64])];
+        for (i, addr) in high_addrs.iter().enumerate() {
+            txs.push(Transaction::dummy(addr, 1..2, &[(2 + i) as u64]));
+        }
+        let block_h1 = Block::dummy(h1, txs);
+        let block_h1_hash = block_h1.block_hash();
+        let filter_h1 = BlockFilter::dummy(&block_h1);
+
+        let mut headers: Vec<Header> = Header::dummy_batch(0..201);
+        headers[h1 as usize] = block_h1.header;
+        storage.block_headers().write().await.store_headers(&headers).await.unwrap();
+
+        let dummy_filter = BlockFilter::new(&[0u8; 32]);
+        let filter_store = storage.filters();
+        {
+            let mut fs = filter_store.write().await;
+            for h in 0..=200u32 {
+                let bytes = if h == h1 {
+                    filter_h1.content.clone()
+                } else {
+                    dummy_filter.content.clone()
+                };
+                fs.store_filter(h, &bytes).await.unwrap();
+            }
+        }
+
+        let mut worker: BackfillWorker<_, _, MultiMockWallet> = BackfillWorker::new(
+            storage.filters(),
+            storage.block_headers(),
+            multi.clone(),
+        );
+
+        let matched = worker.tick().await.unwrap();
+
+        assert_eq!(matched.len(), 1, "expected one matched block, got {:?}", matched);
+        let (key, advances) = matched.iter().next().unwrap();
+        assert_eq!(key.height(), h1);
+        assert_eq!(key.hash(), &block_h1_hash);
+        assert_eq!(advances.len(), 1, "one advance entry expected for the single range");
+        let adv = &advances[0];
+        assert_eq!(adv.wallet_id, wallet_id);
+        assert_eq!(adv.pool, pool);
+        assert_eq!(adv.indexes, 32..41);
+        assert!(
+            adv.advance_to <= 199,
+            "advance_to must not exceed since_height-1=199, got {}",
+            adv.advance_to,
+        );
+    }
+
+    /// `RescanBlockProcessed` must carry both the records (`inserted`) and
+    /// the `advance_to` field in a single event so a downstream persister
+    /// writes them atomically. The forward-sync `BlockProcessed` event must
+    /// not also fire for the same backfill block, otherwise the persister
+    /// would double-write.
+    #[tokio::test]
+    async fn rescan_block_processed_bundles_advance_in_a_single_event() {
+        use key_wallet_manager::BackfillAdvance;
+
+        let multi = Arc::new(RwLock::new(MultiMockWallet::new()));
+        let wallet_id: WalletId = [0xDD; 32];
+        let pool = AddressPoolType::External;
+        let address = Address::dummy(Network::Regtest, 51);
+        let mut event_rx = {
+            let mut w = multi.write().await;
+            w.insert_wallet(
+                wallet_id,
+                MockWalletState {
+                    addresses: vec![address.clone()],
+                    synced_height: 200,
+                    last_processed_height: 200,
+                },
+            );
+            w.set_birth_height(wallet_id, 0);
+            // Push a range whose since-1 exactly matches the advance_to
+            // below so the wallet completes and drops it. That side effect
+            // confirms the "records + advance" pair is processed together.
+            w.push_sync_range_for_test(wallet_id, pool, 5..10, 50, vec![address.clone()]);
+            w.subscribe_events()
+        };
+
+        let block = Block::dummy(50, vec![Transaction::dummy(&address, 0..0, &[7u64])]);
+
+        {
+            let mut w = multi.write().await;
+            w.process_backfill_block_for_wallets(
+                &block,
+                50,
+                &[BackfillAdvance {
+                    wallet_id,
+                    pool,
+                    indexes: 5..10,
+                    advance_to: 49,
+                }],
+            )
+            .await;
+        }
+
+        let mut events = Vec::new();
+        while let Ok(ev) = event_rx.try_recv() {
+            events.push(ev);
+        }
+
+        let rescan_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, key_wallet_manager::WalletEvent::RescanBlockProcessed { .. }))
+            .collect();
+        assert_eq!(
+            rescan_events.len(),
+            1,
+            "exactly one RescanBlockProcessed expected, got {:?}",
+            events,
+        );
+        match rescan_events[0] {
+            key_wallet_manager::WalletEvent::RescanBlockProcessed {
+                wallet_id: wid,
+                height,
+                pool: ev_pool,
+                indexes,
+                advance_to,
+                ..
+            } => {
+                assert_eq!(*wid, wallet_id);
+                assert_eq!(*height, 50);
+                assert_eq!(*ev_pool, pool);
+                assert_eq!(indexes, &(5..10));
+                assert_eq!(*advance_to, 49);
+            }
+            _ => unreachable!(),
+        }
+
+        let block_processed_for_hash = events.iter().any(|e| {
+            matches!(
+                e,
+                key_wallet_manager::WalletEvent::BlockProcessed { .. },
+            )
+        });
+        assert!(
+            !block_processed_for_hash,
+            "backfill block must not also fire BlockProcessed: {:?}",
+            events,
+        );
+
+        // Sanity: the mock's advance_rescan side effect drops the range,
+        // confirming records-and-advance are tied to the same operation.
+        let pending = multi.read().await.pending_rescans();
+        assert!(
+            pending.is_empty(),
+            "advance_to=since-1 must complete and drop the range, got {:?}",
+            pending,
+        );
+    }
 }
 

--- a/dash-spv/src/sync/filters/backfill.rs
+++ b/dash-spv/src/sync/filters/backfill.rs
@@ -1,0 +1,244 @@
+//! Backfill worker for pending sync ranges.
+//!
+//! When `maintain_gap_limit` derives new addresses on a wallet, the
+//! resulting [`AddressSyncRange`] covers an index window that joined the
+//! monitored set at `since_height`. Filters at heights below `since_height`
+//! were originally scanned without those addresses in the active set, so a
+//! tx paying one of them at an earlier height would have been silently
+//! missed by the live filter pipeline. The backfill worker re-scans
+//! `[birth_height..since_height-1]` for each pending range and advances
+//! `caught_up_to` chunk by chunk; when a range catches up the wallet drops
+//! it and `convergence_height` rises.
+//!
+//! Walks the union of all pending range height windows in one sweep so a
+//! chunk's filters are loaded from disk once even when several ranges
+//! overlap that height window. Cost scales with how far back the work
+//! extends, not with the number of historical gap extensions.
+//!
+//! Block-request dedup against forward sync is the caller's responsibility:
+//! `tick` returns the block hashes whose download should be requested, and
+//! the existing `BlockMatchTracker` (or whatever the caller uses for
+//! forward sync) will deduplicate concurrent requests.
+//!
+//! [`AddressSyncRange`]: key_wallet::managed_account::address_pool::AddressSyncRange
+
+use std::collections::{HashMap, HashSet};
+use std::ops::Range;
+use std::sync::Arc;
+
+use dashcore::bip158::BlockFilter;
+use dashcore::prelude::CoreBlockHeight;
+use dashcore::{Address, BlockHash};
+use key_wallet::managed_account::address_pool::AddressPoolType;
+use key_wallet_manager::{
+    check_compact_filters_for_addresses, FilterMatchKey, PendingRescan, WalletId, WalletInterface,
+};
+use tokio::sync::RwLock;
+
+use crate::error::SyncResult;
+use crate::storage::{BlockHeaderStorage, FilterStorage};
+
+/// Maximum filters scanned per chunk before yielding back to the runtime.
+/// Matches the forward-sync batch size so disk reads stay cache-friendly.
+const BACKFILL_CHUNK_SIZE: u32 = 5000;
+
+/// Per-block obligation tracked while waiting for a backfill block to be
+/// downloaded and processed. Held in [`BackfillWorker::pending_advances`]
+/// keyed by block hash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PendingAdvance {
+    pub wallet_id: WalletId,
+    pub pool: AddressPoolType,
+    pub indexes: Range<u32>,
+    pub height: CoreBlockHeight,
+    pub advance_to: CoreBlockHeight,
+}
+
+/// Sweep-line backfill worker over pending sync ranges.
+///
+/// Owns short-lived state (`pending_advances`) plus shared references to
+/// storage and the wallet. The caller drives `tick` (typically wired to a
+/// wake channel signalled when `pending_rescans` becomes non-empty) and
+/// `on_block_processed` (when a block we requested has been downloaded
+/// through the existing block path).
+pub(crate) struct BackfillWorker<F, H, W> {
+    filter_storage: Arc<RwLock<F>>,
+    header_storage: Arc<RwLock<H>>,
+    wallet: Arc<RwLock<W>>,
+    pending_advances: HashMap<BlockHash, PendingAdvance>,
+}
+
+impl<F, H, W> BackfillWorker<F, H, W>
+where
+    F: FilterStorage,
+    H: BlockHeaderStorage,
+    W: WalletInterface + 'static,
+{
+    pub(crate) fn new(
+        filter_storage: Arc<RwLock<F>>,
+        header_storage: Arc<RwLock<H>>,
+        wallet: Arc<RwLock<W>>,
+    ) -> Self {
+        Self {
+            filter_storage,
+            header_storage,
+            wallet,
+            pending_advances: HashMap::new(),
+        }
+    }
+
+    /// Run one sweep over the union of pending range height windows.
+    ///
+    /// For each chunk: load filters once, scan against the union of every
+    /// active range's address set, and either advance `caught_up_to`
+    /// directly (if no matches) or record per-block obligations and return
+    /// the matched block hashes for download.
+    ///
+    /// Yields between chunks via `tokio::task::yield_now()` so forward sync
+    /// continues to make progress.
+    pub(crate) async fn tick(&mut self) -> SyncResult<Vec<BlockHash>> {
+        let rescans = self.wallet.read().await.pending_rescans();
+        if rescans.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut global_min = u32::MAX;
+        let mut global_max = 0u32;
+        for r in &rescans {
+            if r.resume_from > r.ceiling {
+                continue;
+            }
+            global_min = global_min.min(r.resume_from);
+            global_max = global_max.max(r.ceiling);
+        }
+        if global_min == u32::MAX {
+            return Ok(Vec::new());
+        }
+
+        let mut new_requests: Vec<BlockHash> = Vec::new();
+        let mut chunk_start = global_min;
+        while chunk_start <= global_max {
+            let chunk_end = chunk_start
+                .saturating_add(BACKFILL_CHUNK_SIZE.saturating_sub(1))
+                .min(global_max);
+
+            let active: Vec<&PendingRescan> = rescans
+                .iter()
+                .filter(|r| r.resume_from <= chunk_end && r.ceiling >= chunk_start)
+                .collect();
+            if active.is_empty() {
+                chunk_start = chunk_end.saturating_add(1);
+                continue;
+            }
+
+            let mut union_addresses: HashSet<Address> = HashSet::new();
+            for r in &active {
+                for a in &r.addresses {
+                    union_addresses.insert(a.clone());
+                }
+            }
+            let address_vec: Vec<Address> = union_addresses.into_iter().collect();
+
+            let filters = self.load_filters(chunk_start, chunk_end).await?;
+            if filters.is_empty() {
+                chunk_start = chunk_end.saturating_add(1);
+                continue;
+            }
+
+            let matches = check_compact_filters_for_addresses(
+                &filters,
+                address_vec,
+                chunk_start.saturating_sub(1),
+            );
+
+            let mut matched_range_keys: HashSet<(WalletId, AddressPoolType, u32, u32)> =
+                HashSet::new();
+            for key in &matches {
+                let height = key.height();
+                let hash = *key.hash();
+                for r in &active {
+                    if r.resume_from > height || r.ceiling < height {
+                        continue;
+                    }
+                    matched_range_keys.insert((r.wallet_id, r.pool, r.indexes.start, r.indexes.end));
+                    self.pending_advances.insert(
+                        hash,
+                        PendingAdvance {
+                            wallet_id: r.wallet_id,
+                            pool: r.pool,
+                            indexes: r.indexes.clone(),
+                            height,
+                            advance_to: chunk_end,
+                        },
+                    );
+                    new_requests.push(hash);
+                }
+            }
+
+            // Active ranges that did NOT match anything in this chunk advance
+            // straight to `chunk_end`. Ranges that matched defer the advance
+            // until the block actually arrives so persistence stays atomic.
+            let no_match: Vec<(WalletId, AddressPoolType, Range<u32>)> = active
+                .iter()
+                .filter(|r| {
+                    !matched_range_keys.contains(&(
+                        r.wallet_id,
+                        r.pool,
+                        r.indexes.start,
+                        r.indexes.end,
+                    ))
+                })
+                .map(|r| (r.wallet_id, r.pool, r.indexes.clone()))
+                .collect();
+            if !no_match.is_empty() {
+                let mut wallet = self.wallet.write().await;
+                for (wallet_id, pool, indexes) in no_match {
+                    wallet.advance_rescan(&wallet_id, pool, indexes, chunk_end);
+                }
+            }
+
+            tokio::task::yield_now().await;
+            chunk_start = chunk_end.saturating_add(1);
+        }
+
+        Ok(new_requests)
+    }
+
+    /// Called by the orchestrator when a block requested via [`tick`] has
+    /// been downloaded and processed by the existing block-handling path.
+    ///
+    /// Advances `caught_up_to` for the corresponding sync range and returns
+    /// the obligation so the caller can emit
+    /// `WalletEvent::RescanBlockProcessed` with the tx records the block
+    /// produced (the worker does not see those records itself).
+    ///
+    /// Returns `None` when the hash was not in the worker's pending set —
+    /// e.g. the block was forward sync's, not ours.
+    pub(crate) async fn on_block_processed(
+        &mut self,
+        hash: &BlockHash,
+    ) -> Option<PendingAdvance> {
+        let entry = self.pending_advances.remove(hash)?;
+        let mut wallet = self.wallet.write().await;
+        wallet.advance_rescan(&entry.wallet_id, entry.pool, entry.indexes.clone(), entry.advance_to);
+        Some(entry)
+    }
+
+    async fn load_filters(
+        &self,
+        start: u32,
+        end: u32,
+    ) -> SyncResult<HashMap<FilterMatchKey, BlockFilter>> {
+        let filter_data = self.filter_storage.read().await.load_filters(start..end + 1).await?;
+        let headers = self.header_storage.read().await.load_headers(start..end + 1).await?;
+
+        let mut out = HashMap::new();
+        for (idx, (data, header)) in filter_data.iter().zip(headers.iter()).enumerate() {
+            let height = start + idx as u32;
+            let key = FilterMatchKey::new(height, header.block_hash());
+            out.insert(key, BlockFilter::new(data));
+        }
+        Ok(out)
+    }
+}
+

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use dashcore::bip158::BlockFilter;
 use dashcore::Address;
 
-use super::backfill::{BackfillWorker, PendingAdvance};
+use super::backfill::BackfillWorker;
 use super::batch::FiltersBatch;
 use super::block_match_tracker::{BlockMatchTracker, BlockTrackResult};
 use super::pipeline::FiltersPipeline;
@@ -133,20 +133,27 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
 
     /// Drive one sweep of the backfill worker over pending sync ranges.
     ///
-    /// Returns block hashes whose download should be requested via the
-    /// existing block-needed channel. The orchestrator wakes this when
-    /// `pending_rescans` becomes non-empty.
-    pub(super) async fn backfill_tick(&mut self) -> SyncResult<Vec<dashcore::BlockHash>> {
+    /// Returns matched blocks keyed by their `FilterMatchKey`, each with
+    /// the per-sync-range advance obligations the block-processing path
+    /// must satisfy when the block arrives. The orchestrator wraps the
+    /// result in a `SyncEvent::BackfillBlocksNeeded`.
+    pub(super) async fn backfill_tick(
+        &mut self,
+    ) -> SyncResult<
+        std::collections::BTreeMap<FilterMatchKey, Vec<key_wallet_manager::BackfillAdvance>>,
+    > {
         self.backfill.tick().await
     }
 
     /// Notify the backfill worker that a block it requested has been
-    /// processed. Returns the obligation so the caller can co-emit
-    /// `WalletEvent::RescanBlockProcessed` with this block's tx records.
+    /// processed (the wallet's `process_backfill_block_for_wallets` path
+    /// already advanced `caught_up_to` and emitted
+    /// `RescanBlockProcessed`). Removes the block from the worker's
+    /// pending set. Returns `true` when the hash was a backfill block.
     pub(super) async fn backfill_block_processed(
         &mut self,
         hash: &dashcore::BlockHash,
-    ) -> Option<PendingAdvance> {
+    ) -> bool {
         self.backfill.on_block_processed(hash).await
     }
 

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -151,6 +151,15 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         self.backfill.on_block_processed(hash).await
     }
 
+    /// Snapshot the set of block hashes the backfill worker still treats
+    /// as in-flight. The orchestrator passes this to the BlocksManager
+    /// so its mirror `backfill_advances` map can drop stale entries.
+    pub(super) fn backfill_live_block_hashes(
+        &self,
+    ) -> std::collections::HashSet<dashcore::BlockHash> {
+        self.backfill.live_block_hashes()
+    }
+
     /// Returns true if there is no in-flight processing state.
     fn is_idle(&self) -> bool {
         self.active_batches.is_empty()

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use dashcore::bip158::BlockFilter;
 use dashcore::Address;
 
+use super::backfill::{BackfillWorker, PendingAdvance};
 use super::batch::FiltersBatch;
 use super::block_match_tracker::{BlockMatchTracker, BlockTrackResult};
 use super::pipeline::FiltersPipeline;
@@ -71,6 +72,11 @@ pub struct FiltersManager<
     /// `BlockProcessed` and the per-wallet record of which wallets already
     /// have a given processed block applied.
     pub(super) tracker: BlockMatchTracker,
+    /// Sweep-line backfill worker covering pending sync ranges that pre-date
+    /// the current batch. Held as a field so the live pipeline can wire its
+    /// tick to a wake channel in a follow-up — for now the seam is exposed
+    /// via [`Self::backfill_tick`] and [`Self::backfill_block_processed`].
+    pub(super) backfill: BackfillWorker<F, H, W>,
 }
 
 impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: WalletInterface>
@@ -102,6 +108,12 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         initial_progress.update_target_height(target_height);
         initial_progress.update_filter_header_tip_height(filter_header_tip);
 
+        let backfill = BackfillWorker::new(
+            filter_storage.clone(),
+            header_storage.clone(),
+            wallet.clone(),
+        );
+
         Self {
             progress: initial_progress,
             header_storage,
@@ -115,7 +127,27 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             active_batches: BTreeMap::new(),
             processing_height: 0,
             tracker: BlockMatchTracker::new(),
+            backfill,
         }
+    }
+
+    /// Drive one sweep of the backfill worker over pending sync ranges.
+    ///
+    /// Returns block hashes whose download should be requested via the
+    /// existing block-needed channel. The orchestrator wakes this when
+    /// `pending_rescans` becomes non-empty.
+    pub(super) async fn backfill_tick(&mut self) -> SyncResult<Vec<dashcore::BlockHash>> {
+        self.backfill.tick().await
+    }
+
+    /// Notify the backfill worker that a block it requested has been
+    /// processed. Returns the obligation so the caller can co-emit
+    /// `WalletEvent::RescanBlockProcessed` with this block's tx records.
+    pub(super) async fn backfill_block_processed(
+        &mut self,
+        hash: &dashcore::BlockHash,
+    ) -> Option<PendingAdvance> {
+        self.backfill.on_block_processed(hash).await
     }
 
     /// Returns true if there is no in-flight processing state.

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -108,11 +108,8 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         initial_progress.update_target_height(target_height);
         initial_progress.update_filter_header_tip_height(filter_header_tip);
 
-        let backfill = BackfillWorker::new(
-            filter_storage.clone(),
-            header_storage.clone(),
-            wallet.clone(),
-        );
+        let backfill =
+            BackfillWorker::new(filter_storage.clone(), header_storage.clone(), wallet.clone());
 
         Self {
             progress: initial_progress,
@@ -150,10 +147,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
     /// already advanced `caught_up_to` and emitted
     /// `RescanBlockProcessed`). Removes the block from the worker's
     /// pending set. Returns `true` when the hash was a backfill block.
-    pub(super) async fn backfill_block_processed(
-        &mut self,
-        hash: &dashcore::BlockHash,
-    ) -> bool {
+    pub(super) async fn backfill_block_processed(&mut self, hash: &dashcore::BlockHash) -> bool {
         self.backfill.on_block_processed(hash).await
     }
 

--- a/dash-spv/src/sync/filters/mod.rs
+++ b/dash-spv/src/sync/filters/mod.rs
@@ -1,3 +1,4 @@
+mod backfill;
 mod batch;
 mod batch_tracker;
 mod block_match_tracker;

--- a/dash-spv/src/sync/filters/sync_manager.rs
+++ b/dash-spv/src/sync/filters/sync_manager.rs
@@ -261,9 +261,16 @@ impl<
         // emit `RescanBlockProcessed` atomically with the
         // `caught_up_to` advance.
         let backfill_blocks = self.backfill_tick().await?;
-        if !backfill_blocks.is_empty() {
+        // Always emit if either there are new blocks to dispatch or if the
+        // worker's in-flight set has shrunk since the last tick (the
+        // BlocksManager prunes its mirror against `live_hashes`). Sending
+        // when both are empty would be a no-op, but `live_hashes` is also
+        // empty in that case so we skip to avoid event-channel chatter.
+        let live_hashes = self.backfill_live_block_hashes();
+        if !backfill_blocks.is_empty() || !live_hashes.is_empty() {
             events.push(SyncEvent::BackfillBlocksNeeded {
                 blocks: backfill_blocks,
+                live_hashes,
             });
         }
 

--- a/dash-spv/src/sync/filters/sync_manager.rs
+++ b/dash-spv/src/sync/filters/sync_manager.rs
@@ -164,6 +164,13 @@ impl<
                 // `tracker.track` residual.
                 self.tracker.record_processed(*height, *block_hash, wallets);
 
+                // If the backfill worker requested this block, advance the
+                // owning sync range. The atomic `RescanBlockProcessed` event
+                // emission is bundled in the integration follow-up that
+                // finalizes the persister contract; advancing here keeps
+                // `caught_up_to` honest in the meantime.
+                let _ = self.backfill_block_processed(block_hash).await;
+
                 // Check if this block is part of our tracked blocks
                 if let Some((_, batch_start)) = self.tracker.finish_in_flight(block_hash) {
                     if let Some(batch) = self.active_batches.get_mut(&batch_start) {
@@ -247,6 +254,14 @@ impl<
 
         // Try to process blocks in current batch
         events.extend(self.try_process_batch().await?);
+
+        // Drive one sweep of the backfill worker over pending sync ranges.
+        // Block-request routing for backfill matches lands in the
+        // integration commit that finalizes the `RescanBlockProcessed`
+        // atomicity contract; until then `tick` still advances ranges that
+        // have no historical matches in their window and parks any matched
+        // blocks for the follow-up dispatcher.
+        let _ = self.backfill_tick().await?;
 
         Ok(events)
     }

--- a/dash-spv/src/sync/filters/sync_manager.rs
+++ b/dash-spv/src/sync/filters/sync_manager.rs
@@ -164,11 +164,10 @@ impl<
                 // `tracker.track` residual.
                 self.tracker.record_processed(*height, *block_hash, wallets);
 
-                // If the backfill worker requested this block, advance the
-                // owning sync range. The atomic `RescanBlockProcessed` event
-                // emission is bundled in the integration follow-up that
-                // finalizes the persister contract; advancing here keeps
-                // `caught_up_to` honest in the meantime.
+                // If the backfill worker had this block in flight, the
+                // wallet's `process_backfill_block_for_wallets` path already
+                // advanced `caught_up_to` and emitted `RescanBlockProcessed`,
+                // so just clear the worker's pending entry.
                 let _ = self.backfill_block_processed(block_hash).await;
 
                 // Check if this block is part of our tracked blocks
@@ -256,12 +255,17 @@ impl<
         events.extend(self.try_process_batch().await?);
 
         // Drive one sweep of the backfill worker over pending sync ranges.
-        // Block-request routing for backfill matches lands in the
-        // integration commit that finalizes the `RescanBlockProcessed`
-        // atomicity contract; until then `tick` still advances ranges that
-        // have no historical matches in their window and parks any matched
-        // blocks for the follow-up dispatcher.
-        let _ = self.backfill_tick().await?;
+        // Matched blocks are dispatched to `BlocksManager` via
+        // `BackfillBlocksNeeded`; the manager consults the per-block
+        // advance map to call `process_backfill_block_for_wallets` and
+        // emit `RescanBlockProcessed` atomically with the
+        // `caught_up_to` advance.
+        let backfill_blocks = self.backfill_tick().await?;
+        if !backfill_blocks.is_empty() {
+            events.push(SyncEvent::BackfillBlocksNeeded {
+                blocks: backfill_blocks,
+            });
+        }
 
         Ok(events)
     }

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -1055,9 +1055,7 @@ fn push_external_sync_range(
     indexes: core::ops::Range<u32>,
     since_height: CoreBlockHeight,
 ) {
-    let info = manager
-        .get_wallet_info_mut(wallet_id)
-        .expect("wallet exists");
+    let info = manager.get_wallet_info_mut(wallet_id).expect("wallet exists");
     for mut account in info.accounts_mut().all_accounts_mut() {
         for pool in account.managed_account_type_mut().address_pools_mut() {
             if pool.pool_type == AddressPoolType::External {
@@ -1082,10 +1080,8 @@ async fn test_advance_rescan_emits_convergence_changed_and_is_idempotent() {
 
     manager.advance_rescan(&wallet_id, AddressPoolType::External, 30..40, 99);
     let events = drain_events(&mut rx);
-    let conv: Vec<&WalletEvent> = events
-        .iter()
-        .filter(|e| matches!(e, WalletEvent::ConvergenceChanged { .. }))
-        .collect();
+    let conv: Vec<&WalletEvent> =
+        events.iter().filter(|e| matches!(e, WalletEvent::ConvergenceChanged { .. })).collect();
     assert_eq!(conv.len(), 1, "exactly one ConvergenceChanged expected, got {:?}", events);
     match conv[0] {
         WalletEvent::ConvergenceChanged {
@@ -1100,10 +1096,8 @@ async fn test_advance_rescan_emits_convergence_changed_and_is_idempotent() {
 
     manager.advance_rescan(&wallet_id, AddressPoolType::External, 30..40, 99);
     let events = drain_events(&mut rx);
-    let conv_count = events
-        .iter()
-        .filter(|e| matches!(e, WalletEvent::ConvergenceChanged { .. }))
-        .count();
+    let conv_count =
+        events.iter().filter(|e| matches!(e, WalletEvent::ConvergenceChanged { .. })).count();
     assert_eq!(
         conv_count, 0,
         "second advance_rescan must not re-emit ConvergenceChanged, got {:?}",

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -14,7 +14,7 @@ use dashcore::{
     BlockHash, CompactTarget, OutPoint, ScriptBuf, TxIn, TxMerkleNode, TxOut, Txid, Witness,
 };
 use key_wallet::account::StandardAccountType;
-use key_wallet::managed_account::address_pool::AddressPoolType;
+use key_wallet::managed_account::address_pool::{AddressPoolType, AddressSyncRange};
 use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
 use key_wallet::managed_account::managed_account_type::ManagedAccountType;
 use key_wallet::AccountType;
@@ -1041,4 +1041,72 @@ async fn test_instant_send_lock_event_does_not_carry_addresses_derived_field() {
         }
         _ => unreachable!(),
     }
+}
+
+// ---------------------------------------------------------------------------
+// ConvergenceChanged
+// ---------------------------------------------------------------------------
+
+/// Push a pending sync range into the wallet's BIP44 External pool so the
+/// rest of the test can drive `advance_rescan` against a known target.
+fn push_external_sync_range(
+    manager: &mut WalletManager<ManagedWalletInfo>,
+    wallet_id: &WalletId,
+    indexes: core::ops::Range<u32>,
+    since_height: CoreBlockHeight,
+) {
+    let info = manager
+        .get_wallet_info_mut(wallet_id)
+        .expect("wallet exists");
+    for mut account in info.accounts_mut().all_accounts_mut() {
+        for pool in account.managed_account_type_mut().address_pools_mut() {
+            if pool.pool_type == AddressPoolType::External {
+                pool.push_sync_range(AddressSyncRange {
+                    indexes: indexes.clone(),
+                    since_height,
+                    caught_up_to: None,
+                });
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_advance_rescan_emits_convergence_changed_and_is_idempotent() {
+    let (mut manager, wallet_id, _) = setup_manager_with_wallet();
+    manager.update_wallet_synced_height(&wallet_id, 200);
+
+    push_external_sync_range(&mut manager, &wallet_id, 30..40, 100);
+
+    let mut rx = manager.subscribe_events();
+
+    manager.advance_rescan(&wallet_id, AddressPoolType::External, 30..40, 99);
+    let events = drain_events(&mut rx);
+    let conv: Vec<&WalletEvent> = events
+        .iter()
+        .filter(|e| matches!(e, WalletEvent::ConvergenceChanged { .. }))
+        .collect();
+    assert_eq!(conv.len(), 1, "exactly one ConvergenceChanged expected, got {:?}", events);
+    match conv[0] {
+        WalletEvent::ConvergenceChanged {
+            wallet_id: wid,
+            fully_converged_through,
+        } => {
+            assert_eq!(*wid, wallet_id);
+            assert_eq!(*fully_converged_through, Some(200));
+        }
+        _ => unreachable!(),
+    }
+
+    manager.advance_rescan(&wallet_id, AddressPoolType::External, 30..40, 99);
+    let events = drain_events(&mut rx);
+    let conv_count = events
+        .iter()
+        .filter(|e| matches!(e, WalletEvent::ConvergenceChanged { .. }))
+        .count();
+    assert_eq!(
+        conv_count, 0,
+        "second advance_rescan must not re-emit ConvergenceChanged, got {:?}",
+        events,
+    );
 }

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -1110,3 +1110,63 @@ async fn test_advance_rescan_emits_convergence_changed_and_is_idempotent() {
         events,
     );
 }
+
+/// Two pending sync ranges with different `since_height` values: completing
+/// the lower-since one first must report a convergence value capped by the
+/// remaining range, then completing the higher-since one must report the
+/// full `synced_height`. Each completion fires exactly one
+/// `ConvergenceChanged` and the values rise monotonically.
+#[tokio::test]
+async fn test_convergence_changed_rises_step_by_step_across_multi_range_completion() {
+    let (mut manager, wallet_id, _) = setup_manager_with_wallet();
+    manager.update_wallet_synced_height(&wallet_id, 500);
+
+    push_external_sync_range(&mut manager, &wallet_id, 30..40, 100);
+    push_external_sync_range(&mut manager, &wallet_id, 60..70, 200);
+
+    // Convergence is bounded by the worst-progressed range, both at floor=0.
+    assert_eq!(manager.wallet_convergence_height(&wallet_id), Some(0));
+
+    let mut rx = manager.subscribe_events();
+
+    // Complete the since=100 range. Convergence rises but is still bounded
+    // by the since=200 range whose caught_up_to is None (floor-1 saturates
+    // to 0), so the new value is 0 — same as before. No event expected.
+    manager.advance_rescan(&wallet_id, AddressPoolType::External, 30..40, 99);
+    let events_after_first = drain_events(&mut rx);
+    let conv_after_first: Vec<&WalletEvent> = events_after_first
+        .iter()
+        .filter(|e| matches!(e, WalletEvent::ConvergenceChanged { .. }))
+        .collect();
+    assert_eq!(
+        conv_after_first.len(),
+        0,
+        "first completion does not raise convergence (still bounded by other range): {:?}",
+        events_after_first,
+    );
+
+    // Advance the since=200 range to completion. Now no ranges remain so
+    // convergence equals synced_height=500 — a real value transition.
+    manager.advance_rescan(&wallet_id, AddressPoolType::External, 60..70, 199);
+    let events_after_second = drain_events(&mut rx);
+    let conv_after_second: Vec<&WalletEvent> = events_after_second
+        .iter()
+        .filter(|e| matches!(e, WalletEvent::ConvergenceChanged { .. }))
+        .collect();
+    assert_eq!(
+        conv_after_second.len(),
+        1,
+        "exactly one ConvergenceChanged for the second completion, got {:?}",
+        events_after_second,
+    );
+    match conv_after_second[0] {
+        WalletEvent::ConvergenceChanged {
+            wallet_id: wid,
+            fully_converged_through,
+        } => {
+            assert_eq!(*wid, wallet_id);
+            assert_eq!(*fully_converged_through, Some(500));
+        }
+        _ => unreachable!(),
+    }
+}

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -284,12 +284,12 @@ pub enum WalletEvent {
     ///
     /// Convergence is the strict watermark: every currently-monitored
     /// address has been scanned through this height. Unlike
-    /// [`SyncHeightAdvanced`], this value is **non-monotonic** — it drops
-    /// when a new sync range is created (e.g. via gap-limit extension)
-    /// and rises as the backfill worker catches up. May be `None` for a
-    /// fresh wallet that has not yet completed any scan.
+    /// [`Self::SyncHeightAdvanced`], this value is **non-monotonic** — it
+    /// drops when a new sync range is created (e.g. via gap-limit
+    /// extension) and rises as the backfill worker catches up. May be
+    /// `None` for a fresh wallet that has not yet completed any scan.
     ///
-    /// [`convergence_height`]: key_wallet::wallet::managed_wallet_info::WalletInfoInterface::convergence_height
+    /// [`convergence_height`]: key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface::convergence_height
     ConvergenceChanged {
         /// ID of the affected wallet.
         wallet_id: WalletId,
@@ -301,7 +301,7 @@ pub enum WalletEvent {
     ///
     /// Emitted at most once per scanned filter chunk. Consumers that only
     /// care about the final state should listen for
-    /// [`ConvergenceChanged`] instead.
+    /// [`Self::ConvergenceChanged`] instead.
     RescanProgressed {
         /// ID of the affected wallet.
         wallet_id: WalletId,
@@ -318,7 +318,7 @@ pub enum WalletEvent {
     /// at this height with the `caught_up_to` advance for the relevant
     /// sync range so a downstream persister writes both atomically.
     ///
-    /// Distinct from [`BlockProcessed`] (which fires from forward sync) so
+    /// Distinct from [`Self::BlockProcessed`] (which fires from forward sync) so
     /// the persister can route differently. `height` may be far below the
     /// wallet's `synced_height` because backfill walks history below each
     /// range's `since_height`.

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -227,6 +227,12 @@ pub enum WalletEvent {
     /// previously-known records that just confirmed, `matured` is older
     /// coinbase records that crossed the maturity threshold as the scanned
     /// height advanced.
+    ///
+    /// `height` is **not monotonic** in this stream: within-batch rescans
+    /// (and the backfill worker introduced for sync-range coverage) can
+    /// process older blocks after newer ones. Consumers indexing by
+    /// height should accept that earlier heights may appear after later
+    /// ones and dedup on `(wallet_id, txid)` rather than on height.
     BlockProcessed {
         /// ID of the affected wallet.
         wallet_id: WalletId,
@@ -255,14 +261,58 @@ pub enum WalletEvent {
         addresses_derived: Vec<DerivedAddress>,
     },
     /// The wallet's scan cursor advanced because the filter pipeline
-    /// committed a batch covering blocks up to `height`. No records or
-    /// balance — consumers persist this as a checkpoint atomically with
-    /// any records/balance from prior `BlockProcessed` events in the batch.
+    /// committed a batch covering blocks up to `height`.
+    ///
+    /// This is the **monotonic forward edge** — `height` only ever
+    /// increases. It does **not** mean "everything below `height` is
+    /// final": a later gap-limit extension can surface a sync range
+    /// covering earlier heights that have not yet been scanned with the
+    /// newly derived addresses. Consumers needing a strict "everything
+    /// below here is final" watermark should listen for
+    /// [`WalletEvent::ConvergenceChanged`] instead.
+    ///
+    /// No records or balance — consumers persist this as a checkpoint
+    /// atomically with any records/balance from prior `BlockProcessed`
+    /// events in the batch.
     SyncHeightAdvanced {
         /// ID of the affected wallet.
         wallet_id: WalletId,
         /// New scanned height for the wallet.
         height: CoreBlockHeight,
+    },
+    /// A wallet's [`convergence_height`] changed.
+    ///
+    /// Convergence is the strict watermark: every currently-monitored
+    /// address has been scanned through this height. Unlike
+    /// [`SyncHeightAdvanced`], this value is **non-monotonic** — it drops
+    /// when a new sync range is created (e.g. via gap-limit extension)
+    /// and rises as the backfill worker catches up. May be `None` for a
+    /// fresh wallet that has not yet completed any scan.
+    ///
+    /// [`convergence_height`]: key_wallet::wallet::managed_wallet_info::WalletInfoInterface::convergence_height
+    ConvergenceChanged {
+        /// ID of the affected wallet.
+        wallet_id: WalletId,
+        /// New convergence height, or `None` if no progress has been
+        /// recorded yet for any of the wallet's pending sync ranges.
+        fully_converged_through: Option<CoreBlockHeight>,
+    },
+    /// Advisory progress for a backfill scan over one sync range.
+    ///
+    /// Emitted at most once per scanned filter chunk. Consumers that only
+    /// care about the final state should listen for
+    /// [`ConvergenceChanged`] instead.
+    RescanProgressed {
+        /// ID of the affected wallet.
+        wallet_id: WalletId,
+        /// Pool the sync range belongs to.
+        pool: AddressPoolType,
+        /// Index window of the sync range.
+        indexes: core::ops::Range<u32>,
+        /// New `caught_up_to` for the range after this chunk.
+        caught_up_to: CoreBlockHeight,
+        /// Inclusive completion target (`since_height - 1`).
+        target: CoreBlockHeight,
     },
 }
 
@@ -283,6 +333,14 @@ impl WalletEvent {
                 ..
             }
             | WalletEvent::SyncHeightAdvanced {
+                wallet_id,
+                ..
+            }
+            | WalletEvent::ConvergenceChanged {
+                wallet_id,
+                ..
+            }
+            | WalletEvent::RescanProgressed {
                 wallet_id,
                 ..
             } => *wallet_id,
@@ -347,6 +405,25 @@ impl WalletEvent {
                 ..
             } => {
                 format!("SyncHeightAdvanced(height={})", height)
+            }
+            WalletEvent::ConvergenceChanged {
+                fully_converged_through,
+                ..
+            } => match fully_converged_through {
+                Some(h) => format!("ConvergenceChanged(through={})", h),
+                None => "ConvergenceChanged(through=none)".to_string(),
+            },
+            WalletEvent::RescanProgressed {
+                pool,
+                indexes,
+                caught_up_to,
+                target,
+                ..
+            } => {
+                format!(
+                    "RescanProgressed(pool={:?}, indexes={}..{}, caught_up_to={}, target={})",
+                    pool, indexes.start, indexes.end, caught_up_to, target,
+                )
             }
         }
     }

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -314,6 +314,40 @@ pub enum WalletEvent {
         /// Inclusive completion target (`since_height - 1`).
         target: CoreBlockHeight,
     },
+    /// Backfill block processing — bundles transaction records discovered
+    /// at this height with the `caught_up_to` advance for the relevant
+    /// sync range so a downstream persister writes both atomically.
+    ///
+    /// Distinct from [`BlockProcessed`] (which fires from forward sync) so
+    /// the persister can route differently. `height` may be far below the
+    /// wallet's `synced_height` because backfill walks history below each
+    /// range's `since_height`.
+    RescanBlockProcessed {
+        /// ID of the affected wallet.
+        wallet_id: WalletId,
+        /// Height of the matched block that was downloaded and processed.
+        height: CoreBlockHeight,
+        /// Pool the advancing sync range belongs to.
+        pool: AddressPoolType,
+        /// Index window of the advancing sync range.
+        indexes: core::ops::Range<u32>,
+        /// New `caught_up_to` for the range after the chunk that produced
+        /// this block was scanned end-to-end.
+        advance_to: CoreBlockHeight,
+        /// Records first stored for this wallet by this backfill pass.
+        inserted: Vec<TransactionRecord>,
+        /// Previously-known records updated by this block's data.
+        updated: Vec<TransactionRecord>,
+        /// Older coinbase records whose maturity threshold was crossed.
+        matured: Vec<TransactionRecord>,
+        /// Wallet balance after the block was processed.
+        balance: WalletCoreBalance,
+        /// Per-account balance snapshot for accounts whose balance changed.
+        account_balances: BTreeMap<AccountType, WalletCoreBalance>,
+        /// Addresses derived as a side effect of gap-limit maintenance
+        /// during this block's processing.
+        addresses_derived: Vec<DerivedAddress>,
+    },
 }
 
 impl WalletEvent {
@@ -341,6 +375,10 @@ impl WalletEvent {
                 ..
             }
             | WalletEvent::RescanProgressed {
+                wallet_id,
+                ..
+            }
+            | WalletEvent::RescanBlockProcessed {
                 wallet_id,
                 ..
             } => *wallet_id,
@@ -423,6 +461,34 @@ impl WalletEvent {
                 format!(
                     "RescanProgressed(pool={:?}, indexes={}..{}, caught_up_to={}, target={})",
                     pool, indexes.start, indexes.end, caught_up_to, target,
+                )
+            }
+            WalletEvent::RescanBlockProcessed {
+                height,
+                pool,
+                indexes,
+                advance_to,
+                inserted,
+                updated,
+                matured,
+                balance,
+                account_balances,
+                addresses_derived,
+                ..
+            } => {
+                format!(
+                    "RescanBlockProcessed(height={}, pool={:?}, indexes={}..{}, advance_to={}, inserted={}, updated={}, matured={}, balance={}, account_balances={}, derived={})",
+                    height,
+                    pool,
+                    indexes.start,
+                    indexes.end,
+                    advance_to,
+                    inserted.len(),
+                    updated.len(),
+                    matured.len(),
+                    balance,
+                    format_account_balances(account_balances),
+                    addresses_derived.len(),
                 )
             }
         }

--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -24,7 +24,9 @@ pub use error::WalletError;
 pub use events::{DerivedAddress, WalletEvent};
 pub use matching::{check_compact_filters_for_addresses, FilterMatchKey};
 pub use rescan::PendingRescan;
-pub use wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
+pub use wallet_interface::{
+    BackfillAdvance, BlockProcessingResult, MempoolTransactionResult, WalletInterface,
+};
 
 use dashcore::blockdata::transaction::Transaction;
 use dashcore::prelude::CoreBlockHeight;

--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -17,11 +17,13 @@ mod error;
 mod events;
 mod matching;
 mod process_block;
+mod rescan;
 mod wallet_interface;
 
 pub use error::WalletError;
 pub use events::{DerivedAddress, WalletEvent};
 pub use matching::{check_compact_filters_for_addresses, FilterMatchKey};
+pub use rescan::PendingRescan;
 pub use wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
 
 use dashcore::blockdata::transaction::Transaction;

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -358,6 +358,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             return;
         };
         let prev_conv = info.convergence_height();
+        let mut progress: Option<(CoreBlockHeight, CoreBlockHeight)> = None;
         for mut account in info.accounts_mut().all_accounts_mut() {
             for p in account.managed_account_type_mut().address_pools_mut() {
                 if p.pool_type != pool {
@@ -369,11 +370,21 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
                         let new = scanned_through.min(cap);
                         if range.caught_up_to.map(|c| new > c).unwrap_or(true) {
                             range.caught_up_to = Some(new);
+                            progress = Some((new, cap));
                         }
                     }
                 }
                 p.pending_sync_ranges_mut().retain(|r| !r.is_complete());
             }
+        }
+        if let Some((caught_up_to, target)) = progress {
+            let _ = self.event_sender.send(WalletEvent::RescanProgressed {
+                wallet_id: *wallet_id,
+                pool,
+                indexes: indexes.clone(),
+                caught_up_to,
+                target,
+            });
         }
         let new_conv = info.convergence_height();
         if new_conv != prev_conv {

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -1,5 +1,7 @@
 use crate::events::{diff_account_balances, project_derived_addresses, DerivedAddress};
-use crate::wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
+use crate::wallet_interface::{
+    BackfillAdvance, BlockProcessingResult, MempoolTransactionResult, WalletInterface,
+};
 use crate::{PendingRescan, WalletEvent, WalletId, WalletManager};
 use async_trait::async_trait;
 use core::fmt::Write as _;
@@ -63,6 +65,60 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         self.finalize_block_advance(
             height,
             wallets,
+            per_wallet_inserted,
+            per_wallet_updated,
+            per_wallet_derived,
+        );
+
+        result
+    }
+
+    async fn process_backfill_block_for_wallets(
+        &mut self,
+        block: &Block,
+        height: CoreBlockHeight,
+        advances: &[BackfillAdvance],
+    ) -> BlockProcessingResult {
+        let mut result = BlockProcessingResult::default();
+        if advances.is_empty() {
+            return result;
+        }
+        let wallets: BTreeSet<WalletId> = advances.iter().map(|a| a.wallet_id).collect();
+        let info = BlockInfo::new(height, block.block_hash(), block.header.time);
+
+        let mut per_wallet_inserted: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
+        let mut per_wallet_updated: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
+        let mut per_wallet_derived: BTreeMap<WalletId, Vec<DerivedAddressInfo>> = BTreeMap::new();
+
+        for tx in &block.txdata {
+            let context = TransactionContext::InBlock(info);
+            let check_result =
+                self.check_transaction_in_wallets(tx, context, &wallets, true, false).await;
+
+            if !check_result.affected_wallets.is_empty() {
+                if check_result.is_new_transaction {
+                    result.new_txids.push(tx.txid());
+                } else {
+                    result.existing_txids.push(tx.txid());
+                }
+            }
+
+            for (wallet_id, derived) in check_result.new_addresses {
+                let addresses = derived.iter().map(|d| d.info.address.clone()).collect::<Vec<_>>();
+                result.new_addresses.entry(wallet_id).or_default().extend(addresses);
+                per_wallet_derived.entry(wallet_id).or_default().extend(derived);
+            }
+            for (wallet_id, records) in check_result.per_wallet_new_records {
+                per_wallet_inserted.entry(wallet_id).or_default().extend(records);
+            }
+            for (wallet_id, records) in check_result.per_wallet_updated_records {
+                per_wallet_updated.entry(wallet_id).or_default().extend(records);
+            }
+        }
+
+        self.finalize_backfill_block_advance(
+            height,
+            advances,
             per_wallet_inserted,
             per_wallet_updated,
             per_wallet_derived,
@@ -557,6 +613,139 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
                     fully_converged_through: new_conv,
                 });
             }
+        }
+    }
+
+    /// Backfill counterpart of [`Self::finalize_block_advance`]. Applies the
+    /// same balance-snapshot / address-derivation projection but emits
+    /// [`WalletEvent::RescanBlockProcessed`] (one per advance entry) so a
+    /// downstream persister writes the records and the `caught_up_to`
+    /// advance atomically. Calls `advance_rescan` after emission so the
+    /// `ConvergenceChanged` event order stays "records first, then watermark".
+    fn finalize_backfill_block_advance(
+        &mut self,
+        height: CoreBlockHeight,
+        advances: &[BackfillAdvance],
+        mut per_wallet_inserted: BTreeMap<WalletId, Vec<TransactionRecord>>,
+        mut per_wallet_updated: BTreeMap<WalletId, Vec<TransactionRecord>>,
+        mut per_wallet_derived: BTreeMap<WalletId, Vec<DerivedAddressInfo>>,
+    ) {
+        if advances.is_empty() {
+            return;
+        }
+        let wallets: BTreeSet<WalletId> = advances.iter().map(|a| a.wallet_id).collect();
+
+        let snapshot = self.snapshot_balances();
+        let mut prior_account_balances: BTreeMap<
+            WalletId,
+            BTreeMap<AccountType, WalletCoreBalance>,
+        > = wallets
+            .iter()
+            .filter_map(|id| self.wallet_infos.get(id).map(|info| (*id, info.account_balances())))
+            .collect();
+
+        let mut per_wallet_matured: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
+        for wallet_id in &wallets {
+            let Some(info) = self.wallet_infos.get(wallet_id) else {
+                continue;
+            };
+            let old_height = info.last_processed_height();
+            if height > old_height {
+                let matured = info.matured_coinbase_records(old_height, height);
+                if !matured.is_empty() {
+                    per_wallet_matured.insert(*wallet_id, matured);
+                }
+            }
+        }
+
+        // Refresh balances; do NOT advance last_processed_height for backfill
+        // blocks since they live below the wallet's forward edge and would
+        // bump the cursor backwards otherwise.
+        for wallet_id in &wallets {
+            if let Some(info) = self.wallet_infos.get_mut(wallet_id) {
+                info.update_balance();
+            }
+        }
+
+        let mut per_wallet_balance: BTreeMap<WalletId, WalletCoreBalance> = BTreeMap::new();
+        let mut per_wallet_account_diff: BTreeMap<
+            WalletId,
+            BTreeMap<AccountType, WalletCoreBalance>,
+        > = BTreeMap::new();
+        for wallet_id in &wallets {
+            let Some(info) = self.wallet_infos.get(wallet_id) else {
+                continue;
+            };
+            let new_balance = info.balance();
+            per_wallet_balance.insert(*wallet_id, new_balance);
+            let prior = prior_account_balances.remove(wallet_id).unwrap_or_default();
+            per_wallet_account_diff
+                .insert(*wallet_id, diff_account_balances(&prior, &info.account_balances()));
+        }
+
+        // Drain per-wallet record / derivation maps so each wallet's events
+        // carry the right slice. Multiple advances on the same wallet (a
+        // block matched by two sync ranges of one wallet) split records
+        // across the first advance only, since records are
+        // wallet-attributed not range-attributed; later same-wallet advances
+        // ship empty record slices.
+        let mut wallet_inserted: BTreeMap<WalletId, Vec<TransactionRecord>> = wallets
+            .iter()
+            .map(|id| (*id, per_wallet_inserted.remove(id).unwrap_or_default()))
+            .collect();
+        let mut wallet_updated: BTreeMap<WalletId, Vec<TransactionRecord>> = wallets
+            .iter()
+            .map(|id| (*id, per_wallet_updated.remove(id).unwrap_or_default()))
+            .collect();
+        let mut wallet_derived: BTreeMap<WalletId, Vec<DerivedAddressInfo>> = wallets
+            .iter()
+            .map(|id| (*id, per_wallet_derived.remove(id).unwrap_or_default()))
+            .collect();
+
+        for advance in advances {
+            let wallet_id = advance.wallet_id;
+            let inserted = wallet_inserted.remove(&wallet_id).unwrap_or_default();
+            let updated = wallet_updated.remove(&wallet_id).unwrap_or_default();
+            let matured = per_wallet_matured.remove(&wallet_id).unwrap_or_default();
+            let derived_for_wallet = wallet_derived.remove(&wallet_id).unwrap_or_default();
+            let addresses_derived: Vec<DerivedAddress> =
+                project_derived_addresses(derived_for_wallet);
+            let balance =
+                per_wallet_balance.get(&wallet_id).copied().unwrap_or_default();
+            let account_balances =
+                per_wallet_account_diff.get(&wallet_id).cloned().unwrap_or_default();
+            let balance_changed = snapshot.get(&wallet_id).copied() != Some(balance);
+
+            if !inserted.is_empty()
+                || !updated.is_empty()
+                || !matured.is_empty()
+                || !addresses_derived.is_empty()
+                || balance_changed
+            {
+                let event = WalletEvent::RescanBlockProcessed {
+                    wallet_id,
+                    height,
+                    pool: advance.pool,
+                    indexes: advance.indexes.clone(),
+                    advance_to: advance.advance_to,
+                    inserted,
+                    updated,
+                    matured,
+                    balance,
+                    account_balances,
+                    addresses_derived,
+                };
+                let _ = self.event_sender.send(event);
+            }
+        }
+
+        for advance in advances {
+            self.advance_rescan(
+                &advance.wallet_id,
+                advance.pool,
+                advance.indexes.clone(),
+                advance.advance_to,
+            );
         }
     }
 }

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -328,6 +328,24 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         }
     }
 
+    fn on_chain_reorg(&mut self, fork_height: CoreBlockHeight) {
+        for (wallet_id, info) in self.wallet_infos.iter_mut() {
+            let prev_conv = info.convergence_height();
+            for mut account in info.accounts_mut().all_accounts_mut() {
+                for pool in account.managed_account_type_mut().address_pools_mut() {
+                    pool.clamp_caught_up_to(fork_height);
+                }
+            }
+            let new_conv = info.convergence_height();
+            if new_conv != prev_conv {
+                let _ = self.event_sender.send(WalletEvent::ConvergenceChanged {
+                    wallet_id: *wallet_id,
+                    fully_converged_through: new_conv,
+                });
+            }
+        }
+    }
+
     fn update_wallet_synced_height(&mut self, wallet_id: &WalletId, height: CoreBlockHeight) {
         if let Some(info) = self.wallet_infos.get_mut(wallet_id) {
             if height > info.synced_height() {
@@ -925,5 +943,70 @@ mod tests {
         assert_eq!(manager.pending_rescans().len(), 0);
         assert_eq!(manager.wallet_convergence_height(&wallet_id), Some(100));
         assert!(manager.wallets_pending_convergence(100).is_empty());
+    }
+
+    #[tokio::test]
+    async fn on_chain_reorg_clamps_pending_sync_ranges_across_pools() {
+        use key_wallet::managed_account::address_pool::AddressSyncRange;
+
+        let (mut manager, wallet_id, _) = setup_manager_with_wallet();
+        manager.update_wallet_synced_height(&wallet_id, 400);
+
+        let info = manager
+            .get_wallet_info_mut(&wallet_id)
+            .expect("wallet exists");
+        for mut account in info.accounts_mut().all_accounts_mut() {
+            for pool in account.managed_account_type_mut().address_pools_mut() {
+                if pool.pool_type == AddressPoolType::External {
+                    pool.push_sync_range(AddressSyncRange {
+                        indexes: 30..40,
+                        since_height: 200,
+                        caught_up_to: Some(150),
+                    });
+                    pool.push_sync_range(AddressSyncRange {
+                        indexes: 50..60,
+                        since_height: 300,
+                        caught_up_to: Some(50),
+                    });
+                }
+            }
+        }
+
+        manager.on_chain_reorg(100);
+
+        let rescans = manager.pending_rescans();
+        let by_indexes: BTreeMap<u32, _> =
+            rescans.iter().map(|r| (r.indexes.start, r)).collect();
+
+        let info = manager.get_wallet_info(&wallet_id).expect("wallet exists");
+        let mut snapshots: Vec<(u32, u32, Option<CoreBlockHeight>)> = Vec::new();
+        for account in info.accounts().all_accounts() {
+            for pool in account.managed_account_type().address_pools() {
+                if pool.pool_type == AddressPoolType::External {
+                    for range in pool.pending_sync_ranges() {
+                        snapshots.push((
+                            range.indexes.start,
+                            range.indexes.end,
+                            range.caught_up_to,
+                        ));
+                    }
+                }
+            }
+        }
+
+        let clamped = snapshots
+            .iter()
+            .find(|(s, _, _)| *s == 30)
+            .expect("range 30..40 must still be pending");
+        assert_eq!(clamped.2, Some(100), "above-fork range pulled back to fork height");
+
+        let unchanged = snapshots
+            .iter()
+            .find(|(s, _, _)| *s == 50)
+            .expect("range 50..60 must still be pending");
+        assert_eq!(unchanged.2, Some(50), "below-fork range left untouched");
+
+        assert!(by_indexes.contains_key(&30));
+        assert!(by_indexes.contains_key(&50));
     }
 }

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -1,12 +1,14 @@
 use crate::events::{diff_account_balances, project_derived_addresses, DerivedAddress};
 use crate::wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
-use crate::{WalletEvent, WalletId, WalletManager};
+use crate::{PendingRescan, WalletEvent, WalletId, WalletManager};
 use async_trait::async_trait;
 use core::fmt::Write as _;
+use core::ops::Range;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, Block, Transaction};
 use key_wallet::account::AccountType;
+use key_wallet::managed_account::address_pool::AddressPoolType;
 use key_wallet::managed_account::transaction_record::TransactionRecord;
 use key_wallet::transaction_checking::{BlockInfo, DerivedAddressInfo, TransactionContext};
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
@@ -236,6 +238,88 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         self.wallet_infos.get(wallet_id).map(|info| info.synced_height()).unwrap_or(0)
     }
 
+    fn wallet_convergence_height(&self, wallet_id: &WalletId) -> Option<CoreBlockHeight> {
+        self.wallet_infos.get(wallet_id).and_then(|info| info.convergence_height())
+    }
+
+    fn wallets_pending_convergence(&self, height: CoreBlockHeight) -> BTreeSet<WalletId> {
+        self.wallet_infos
+            .iter()
+            .filter_map(|(id, info)| {
+                let conv = info.convergence_height()?;
+                (conv < height).then_some(*id)
+            })
+            .collect()
+    }
+
+    fn pending_rescans(&self) -> Vec<PendingRescan> {
+        let mut out = Vec::new();
+        for (wallet_id, info) in self.wallet_infos.iter() {
+            let birth = info.birth_height();
+            for account in info.accounts().all_accounts() {
+                for pool in account.managed_account_type().address_pools() {
+                    let pool_type = pool.pool_type;
+                    for range in pool.pending_sync_ranges() {
+                        let ceiling = range.since_height.saturating_sub(1);
+                        let resume_from = range
+                            .caught_up_to
+                            .map(|c| c.saturating_add(1).max(birth))
+                            .unwrap_or(birth);
+                        if resume_from > ceiling {
+                            continue;
+                        }
+                        let addresses: Vec<Address> = range
+                            .indexes
+                            .clone()
+                            .filter_map(|idx| {
+                                pool.addresses.get(&idx).map(|info| info.address.clone())
+                            })
+                            .collect();
+                        out.push(PendingRescan {
+                            wallet_id: *wallet_id,
+                            pool: pool_type,
+                            indexes: range.indexes.clone(),
+                            addresses,
+                            floor: birth,
+                            ceiling,
+                            resume_from,
+                        });
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    fn advance_rescan(
+        &mut self,
+        wallet_id: &WalletId,
+        pool: AddressPoolType,
+        indexes: Range<u32>,
+        scanned_through: CoreBlockHeight,
+    ) {
+        let Some(info) = self.wallet_infos.get_mut(wallet_id) else {
+            return;
+        };
+        for mut account in info.accounts_mut().all_accounts_mut() {
+            for p in account.managed_account_type_mut().address_pools_mut() {
+                if p.pool_type != pool {
+                    continue;
+                }
+                for range in p.pending_sync_ranges_mut().iter_mut() {
+                    if range.indexes == indexes {
+                        let cap = range.since_height.saturating_sub(1);
+                        let new = scanned_through.min(cap);
+                        if range.caught_up_to.map(|c| new > c).unwrap_or(true) {
+                            range.caught_up_to = Some(new);
+                        }
+                    }
+                }
+                p.pending_sync_ranges_mut().retain(|r| !r.is_complete());
+            }
+        }
+    }
+
     fn update_wallet_synced_height(&mut self, wallet_id: &WalletId, height: CoreBlockHeight) {
         if let Some(info) = self.wallet_infos.get_mut(wallet_id) {
             if height > info.synced_height() {
@@ -449,7 +533,10 @@ mod tests {
     use dashcore::{
         BlockHash, Network, OutPoint, ScriptBuf, TxIn, TxMerkleNode, TxOut, Txid, Witness,
     };
+    use key_wallet::account::ManagedAccountTrait;
     use key_wallet::account::StandardAccountType;
+    use key_wallet::managed_account::address_pool::AddressPoolType;
+    use key_wallet::managed_account::managed_account_type::ManagedAccountType;
     use key_wallet::mnemonic::Language;
     use key_wallet::wallet::initialization::WalletAccountCreationOptions;
     use key_wallet::wallet::managed_wallet_info::transaction_building::AccountTypePreference;
@@ -750,5 +837,73 @@ mod tests {
             manager.monitor_revision() > rev_before,
             "create_wallet_with_random_mnemonic should bump revision"
         );
+    }
+
+    fn highest_external_address(
+        manager: &WalletManager,
+        wallet_id: &WalletId,
+    ) -> (u32, Address) {
+        let info = manager.get_wallet_info(wallet_id).expect("wallet info");
+        let acct = info
+            .accounts
+            .standard_bip44_accounts
+            .get(&0)
+            .expect("BIP44 account 0 should exist on the default test wallet");
+        let pool = match acct.managed_account_type() {
+            ManagedAccountType::Standard {
+                external_addresses, ..
+            } => external_addresses,
+            _ => panic!("expected Standard account"),
+        };
+        let highest = pool.highest_generated.expect("pool should be pre-generated");
+        let addr = pool.address_at_index(highest).expect("highest address must exist");
+        (highest, addr)
+    }
+
+    #[tokio::test]
+    async fn convergence_drops_when_sync_range_added_and_rises_after_advance_rescan() {
+        let (mut manager, wallet_id, _) = setup_manager_with_wallet();
+
+        // Pristine wallet: no pending sync ranges, convergence == synced.
+        assert_eq!(manager.pending_rescans().len(), 0);
+        assert_eq!(manager.wallet_convergence_height(&wallet_id), Some(0));
+        assert_eq!(manager.wallet_synced_height(&wallet_id), 0);
+
+        // Pay to the highest pre-generated External address inside a block at
+        // height 100. This forces gap-limit extension, which step 1 records as
+        // a pending sync range with `since_height = 100, caught_up_to = None`.
+        let (_highest_idx_before, highest_addr) = highest_external_address(&manager, &wallet_id);
+        let tx = create_tx_paying_to(&highest_addr, 0xa1);
+        let block = make_block(vec![tx]);
+        let wallets = BTreeSet::from([wallet_id]);
+        manager.process_block_for_wallets(&block, 100, &wallets).await;
+        manager.update_wallet_synced_height(&wallet_id, 100);
+
+        // The pending obligation surfaces as a single rescan covering the
+        // External pool of BIP44 account 0.
+        let rescans = manager.pending_rescans();
+        assert_eq!(rescans.len(), 1, "exactly one pending rescan expected");
+        let rescan = &rescans[0];
+        assert_eq!(rescan.wallet_id, wallet_id);
+        assert_eq!(rescan.pool, AddressPoolType::External);
+        assert_eq!(rescan.ceiling, 99);
+        assert_eq!(rescan.floor, 0);
+        assert_eq!(rescan.resume_from, 0);
+        let indexes = rescan.indexes.clone();
+
+        // synced advanced to 100 but convergence drops to the floor (birth-1
+        // saturates to 0) because the new range hasn't been backfilled.
+        assert_eq!(manager.wallet_synced_height(&wallet_id), 100);
+        assert_eq!(manager.wallet_convergence_height(&wallet_id), Some(0));
+        let pending_at_50 = manager.wallets_pending_convergence(50);
+        assert!(pending_at_50.contains(&wallet_id));
+
+        // Backfill scans the full window. After advance_rescan reaches the
+        // ceiling, the range completes and is dropped.
+        manager.advance_rescan(&wallet_id, AddressPoolType::External, indexes, 99);
+
+        assert_eq!(manager.pending_rescans().len(), 0);
+        assert_eq!(manager.wallet_convergence_height(&wallet_id), Some(100));
+        assert!(manager.wallets_pending_convergence(100).is_empty());
     }
 }

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -1115,13 +1115,14 @@ mod tests {
         manager.update_wallet_synced_height(&wallet_id, 100);
 
         // The pending obligation surfaces as a single rescan covering the
-        // External pool of BIP44 account 0.
+        // External pool of BIP44 account 0. The since_height=100 rounds up
+        // to the 5000-block bucket so ceiling=4999.
         let rescans = manager.pending_rescans();
         assert_eq!(rescans.len(), 1, "exactly one pending rescan expected");
         let rescan = &rescans[0];
         assert_eq!(rescan.wallet_id, wallet_id);
         assert_eq!(rescan.pool, AddressPoolType::External);
-        assert_eq!(rescan.ceiling, 99);
+        assert_eq!(rescan.ceiling, 4999);
         assert_eq!(rescan.floor, 0);
         assert_eq!(rescan.resume_from, 0);
         let indexes = rescan.indexes.clone();
@@ -1135,7 +1136,7 @@ mod tests {
 
         // Backfill scans the full window. After advance_rescan reaches the
         // ceiling, the range completes and is dropped.
-        manager.advance_rescan(&wallet_id, AddressPoolType::External, indexes, 99);
+        manager.advance_rescan(&wallet_id, AddressPoolType::External, indexes, 4999);
 
         assert_eq!(manager.pending_rescans().len(), 0);
         assert_eq!(manager.wallet_convergence_height(&wallet_id), Some(100));

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -1198,4 +1198,54 @@ mod tests {
         assert!(by_indexes.contains_key(&30));
         assert!(by_indexes.contains_key(&50));
     }
+
+    /// After `on_chain_reorg(F)` pulls a range's `caught_up_to` back to F,
+    /// the very next `pending_rescans()` call must report `resume_from = F+1`
+    /// for that range. This is what causes the backfill worker to re-cover
+    /// the affected window on its next tick — the worker reads
+    /// `pending_rescans` fresh each iteration, so a clamp at the wallet
+    /// layer surfaces directly as new work without any extra wiring.
+    #[tokio::test]
+    async fn on_chain_reorg_re_exposes_clamped_window_via_pending_rescans() {
+        use key_wallet::managed_account::address_pool::AddressSyncRange;
+
+        let (mut manager, wallet_id, _) = setup_manager_with_wallet();
+        manager.update_wallet_synced_height(&wallet_id, 400);
+
+        let info = manager
+            .get_wallet_info_mut(&wallet_id)
+            .expect("wallet exists");
+        for mut account in info.accounts_mut().all_accounts_mut() {
+            for pool in account.managed_account_type_mut().address_pools_mut() {
+                if pool.pool_type == AddressPoolType::External {
+                    pool.push_sync_range(AddressSyncRange {
+                        indexes: 30..40,
+                        since_height: 300,
+                        caught_up_to: Some(250),
+                    });
+                }
+            }
+        }
+
+        let pre = manager.pending_rescans();
+        let pre_resume = pre
+            .iter()
+            .find(|r| r.indexes == (30..40))
+            .map(|r| r.resume_from)
+            .expect("range 30..40 surfaced before reorg");
+        assert_eq!(pre_resume, 251, "pre-reorg resume picks up where caught_up_to left off");
+
+        manager.on_chain_reorg(150);
+
+        let post = manager.pending_rescans();
+        let post_resume = post
+            .iter()
+            .find(|r| r.indexes == (30..40))
+            .map(|r| r.resume_from)
+            .expect("range 30..40 still pending after reorg");
+        assert_eq!(
+            post_resume, 151,
+            "post-reorg resume must restart at fork+1 so backfill re-covers [151..299]",
+        );
+    }
 }

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -762,7 +762,7 @@ mod tests {
     };
     use key_wallet::account::ManagedAccountTrait;
     use key_wallet::account::StandardAccountType;
-    use key_wallet::managed_account::address_pool::AddressPoolType;
+    use key_wallet::managed_account::address_pool::{AddressPoolType, AddressSyncRange};
     use key_wallet::managed_account::managed_account_type::ManagedAccountType;
     use key_wallet::mnemonic::Language;
     use key_wallet::wallet::initialization::WalletAccountCreationOptions;
@@ -1136,8 +1136,6 @@ mod tests {
 
     #[tokio::test]
     async fn on_chain_reorg_clamps_pending_sync_ranges_across_pools() {
-        use key_wallet::managed_account::address_pool::AddressSyncRange;
-
         let (mut manager, wallet_id, _) = setup_manager_with_wallet();
         manager.update_wallet_synced_height(&wallet_id, 400);
 
@@ -1207,8 +1205,6 @@ mod tests {
     /// layer surfaces directly as new work without any extra wiring.
     #[tokio::test]
     async fn on_chain_reorg_re_exposes_clamped_window_via_pending_rescans() {
-        use key_wallet::managed_account::address_pool::AddressSyncRange;
-
         let (mut manager, wallet_id, _) = setup_manager_with_wallet();
         manager.update_wallet_synced_height(&wallet_id, 400);
 

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -301,6 +301,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         let Some(info) = self.wallet_infos.get_mut(wallet_id) else {
             return;
         };
+        let prev_conv = info.convergence_height();
         for mut account in info.accounts_mut().all_accounts_mut() {
             for p in account.managed_account_type_mut().address_pools_mut() {
                 if p.pool_type != pool {
@@ -317,6 +318,13 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
                 }
                 p.pending_sync_ranges_mut().retain(|r| !r.is_complete());
             }
+        }
+        let new_conv = info.convergence_height();
+        if new_conv != prev_conv {
+            let _ = self.event_sender.send(WalletEvent::ConvergenceChanged {
+                wallet_id: *wallet_id,
+                fully_converged_through: new_conv,
+            });
         }
     }
 
@@ -455,6 +463,10 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
                 self.wallet_infos.get(id).map(|info| (*id, info.last_processed_height()))
             })
             .collect();
+        let prior_convergence: BTreeMap<WalletId, Option<CoreBlockHeight>> = wallets
+            .iter()
+            .filter_map(|id| self.wallet_infos.get(id).map(|info| (*id, info.convergence_height())))
+            .collect();
 
         // Collect matured coinbase records before advancing the height so the
         // (old, new] window is well-defined per wallet. Wallets whose height
@@ -518,6 +530,14 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
                     addresses_derived,
                 };
                 let _ = self.event_sender.send(event);
+            }
+
+            let new_conv = info.convergence_height();
+            if prior_convergence.get(wallet_id).copied() != Some(new_conv) {
+                let _ = self.event_sender.send(WalletEvent::ConvergenceChanged {
+                    wallet_id: *wallet_id,
+                    fully_converged_through: new_conv,
+                });
             }
         }
     }

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -710,8 +710,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
             let derived_for_wallet = wallet_derived.remove(&wallet_id).unwrap_or_default();
             let addresses_derived: Vec<DerivedAddress> =
                 project_derived_addresses(derived_for_wallet);
-            let balance =
-                per_wallet_balance.get(&wallet_id).copied().unwrap_or_default();
+            let balance = per_wallet_balance.get(&wallet_id).copied().unwrap_or_default();
             let account_balances =
                 per_wallet_account_diff.get(&wallet_id).cloned().unwrap_or_default();
             let balance_changed = snapshot.get(&wallet_id).copied() != Some(balance);
@@ -1066,10 +1065,7 @@ mod tests {
         );
     }
 
-    fn highest_external_address(
-        manager: &WalletManager,
-        wallet_id: &WalletId,
-    ) -> (u32, Address) {
+    fn highest_external_address(manager: &WalletManager, wallet_id: &WalletId) -> (u32, Address) {
         let info = manager.get_wallet_info(wallet_id).expect("wallet info");
         let acct = info
             .accounts
@@ -1078,7 +1074,8 @@ mod tests {
             .expect("BIP44 account 0 should exist on the default test wallet");
         let pool = match acct.managed_account_type() {
             ManagedAccountType::Standard {
-                external_addresses, ..
+                external_addresses,
+                ..
             } => external_addresses,
             _ => panic!("expected Standard account"),
         };
@@ -1139,9 +1136,7 @@ mod tests {
         let (mut manager, wallet_id, _) = setup_manager_with_wallet();
         manager.update_wallet_synced_height(&wallet_id, 400);
 
-        let info = manager
-            .get_wallet_info_mut(&wallet_id)
-            .expect("wallet exists");
+        let info = manager.get_wallet_info_mut(&wallet_id).expect("wallet exists");
         for mut account in info.accounts_mut().all_accounts_mut() {
             for pool in account.managed_account_type_mut().address_pools_mut() {
                 if pool.pool_type == AddressPoolType::External {
@@ -1162,8 +1157,7 @@ mod tests {
         manager.on_chain_reorg(100);
 
         let rescans = manager.pending_rescans();
-        let by_indexes: BTreeMap<u32, _> =
-            rescans.iter().map(|r| (r.indexes.start, r)).collect();
+        let by_indexes: BTreeMap<u32, _> = rescans.iter().map(|r| (r.indexes.start, r)).collect();
 
         let info = manager.get_wallet_info(&wallet_id).expect("wallet exists");
         let mut snapshots: Vec<(u32, u32, Option<CoreBlockHeight>)> = Vec::new();
@@ -1208,9 +1202,7 @@ mod tests {
         let (mut manager, wallet_id, _) = setup_manager_with_wallet();
         manager.update_wallet_synced_height(&wallet_id, 400);
 
-        let info = manager
-            .get_wallet_info_mut(&wallet_id)
-            .expect("wallet exists");
+        let info = manager.get_wallet_info_mut(&wallet_id).expect("wallet exists");
         for mut account in info.accounts_mut().all_accounts_mut() {
             for pool in account.managed_account_type_mut().address_pools_mut() {
                 if pool.pool_type == AddressPoolType::External {

--- a/key-wallet-manager/src/rescan.rs
+++ b/key-wallet-manager/src/rescan.rs
@@ -1,0 +1,25 @@
+use core::ops::Range;
+
+use dashcore::prelude::CoreBlockHeight;
+use dashcore::Address;
+use key_wallet::managed_account::address_pool::AddressPoolType;
+
+use crate::WalletId;
+
+/// A backfill obligation surfaced from a wallet's pending sync ranges.
+///
+/// `floor` is the wallet's `birth_height` and the absolute lower bound below
+/// which scans are pointless. `ceiling` is `since_height - 1` and the
+/// inclusive upper bound at which point the range is fully caught up.
+/// `resume_from` is `caught_up_to.map(|c| c + 1).max(floor)`, so the
+/// backfill worker can pick up exactly where it left off.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingRescan {
+    pub wallet_id: WalletId,
+    pub pool: AddressPoolType,
+    pub indexes: Range<u32>,
+    pub addresses: Vec<Address>,
+    pub floor: CoreBlockHeight,
+    pub ceiling: CoreBlockHeight,
+    pub resume_from: CoreBlockHeight,
+}

--- a/key-wallet-manager/src/test_utils/mock_wallet.rs
+++ b/key-wallet-manager/src/test_utils/mock_wallet.rs
@@ -5,7 +5,7 @@ use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, Block, OutPoint, Transaction, Txid};
 use key_wallet::transaction_checking::TransactionContext;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use tokio::sync::{broadcast, Mutex};
 
@@ -371,6 +371,24 @@ pub struct MockWalletState {
     pub last_processed_height: CoreBlockHeight,
 }
 
+#[derive(Debug, Clone)]
+pub struct MockPendingRange {
+    pub pool: key_wallet::managed_account::address_pool::AddressPoolType,
+    pub indexes: core::ops::Range<u32>,
+    pub since_height: CoreBlockHeight,
+    pub addresses: Vec<Address>,
+    pub caught_up_to: Option<CoreBlockHeight>,
+}
+
+impl MockPendingRange {
+    pub fn is_complete(&self) -> bool {
+        match self.caught_up_to {
+            Some(c) => c + 1 >= self.since_height,
+            None => self.since_height == 0,
+        }
+    }
+}
+
 /// Multi-wallet mock that holds independent state for several wallet IDs,
 /// enabling tests that exercise per-wallet attribution paths.
 pub struct MultiMockWallet {
@@ -378,6 +396,13 @@ pub struct MultiMockWallet {
     event_sender: broadcast::Sender<WalletEvent>,
     /// Track every block processed for assertions.
     processed: Arc<Mutex<Vec<(WalletId, dashcore::BlockHash, u32)>>>,
+    /// Per-wallet birth heights for backfill tests; defaults to 0 when
+    /// not explicitly set.
+    birth_heights: std::collections::BTreeMap<WalletId, CoreBlockHeight>,
+    /// Per-wallet pending sync ranges for backfill tests. Built directly
+    /// without a real `ManagedWalletInfo` so the routing path can be
+    /// exercised in isolation.
+    pending_ranges: std::collections::BTreeMap<WalletId, Vec<MockPendingRange>>,
 }
 
 impl Default for MultiMockWallet {
@@ -393,7 +418,13 @@ impl MultiMockWallet {
             wallets: std::collections::BTreeMap::new(),
             event_sender,
             processed: Arc::new(Mutex::new(Vec::new())),
+            birth_heights: std::collections::BTreeMap::new(),
+            pending_ranges: std::collections::BTreeMap::new(),
         }
+    }
+
+    pub fn set_birth_height(&mut self, wallet_id: WalletId, height: CoreBlockHeight) {
+        self.birth_heights.insert(wallet_id, height);
     }
 
     /// Insert or replace a wallet's state.
@@ -408,6 +439,30 @@ impl MultiMockWallet {
 
     pub fn processed(&self) -> Arc<Mutex<Vec<(WalletId, dashcore::BlockHash, u32)>>> {
         self.processed.clone()
+    }
+
+    /// Push a pending sync range onto a wallet for the backfill worker
+    /// to discover. Tests use this instead of mutating real address
+    /// pools.
+    pub fn push_sync_range_for_test(
+        &mut self,
+        wallet_id: WalletId,
+        pool: key_wallet::managed_account::address_pool::AddressPoolType,
+        indexes: core::ops::Range<u32>,
+        since_height: CoreBlockHeight,
+        addresses: Vec<Address>,
+    ) {
+        self.pending_ranges.entry(wallet_id).or_default().push(MockPendingRange {
+            pool,
+            indexes,
+            since_height,
+            addresses,
+            caught_up_to: None,
+        });
+    }
+
+    pub fn pending_ranges_for(&self, wallet_id: &WalletId) -> Vec<MockPendingRange> {
+        self.pending_ranges.get(wallet_id).cloned().unwrap_or_default()
     }
 }
 
@@ -499,6 +554,95 @@ impl WalletInterface for MultiMockWallet {
 
     fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent> {
         self.event_sender.subscribe()
+    }
+
+    fn pending_rescans(&self) -> Vec<crate::PendingRescan> {
+        let mut out = Vec::new();
+        for (wallet_id, ranges) in &self.pending_ranges {
+            let birth = self.birth_heights.get(wallet_id).copied().unwrap_or(0);
+            for range in ranges {
+                if range.is_complete() {
+                    continue;
+                }
+                let ceiling = range.since_height.saturating_sub(1);
+                let resume_from = range
+                    .caught_up_to
+                    .map(|c| c.saturating_add(1).max(birth))
+                    .unwrap_or(birth);
+                if resume_from > ceiling {
+                    continue;
+                }
+                out.push(crate::PendingRescan {
+                    wallet_id: *wallet_id,
+                    pool: range.pool,
+                    indexes: range.indexes.clone(),
+                    addresses: range.addresses.clone(),
+                    floor: birth,
+                    ceiling,
+                    resume_from,
+                });
+            }
+        }
+        out
+    }
+
+    fn advance_rescan(
+        &mut self,
+        wallet_id: &WalletId,
+        pool: key_wallet::managed_account::address_pool::AddressPoolType,
+        indexes: core::ops::Range<u32>,
+        scanned_through: CoreBlockHeight,
+    ) {
+        let Some(ranges) = self.pending_ranges.get_mut(wallet_id) else {
+            return;
+        };
+        for range in ranges.iter_mut() {
+            if range.pool == pool && range.indexes == indexes {
+                let cap = range.since_height.saturating_sub(1);
+                let new = scanned_through.min(cap);
+                if range.caught_up_to.map(|c| new > c).unwrap_or(true) {
+                    range.caught_up_to = Some(new);
+                }
+            }
+        }
+        ranges.retain(|r| !r.is_complete());
+    }
+
+    async fn process_backfill_block_for_wallets(
+        &mut self,
+        block: &Block,
+        height: CoreBlockHeight,
+        advances: &[crate::BackfillAdvance],
+    ) -> BlockProcessingResult {
+        let hash = block.block_hash();
+        {
+            let mut processed = self.processed.lock().await;
+            for advance in advances {
+                processed.push((advance.wallet_id, hash, height));
+            }
+        }
+        for advance in advances {
+            let _ = self.event_sender.send(WalletEvent::RescanBlockProcessed {
+                wallet_id: advance.wallet_id,
+                height,
+                pool: advance.pool,
+                indexes: advance.indexes.clone(),
+                advance_to: advance.advance_to,
+                inserted: Vec::new(),
+                updated: Vec::new(),
+                matured: Vec::new(),
+                balance: key_wallet::WalletCoreBalance::default(),
+                account_balances: BTreeMap::new(),
+                addresses_derived: Vec::new(),
+            });
+            self.advance_rescan(
+                &advance.wallet_id,
+                advance.pool,
+                advance.indexes.clone(),
+                advance.advance_to,
+            );
+        }
+        BlockProcessingResult::default()
     }
 
     async fn describe(&self) -> String {

--- a/key-wallet-manager/src/test_utils/mock_wallet.rs
+++ b/key-wallet-manager/src/test_utils/mock_wallet.rs
@@ -565,10 +565,8 @@ impl WalletInterface for MultiMockWallet {
                     continue;
                 }
                 let ceiling = range.since_height.saturating_sub(1);
-                let resume_from = range
-                    .caught_up_to
-                    .map(|c| c.saturating_add(1).max(birth))
-                    .unwrap_or(birth);
+                let resume_from =
+                    range.caught_up_to.map(|c| c.saturating_add(1).max(birth)).unwrap_or(birth);
                 if resume_from > ceiling {
                     continue;
                 }

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -56,16 +56,18 @@ impl BlockProcessingResult {
 }
 
 /// One backfill obligation associated with a block: which sync range to
-/// advance, and to what height. The block itself (height, hash, wallet
-/// attribution) lives outside this struct in the event and pipeline
-/// carriers.
+/// advance, and to what height. Carries both the matched block's height
+/// (so the worker can prune stale obligations on reorg or completion) and
+/// `advance_to`, the chunk_end of the backfill sweep that produced the
+/// match.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackfillAdvance {
     pub wallet_id: WalletId,
     pub pool: AddressPoolType,
     pub indexes: Range<u32>,
-    /// Where `caught_up_to` should land after this block is processed —
-    /// the chunk_end of the backfill sweep that produced the match.
+    /// Height of the matched block whose download is awaited.
+    pub height: CoreBlockHeight,
+    /// Where `caught_up_to` should land after this block is processed.
     pub advance_to: CoreBlockHeight,
 }
 

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -55,6 +55,20 @@ impl BlockProcessingResult {
     }
 }
 
+/// One backfill obligation associated with a block: which sync range to
+/// advance, and to what height. The block itself (height, hash, wallet
+/// attribution) lives outside this struct in the event and pipeline
+/// carriers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackfillAdvance {
+    pub wallet_id: WalletId,
+    pub pool: AddressPoolType,
+    pub indexes: Range<u32>,
+    /// Where `caught_up_to` should land after this block is processed —
+    /// the chunk_end of the backfill sweep that produced the match.
+    pub advance_to: CoreBlockHeight,
+}
+
 /// Trait for wallet implementations to receive SPV events
 #[async_trait]
 pub trait WalletInterface: Send + Sync + 'static {
@@ -70,6 +84,37 @@ pub trait WalletInterface: Send + Sync + 'static {
         height: CoreBlockHeight,
         wallets: &BTreeSet<WalletId>,
     ) -> BlockProcessingResult;
+
+    /// Process a block discovered by the backfill worker. Bundles the
+    /// per-sync-range advance obligations so a downstream persister can
+    /// write the records and the `caught_up_to` advance atomically via
+    /// [`WalletEvent::RescanBlockProcessed`].
+    ///
+    /// The default implementation derives the wallet set from `advances`
+    /// and delegates to [`Self::process_block_for_wallets`], so minimal
+    /// mock implementations keep working unchanged. Real implementations
+    /// should override this to emit the dedicated event instead of
+    /// `BlockProcessed` for backfill blocks.
+    ///
+    /// [`WalletEvent::RescanBlockProcessed`]: crate::WalletEvent::RescanBlockProcessed
+    async fn process_backfill_block_for_wallets(
+        &mut self,
+        block: &Block,
+        height: CoreBlockHeight,
+        advances: &[BackfillAdvance],
+    ) -> BlockProcessingResult {
+        let wallets: BTreeSet<WalletId> = advances.iter().map(|a| a.wallet_id).collect();
+        let result = self.process_block_for_wallets(block, height, &wallets).await;
+        for advance in advances {
+            self.advance_rescan(
+                &advance.wallet_id,
+                advance.pool,
+                advance.indexes.clone(),
+                advance.advance_to,
+            );
+        }
+        result
+    }
 
     /// Called when a transaction is seen in the mempool.
     /// Returns whether the transaction was relevant and any new addresses generated.

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -92,21 +92,24 @@ pub trait WalletInterface: Send + Sync + 'static {
     /// write the records and the `caught_up_to` advance atomically via
     /// [`WalletEvent::RescanBlockProcessed`].
     ///
-    /// The default implementation derives the wallet set from `advances`
-    /// and delegates to [`Self::process_block_for_wallets`], so minimal
-    /// mock implementations keep working unchanged. Real implementations
-    /// should override this to emit the dedicated event instead of
-    /// `BlockProcessed` for backfill blocks.
+    /// The default implementation only calls [`Self::advance_rescan`] for
+    /// each advance and returns an empty result — it deliberately does NOT
+    /// fall back to [`Self::process_block_for_wallets`] because that path
+    /// emits [`WalletEvent::BlockProcessed`], which breaks the atomicity
+    /// contract the caller relies on (records and `advance_to` must arrive
+    /// in a single event so a downstream persister can write both
+    /// transactionally). Implementations that need to actually scan the
+    /// block's transactions during backfill MUST override this to emit
+    /// `RescanBlockProcessed` with the discovered records.
     ///
     /// [`WalletEvent::RescanBlockProcessed`]: crate::WalletEvent::RescanBlockProcessed
+    /// [`WalletEvent::BlockProcessed`]: crate::WalletEvent::BlockProcessed
     async fn process_backfill_block_for_wallets(
         &mut self,
-        block: &Block,
-        height: CoreBlockHeight,
+        _block: &Block,
+        _height: CoreBlockHeight,
         advances: &[BackfillAdvance],
     ) -> BlockProcessingResult {
-        let wallets: BTreeSet<WalletId> = advances.iter().map(|a| a.wallet_id).collect();
-        let result = self.process_block_for_wallets(block, height, &wallets).await;
         for advance in advances {
             self.advance_rescan(
                 &advance.wallet_id,
@@ -115,7 +118,7 @@ pub trait WalletInterface: Send + Sync + 'static {
                 advance.advance_to,
             );
         }
-        result
+        BlockProcessingResult::default()
     }
 
     /// Called when a transaction is seen in the mempool.

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -2,11 +2,13 @@
 //!
 //! This module defines the trait that SPV clients use to interact with wallets.
 
-use crate::{WalletEvent, WalletId};
+use crate::{PendingRescan, WalletEvent, WalletId};
 use async_trait::async_trait;
+use core::ops::Range;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, Block, OutPoint, Transaction, Txid};
+use key_wallet::managed_account::address_pool::AddressPoolType;
 use std::collections::{BTreeMap, BTreeSet};
 use tokio::sync::broadcast;
 
@@ -119,7 +121,56 @@ pub trait WalletInterface: Send + Sync + 'static {
     }
 
     /// Return the per-wallet committed sync checkpoint, or `0` if unknown.
+    ///
+    /// This is the strictly monotonic forward edge. Pair with
+    /// [`Self::wallet_convergence_height`] when a consumer needs the
+    /// "everything below this is final" semantics.
     fn wallet_synced_height(&self, wallet_id: &WalletId) -> CoreBlockHeight;
+
+    /// Per-wallet convergence height, or `None` if the wallet is unknown.
+    ///
+    /// See [`key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface::convergence_height`]
+    /// for the semantics. Non-monotonic by nature.
+    ///
+    /// The default implementation falls back to
+    /// [`Self::wallet_synced_height`], which is correct for any wallet
+    /// implementation that does not track sync ranges.
+    fn wallet_convergence_height(&self, wallet_id: &WalletId) -> Option<CoreBlockHeight> {
+        Some(self.wallet_synced_height(wallet_id))
+    }
+
+    /// Wallet IDs whose `convergence_height` is strictly below `height`,
+    /// i.e. the wallets that still have pending backfill obligations
+    /// reaching that high.
+    ///
+    /// The default implementation falls back to [`Self::wallets_behind`].
+    fn wallets_pending_convergence(&self, height: CoreBlockHeight) -> BTreeSet<WalletId> {
+        self.wallets_behind(height)
+    }
+
+    /// All pending rescan obligations across all wallets, suitable for the
+    /// backfill worker to drive its sweep-line scan.
+    ///
+    /// The default implementation returns an empty vec, suitable for
+    /// implementations that do not track sync ranges.
+    fn pending_rescans(&self) -> Vec<PendingRescan> {
+        Vec::new()
+    }
+
+    /// Mark a contiguous slice of filter heights as scanned for a
+    /// particular pool's pending sync range. The wallet advances each
+    /// matching range's `caught_up_to`, dropping any that complete.
+    ///
+    /// The default implementation is a no-op, suitable for
+    /// implementations that do not track sync ranges.
+    fn advance_rescan(
+        &mut self,
+        _wallet_id: &WalletId,
+        _pool: AddressPoolType,
+        _indexes: Range<u32>,
+        _scanned_through: CoreBlockHeight,
+    ) {
+    }
 
     /// Advance one wallet's committed sync checkpoint. Implementations must
     /// only advance forward (a value below the current is silently ignored).

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -172,6 +172,14 @@ pub trait WalletInterface: Send + Sync + 'static {
     ) {
     }
 
+    /// React to a confirmed chain reorg to `fork_height`. Clamps every
+    /// pending sync range's `caught_up_to` to at most `fork_height` so the
+    /// backfill worker re-covers any window that progressed past the fork.
+    ///
+    /// The default implementation is a no-op, suitable for implementations
+    /// that do not track sync ranges.
+    fn on_chain_reorg(&mut self, _fork_height: CoreBlockHeight) {}
+
     /// Advance one wallet's committed sync checkpoint. Implementations must
     /// only advance forward (a value below the current is silently ignored).
     fn update_wallet_synced_height(&mut self, wallet_id: &WalletId, height: CoreBlockHeight);

--- a/key-wallet/Cargo.toml
+++ b/key-wallet/Cargo.toml
@@ -47,7 +47,7 @@ sha2 = { version = "0.10", default-features = false }
 bs58 = { version = "0.5", default-features = false, features = ["check", "alloc"], optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
 # Serialization
-bincode = { version = "2.0.1", optional = true }
+bincode = { version = "2.0.1", optional = true, features = ["serde"] }
 bincode_derive = { version = "2.0.1", optional = true }
 base64 = { version = "0.22", optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/key-wallet/src/managed_account/address_pool.rs
+++ b/key-wallet/src/managed_account/address_pool.rs
@@ -15,6 +15,7 @@ use crate::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey}
 use crate::error::{Error, Result};
 use crate::gap_limit::DEFAULT_EXTERNAL_GAP_LIMIT;
 use crate::Network;
+use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, AddressType, ScriptBuf};
 
 /// Types of public keys used in the address pool
@@ -319,6 +320,36 @@ impl AddressInfo {
     }
 }
 
+/// A contiguous range of address indexes within a pool, tracking how far the
+/// filters covering them have been scanned.
+///
+/// A range becomes complete once `caught_up_to + 1 >= since_height`. At that
+/// point it carries no information beyond what `synced_height` already
+/// encodes and is dropped, so wallet state stays bounded regardless of how
+/// many gap extensions the wallet has seen historically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
+pub struct AddressSyncRange {
+    /// Inclusive start, exclusive end within the pool's index space.
+    #[cfg_attr(feature = "bincode", bincode(with_serde))]
+    pub indexes: core::ops::Range<u32>,
+    /// Forward-sync height at which these indexes joined the monitored set.
+    pub since_height: CoreBlockHeight,
+    /// Highest filter height these indexes have been scanned through.
+    /// `None` means no scan past `since_height - 1` has happened yet.
+    pub caught_up_to: Option<CoreBlockHeight>,
+}
+
+impl AddressSyncRange {
+    pub fn is_complete(&self) -> bool {
+        match self.caught_up_to {
+            Some(c) => c + 1 >= self.since_height,
+            None => self.since_height == 0,
+        }
+    }
+}
+
 /// Address pool for managing HD wallet addresses
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -346,6 +377,12 @@ pub struct AddressPool {
     pub highest_used: Option<u32>,
     /// Address type preference
     pub address_type: AddressType,
+    /// Pending sync ranges covering the indexes derived in this pool, sorted
+    /// by `indexes.start` and non-overlapping. Complete ranges (where
+    /// `caught_up_to + 1 >= since_height`) are dropped, so this vector
+    /// shrinks back to empty once the backfill worker catches up.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub sync_ranges: Vec<AddressSyncRange>,
 }
 
 impl AddressPool {
@@ -386,6 +423,7 @@ impl AddressPool {
             highest_generated: None,
             highest_used: None,
             address_type: AddressType::P2pkh,
+            sync_ranges: Vec::new(),
         }
     }
 
@@ -884,12 +922,23 @@ impl AddressPool {
     /// [`Address`] lets callers — in particular the wallet-manager event
     /// emission seam — surface the full derivation context (index, path,
     /// public key) for downstream persisters without re-deriving it.
-    pub fn maintain_gap_limit(&mut self, key_source: &KeySource) -> Result<Vec<AddressInfo>> {
+    ///
+    /// `since_height` is the chain height at which the newly derived
+    /// addresses joined the wallet's monitored set. Filters at heights below
+    /// `since_height` were scanned without these addresses in the query set,
+    /// so a pending [`AddressSyncRange`] is recorded for the backfill worker
+    /// to revisit them.
+    pub fn maintain_gap_limit(
+        &mut self,
+        key_source: &KeySource,
+        since_height: CoreBlockHeight,
+    ) -> Result<Vec<AddressInfo>> {
         let target = match self.highest_used {
             None => self.gap_limit - 1,
             Some(highest) => highest + self.gap_limit,
         };
 
+        let prev_top = self.highest_generated;
         let mut new_addresses = Vec::new();
         while self.highest_generated.unwrap_or(0) < target {
             let next_index = self.highest_generated.map(|h| h + 1).unwrap_or(0);
@@ -909,7 +958,99 @@ impl AddressPool {
             new_addresses.push(info);
         }
 
+        if !new_addresses.is_empty() {
+            let start = prev_top.map(|h| h + 1).unwrap_or(0);
+            let end_exclusive = self
+                .highest_generated
+                .expect("highest_generated must be set after deriving addresses")
+                + 1;
+            self.push_sync_range(AddressSyncRange {
+                indexes: start..end_exclusive,
+                since_height,
+                caught_up_to: None,
+            });
+        }
+
         Ok(new_addresses)
+    }
+
+    /// Pending sync ranges in this pool, sorted by start index.
+    pub fn pending_sync_ranges(&self) -> &[AddressSyncRange] {
+        &self.sync_ranges
+    }
+
+    /// Mutable access to pending sync ranges (used by callers that advance
+    /// `caught_up_to` together with a wallet-snapshot flush).
+    pub fn pending_sync_ranges_mut(&mut self) -> &mut Vec<AddressSyncRange> {
+        &mut self.sync_ranges
+    }
+
+    /// Insert a sync range, keeping the vector sorted by `indexes.start`,
+    /// then collapse adjacent ranges with matching scan progress and drop
+    /// any range that is already complete.
+    pub fn push_sync_range(&mut self, range: AddressSyncRange) {
+        let pos = self
+            .sync_ranges
+            .binary_search_by_key(&range.indexes.start, |r| r.indexes.start)
+            .unwrap_or_else(|p| p);
+        self.sync_ranges.insert(pos, range);
+        self.collapse_adjacent_ranges();
+        self.drop_complete_ranges();
+    }
+
+    /// Advance every pending range's `caught_up_to` toward `height`, capped
+    /// at `since_height - 1`. Ranges that reach completion are dropped.
+    pub fn advance_caught_up_to(&mut self, height: CoreBlockHeight) {
+        for range in &mut self.sync_ranges {
+            let cap = range.since_height.saturating_sub(1);
+            let new = height.min(cap);
+            match range.caught_up_to {
+                Some(c) if new > c => range.caught_up_to = Some(new),
+                None => range.caught_up_to = Some(new),
+                _ => {}
+            }
+        }
+        self.drop_complete_ranges();
+    }
+
+    /// Reorg-time clamp: if any range progressed past the fork point, pull
+    /// `caught_up_to` back to `fork_height` so the backfill worker re-covers
+    /// the affected window.
+    pub fn clamp_caught_up_to(&mut self, fork_height: CoreBlockHeight) {
+        for range in &mut self.sync_ranges {
+            if let Some(c) = range.caught_up_to {
+                if c > fork_height {
+                    range.caught_up_to = Some(fork_height);
+                }
+            }
+        }
+    }
+
+    /// Merge contiguous ranges that share the same `(since_height,
+    /// caught_up_to)`. Independently mutating accessors should call this
+    /// after batched edits.
+    pub fn collapse_adjacent_ranges(&mut self) {
+        if self.sync_ranges.len() < 2 {
+            return;
+        }
+        let mut merged: Vec<AddressSyncRange> = Vec::with_capacity(self.sync_ranges.len());
+        for range in self.sync_ranges.drain(..) {
+            match merged.last_mut() {
+                Some(prev)
+                    if prev.indexes.end == range.indexes.start
+                        && prev.since_height == range.since_height
+                        && prev.caught_up_to == range.caught_up_to =>
+                {
+                    prev.indexes.end = range.indexes.end;
+                }
+                _ => merged.push(range),
+            }
+        }
+        self.sync_ranges = merged;
+    }
+
+    fn drop_complete_ranges(&mut self) {
+        self.sync_ranges.retain(|r| !r.is_complete());
     }
 
     /// Set a custom label for an address
@@ -1235,32 +1376,42 @@ mod tests {
         assert_eq!(pool.addresses.len(), gap_limit as usize);
 
         // Calling maintain_gap_limit should not generate any new addresses when none are used
-        let new_addresses = pool.maintain_gap_limit(&key_source).unwrap();
+        let new_addresses = pool.maintain_gap_limit(&key_source, 0).unwrap();
         assert_eq!(new_addresses.len(), 0);
         assert_eq!(pool.highest_generated, Some(gap_limit - 1));
         assert_eq!(pool.addresses.len(), gap_limit as usize);
+        assert!(pool.sync_ranges.is_empty());
 
         // Mark address at index 0 as used
         pool.mark_index_used(0);
         assert_eq!(pool.highest_used, Some(0));
 
         // Should generate exactly 1 address to maintain gap_limit unused after index 0
-        let new_addresses = pool.maintain_gap_limit(&key_source).unwrap();
+        let new_addresses = pool.maintain_gap_limit(&key_source, 100).unwrap();
         assert_eq!(new_addresses.len(), 1);
         assert_eq!(new_addresses[0].index, gap_limit);
         assert_eq!(pool.highest_generated, Some(gap_limit));
         assert_eq!(pool.addresses.len(), gap_limit as usize + 1);
+        assert_eq!(pool.sync_ranges.len(), 1);
+        assert_eq!(pool.sync_ranges[0].since_height, 100);
+        assert_eq!(pool.sync_ranges[0].caught_up_to, None);
+        assert_eq!(pool.sync_ranges[0].indexes, gap_limit..(gap_limit + 1));
 
         // Mark address at index 1 and 2 as used
         pool.mark_index_used(1);
         pool.mark_index_used(2);
 
         // Should generate exactly 2 more addresses
-        let new_addresses = pool.maintain_gap_limit(&key_source).unwrap();
+        let new_addresses = pool.maintain_gap_limit(&key_source, 100).unwrap();
         assert_eq!(new_addresses.len(), 2);
         assert_eq!(new_addresses[0].index, gap_limit + 1);
         assert_eq!(new_addresses[1].index, gap_limit + 2);
         assert_eq!(pool.highest_generated, Some(gap_limit + 2));
+        // Two derivations at the same `since_height` collapse into one
+        // contiguous range covering the full extension.
+        assert_eq!(pool.sync_ranges.len(), 1);
+        assert_eq!(pool.sync_ranges[0].indexes, gap_limit..(gap_limit + 3));
+        assert_eq!(pool.sync_ranges[0].since_height, 100);
         assert_eq!(pool.addresses.len(), gap_limit as usize + 3);
     }
 
@@ -1302,5 +1453,95 @@ mod tests {
         assert_eq!(found.len(), 3);
         assert_eq!(pool.used_indices.len(), 3);
         assert_eq!(pool.highest_used, Some(7));
+    }
+
+    #[test]
+    fn test_sync_range_advance_and_drop() {
+        let base_path = DerivationPath::from(vec![ChildNumber::from_normal_idx(0).unwrap()]);
+        let key_source = test_key_source();
+        let gap_limit = 10;
+
+        let mut pool = AddressPool::new(
+            base_path,
+            AddressPoolType::External,
+            gap_limit,
+            Network::Testnet,
+            &key_source,
+        )
+        .unwrap();
+
+        pool.mark_index_used(5);
+        let new_addresses = pool.maintain_gap_limit(&key_source, 100).unwrap();
+        assert!(!new_addresses.is_empty());
+        assert_eq!(pool.sync_ranges.len(), 1);
+        assert_eq!(pool.sync_ranges[0].since_height, 100);
+        assert_eq!(pool.sync_ranges[0].caught_up_to, None);
+
+        pool.advance_caught_up_to(50);
+        assert_eq!(pool.sync_ranges.len(), 1);
+        assert_eq!(pool.sync_ranges[0].caught_up_to, Some(50));
+
+        pool.advance_caught_up_to(99);
+        assert!(
+            pool.sync_ranges.is_empty(),
+            "complete range should be dropped"
+        );
+    }
+
+    #[test]
+    fn test_clamp_caught_up_to() {
+        let base_path = DerivationPath::from(vec![ChildNumber::from_normal_idx(0).unwrap()]);
+        let mut pool = AddressPool::new_without_generation(
+            base_path,
+            AddressPoolType::External,
+            10,
+            Network::Testnet,
+        );
+        pool.sync_ranges.push(AddressSyncRange {
+            indexes: 0..10,
+            since_height: 100,
+            caught_up_to: Some(50),
+        });
+        pool.sync_ranges.push(AddressSyncRange {
+            indexes: 10..20,
+            since_height: 200,
+            caught_up_to: Some(150),
+        });
+
+        pool.clamp_caught_up_to(75);
+        assert_eq!(pool.sync_ranges[0].caught_up_to, Some(50));
+        assert_eq!(pool.sync_ranges[1].caught_up_to, Some(75));
+    }
+
+    #[test]
+    fn test_collapse_adjacent_ranges() {
+        let base_path = DerivationPath::from(vec![ChildNumber::from_normal_idx(0).unwrap()]);
+        let mut pool = AddressPool::new_without_generation(
+            base_path,
+            AddressPoolType::External,
+            10,
+            Network::Testnet,
+        );
+        pool.sync_ranges.push(AddressSyncRange {
+            indexes: 0..10,
+            since_height: 100,
+            caught_up_to: None,
+        });
+        pool.sync_ranges.push(AddressSyncRange {
+            indexes: 10..20,
+            since_height: 100,
+            caught_up_to: None,
+        });
+        pool.collapse_adjacent_ranges();
+        assert_eq!(pool.sync_ranges.len(), 1);
+        assert_eq!(pool.sync_ranges[0].indexes, 0..20);
+
+        pool.sync_ranges.push(AddressSyncRange {
+            indexes: 20..30,
+            since_height: 200,
+            caught_up_to: None,
+        });
+        pool.collapse_adjacent_ranges();
+        assert_eq!(pool.sync_ranges.len(), 2);
     }
 }

--- a/key-wallet/src/managed_account/address_pool.rs
+++ b/key-wallet/src/managed_account/address_pool.rs
@@ -1482,10 +1482,7 @@ mod tests {
         assert_eq!(pool.sync_ranges[0].caught_up_to, Some(50));
 
         pool.advance_caught_up_to(99);
-        assert!(
-            pool.sync_ranges.is_empty(),
-            "complete range should be dropped"
-        );
+        assert!(pool.sync_ranges.is_empty(), "complete range should be dropped");
     }
 
     #[test]
@@ -1581,8 +1578,8 @@ mod tests {
             caught_up_to: Some(900),
         });
 
-        let bytes = bincode::encode_to_vec(&pool, bincode::config::standard())
-            .expect("bincode encode");
+        let bytes =
+            bincode::encode_to_vec(&pool, bincode::config::standard()).expect("bincode encode");
         let (restored, _): (AddressPool, _) =
             bincode::decode_from_slice(&bytes, bincode::config::standard())
                 .expect("bincode decode");

--- a/key-wallet/src/managed_account/address_pool.rs
+++ b/key-wallet/src/managed_account/address_pool.rs
@@ -1544,4 +1544,52 @@ mod tests {
         pool.collapse_adjacent_ranges();
         assert_eq!(pool.sync_ranges.len(), 2);
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn legacy_serde_snapshot_loads_with_empty_sync_ranges() {
+        let base_path = DerivationPath::from(vec![ChildNumber::from_normal_idx(0).unwrap()]);
+        let pool = AddressPool::new_without_generation(
+            base_path,
+            AddressPoolType::External,
+            10,
+            Network::Testnet,
+        );
+
+        let mut value = serde_json::to_value(&pool).unwrap();
+        value.as_object_mut().unwrap().remove("sync_ranges");
+        let restored: AddressPool = serde_json::from_value(value).unwrap();
+        assert!(restored.sync_ranges.is_empty());
+        assert_eq!(restored.gap_limit, pool.gap_limit);
+        assert_eq!(restored.network, pool.network);
+        assert_eq!(restored.pool_type, pool.pool_type);
+    }
+
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn address_pool_bincode_round_trip_preserves_sync_ranges() {
+        let base_path = DerivationPath::from(vec![ChildNumber::from_normal_idx(0).unwrap()]);
+        let mut pool = AddressPool::new_without_generation(
+            base_path,
+            AddressPoolType::External,
+            10,
+            Network::Testnet,
+        );
+        pool.sync_ranges.push(AddressSyncRange {
+            indexes: 5..15,
+            since_height: 1234,
+            caught_up_to: Some(900),
+        });
+
+        let bytes = bincode::encode_to_vec(&pool, bincode::config::standard())
+            .expect("bincode encode");
+        let (restored, _): (AddressPool, _) =
+            bincode::decode_from_slice(&bytes, bincode::config::standard())
+                .expect("bincode decode");
+
+        assert_eq!(restored.sync_ranges.len(), 1);
+        assert_eq!(restored.sync_ranges[0].indexes, 5..15);
+        assert_eq!(restored.sync_ranges[0].since_height, 1234);
+        assert_eq!(restored.sync_ranges[0].caught_up_to, Some(900));
+    }
 }

--- a/key-wallet/src/managed_account/address_pool.rs
+++ b/key-wallet/src/managed_account/address_pool.rs
@@ -320,6 +320,15 @@ impl AddressInfo {
     }
 }
 
+/// Round `since_height` UP to a multiple of this value when pushing a new
+/// `AddressSyncRange`. Closely-spaced gap extensions in the same window then
+/// share `since_height` and merge via `collapse_adjacent_ranges`, keeping the
+/// number of in-flight ranges bounded for active wallets.
+///
+/// Should match `dash-spv::sync::filters::backfill::BACKFILL_CHUNK_SIZE` so
+/// each rounded range aligns with one filter scan chunk.
+const SYNC_RANGE_HEIGHT_BUCKET: CoreBlockHeight = 5_000;
+
 /// A contiguous range of address indexes within a pool, tracking how far the
 /// filters covering them have been scanned.
 ///
@@ -974,17 +983,25 @@ impl AddressPool {
                 .highest_generated
                 .expect("highest_generated must be set after deriving addresses")
                 + 1;
-            // Retroactive derivations (since_height already covered by
-            // forward sync) are born complete so the prune pass discards
-            // them; the addresses were scanned before, no backfill needed.
-            let caught_up_to = if since_height <= wallet_synced_height {
-                Some(since_height.saturating_sub(1))
+            // Round up to the next bucket boundary so closely-spaced gap
+            // extensions share a `since_height` and merge into one range
+            // via `collapse_adjacent_ranges`.
+            let bucket_since_height = match since_height % SYNC_RANGE_HEIGHT_BUCKET {
+                0 => since_height,
+                rem => since_height.saturating_add(SYNC_RANGE_HEIGHT_BUCKET - rem),
+            };
+            // Retroactive derivations (the rounded `since_height` already
+            // covered by forward sync) are born complete so the prune pass
+            // discards them; the addresses were scanned before, no backfill
+            // needed.
+            let caught_up_to = if bucket_since_height <= wallet_synced_height {
+                Some(bucket_since_height.saturating_sub(1))
             } else {
                 None
             };
             self.push_sync_range(AddressSyncRange {
                 indexes: start..end_exclusive,
-                since_height,
+                since_height: bucket_since_height,
                 caught_up_to,
             });
         }
@@ -1404,14 +1421,15 @@ mod tests {
         pool.mark_index_used(0);
         assert_eq!(pool.highest_used, Some(0));
 
-        // Should generate exactly 1 address to maintain gap_limit unused after index 0
+        // Should generate exactly 1 address to maintain gap_limit unused after index 0.
+        // since_height=100 rounds up to 5000 (the bucket boundary).
         let new_addresses = pool.maintain_gap_limit(&key_source, 100, 0).unwrap();
         assert_eq!(new_addresses.len(), 1);
         assert_eq!(new_addresses[0].index, gap_limit);
         assert_eq!(pool.highest_generated, Some(gap_limit));
         assert_eq!(pool.addresses.len(), gap_limit as usize + 1);
         assert_eq!(pool.sync_ranges.len(), 1);
-        assert_eq!(pool.sync_ranges[0].since_height, 100);
+        assert_eq!(pool.sync_ranges[0].since_height, 5000);
         assert_eq!(pool.sync_ranges[0].caught_up_to, None);
         assert_eq!(pool.sync_ranges[0].indexes, gap_limit..(gap_limit + 1));
 
@@ -1425,11 +1443,11 @@ mod tests {
         assert_eq!(new_addresses[0].index, gap_limit + 1);
         assert_eq!(new_addresses[1].index, gap_limit + 2);
         assert_eq!(pool.highest_generated, Some(gap_limit + 2));
-        // Two derivations at the same `since_height` collapse into one
-        // contiguous range covering the full extension.
+        // Two derivations at the same rounded `since_height` collapse into
+        // one contiguous range covering the full extension.
         assert_eq!(pool.sync_ranges.len(), 1);
         assert_eq!(pool.sync_ranges[0].indexes, gap_limit..(gap_limit + 3));
-        assert_eq!(pool.sync_ranges[0].since_height, 100);
+        assert_eq!(pool.sync_ranges[0].since_height, 5000);
         assert_eq!(pool.addresses.len(), gap_limit as usize + 3);
     }
 
@@ -1489,17 +1507,18 @@ mod tests {
         .unwrap();
 
         pool.mark_index_used(5);
+        // since_height=100 rounds up to 5000.
         let new_addresses = pool.maintain_gap_limit(&key_source, 100, 0).unwrap();
         assert!(!new_addresses.is_empty());
         assert_eq!(pool.sync_ranges.len(), 1);
-        assert_eq!(pool.sync_ranges[0].since_height, 100);
+        assert_eq!(pool.sync_ranges[0].since_height, 5000);
         assert_eq!(pool.sync_ranges[0].caught_up_to, None);
 
-        pool.advance_caught_up_to(50);
+        pool.advance_caught_up_to(2500);
         assert_eq!(pool.sync_ranges.len(), 1);
-        assert_eq!(pool.sync_ranges[0].caught_up_to, Some(50));
+        assert_eq!(pool.sync_ranges[0].caught_up_to, Some(2500));
 
-        pool.advance_caught_up_to(99);
+        pool.advance_caught_up_to(4999);
         assert!(pool.sync_ranges.is_empty(), "complete range should be dropped");
     }
 
@@ -1582,7 +1601,10 @@ mod tests {
         .unwrap();
 
         pool.mark_index_used(0);
-        let new_addresses = pool.maintain_gap_limit(&key_source, 100, 200).unwrap();
+        // since_height=5000 (already on the bucket boundary) is below
+        // wallet_synced_height=10000, so the range is born complete and
+        // dropped by the prune pass.
+        let new_addresses = pool.maintain_gap_limit(&key_source, 5000, 10000).unwrap();
         assert!(!new_addresses.is_empty(), "an address must still be derived to maintain the gap");
         assert!(
             pool.sync_ranges.is_empty(),
@@ -1610,14 +1632,74 @@ mod tests {
         .unwrap();
 
         pool.mark_index_used(0);
-        let new_addresses = pool.maintain_gap_limit(&key_source, 200, 100).unwrap();
+        // since_height=10000 (on bucket boundary) is above wallet_synced_height=5000,
+        // so the range is genuinely-new and stays pending.
+        let new_addresses = pool.maintain_gap_limit(&key_source, 10000, 5000).unwrap();
         assert!(!new_addresses.is_empty());
         assert_eq!(pool.sync_ranges.len(), 1);
-        assert_eq!(pool.sync_ranges[0].since_height, 200);
+        assert_eq!(pool.sync_ranges[0].since_height, 10000);
         assert_eq!(
             pool.sync_ranges[0].caught_up_to, None,
             "genuinely-new derivation must have caught_up_to = None so backfill picks it up",
         );
+    }
+
+    /// Two close-but-distinct `since_height` values inside the same bucket
+    /// must round to the same `since_height` and produce a single collapsed
+    /// range. Without rounding, an active wallet's many gap extensions each
+    /// land at slightly different chain heights and accumulate as separate
+    /// ranges that the backfill worker has to track per-tick.
+    #[test]
+    fn maintain_gap_limit_rounds_since_height_up_to_bucket_so_close_extensions_collapse() {
+        let base_path = DerivationPath::from(vec![ChildNumber::from_normal_idx(0).unwrap()]);
+        let key_source = test_key_source();
+        let gap_limit = 5;
+        let mut pool = AddressPool::new(
+            base_path,
+            AddressPoolType::External,
+            gap_limit,
+            Network::Testnet,
+            &key_source,
+        )
+        .unwrap();
+
+        // First extension at since_height=248001 → rounds up to 250000.
+        pool.mark_index_used(0);
+        let derived = pool.maintain_gap_limit(&key_source, 248001, 0).unwrap();
+        assert!(!derived.is_empty());
+        let first_extension_top = pool.highest_generated.unwrap();
+        assert_eq!(pool.sync_ranges.len(), 1);
+        assert_eq!(pool.sync_ranges[0].since_height, 250000);
+        assert_eq!(pool.sync_ranges[0].caught_up_to, None);
+        let first_indexes = pool.sync_ranges[0].indexes.clone();
+
+        // Second extension at since_height=248050 → also rounds up to 250000,
+        // and the contiguous index range merges with the first via collapse.
+        pool.mark_index_used(first_extension_top);
+        let derived = pool.maintain_gap_limit(&key_source, 248050, 0).unwrap();
+        assert!(!derived.is_empty());
+        let second_extension_top = pool.highest_generated.unwrap();
+        assert_eq!(
+            pool.sync_ranges.len(),
+            1,
+            "extensions at different heights inside one bucket must collapse, got {:?}",
+            pool.sync_ranges,
+        );
+        assert_eq!(pool.sync_ranges[0].since_height, 250000);
+        assert_eq!(pool.sync_ranges[0].indexes.start, first_indexes.start);
+        assert_eq!(pool.sync_ranges[0].indexes.end, second_extension_top + 1);
+        assert_eq!(pool.sync_ranges[0].caught_up_to, None);
+
+        // A third extension landing in the NEXT bucket stays separate.
+        pool.mark_index_used(second_extension_top);
+        pool.maintain_gap_limit(&key_source, 251000, 0).unwrap();
+        assert_eq!(
+            pool.sync_ranges.len(),
+            2,
+            "extension in the next bucket must not merge into the prior one, got {:?}",
+            pool.sync_ranges,
+        );
+        assert_eq!(pool.sync_ranges[1].since_height, 255000);
     }
 
     #[cfg(feature = "serde")]

--- a/key-wallet/src/managed_account/address_pool.rs
+++ b/key-wallet/src/managed_account/address_pool.rs
@@ -928,10 +928,20 @@ impl AddressPool {
     /// `since_height` were scanned without these addresses in the query set,
     /// so a pending [`AddressSyncRange`] is recorded for the backfill worker
     /// to revisit them.
+    ///
+    /// `wallet_synced_height` is the wallet's current forward-edge watermark.
+    /// When `since_height <= wallet_synced_height`, the gap-limit derivation
+    /// is retroactive (running during snapshot replay or block reprocessing
+    /// for heights the wallet has already covered), so the recorded range is
+    /// born complete and the prune pass discards it on insert. Without this
+    /// guard, an active wallet's startup replay would manufacture dozens of
+    /// "pending" ranges that the backfill worker then re-scans from
+    /// `birth_height` even though the addresses were already covered.
     pub fn maintain_gap_limit(
         &mut self,
         key_source: &KeySource,
         since_height: CoreBlockHeight,
+        wallet_synced_height: CoreBlockHeight,
     ) -> Result<Vec<AddressInfo>> {
         let target = match self.highest_used {
             None => self.gap_limit - 1,
@@ -964,10 +974,18 @@ impl AddressPool {
                 .highest_generated
                 .expect("highest_generated must be set after deriving addresses")
                 + 1;
+            // Retroactive derivations (since_height already covered by
+            // forward sync) are born complete so the prune pass discards
+            // them; the addresses were scanned before, no backfill needed.
+            let caught_up_to = if since_height <= wallet_synced_height {
+                Some(since_height.saturating_sub(1))
+            } else {
+                None
+            };
             self.push_sync_range(AddressSyncRange {
                 indexes: start..end_exclusive,
                 since_height,
-                caught_up_to: None,
+                caught_up_to,
             });
         }
 
@@ -1376,7 +1394,7 @@ mod tests {
         assert_eq!(pool.addresses.len(), gap_limit as usize);
 
         // Calling maintain_gap_limit should not generate any new addresses when none are used
-        let new_addresses = pool.maintain_gap_limit(&key_source, 0).unwrap();
+        let new_addresses = pool.maintain_gap_limit(&key_source, 0, 0).unwrap();
         assert_eq!(new_addresses.len(), 0);
         assert_eq!(pool.highest_generated, Some(gap_limit - 1));
         assert_eq!(pool.addresses.len(), gap_limit as usize);
@@ -1387,7 +1405,7 @@ mod tests {
         assert_eq!(pool.highest_used, Some(0));
 
         // Should generate exactly 1 address to maintain gap_limit unused after index 0
-        let new_addresses = pool.maintain_gap_limit(&key_source, 100).unwrap();
+        let new_addresses = pool.maintain_gap_limit(&key_source, 100, 0).unwrap();
         assert_eq!(new_addresses.len(), 1);
         assert_eq!(new_addresses[0].index, gap_limit);
         assert_eq!(pool.highest_generated, Some(gap_limit));
@@ -1402,7 +1420,7 @@ mod tests {
         pool.mark_index_used(2);
 
         // Should generate exactly 2 more addresses
-        let new_addresses = pool.maintain_gap_limit(&key_source, 100).unwrap();
+        let new_addresses = pool.maintain_gap_limit(&key_source, 100, 0).unwrap();
         assert_eq!(new_addresses.len(), 2);
         assert_eq!(new_addresses[0].index, gap_limit + 1);
         assert_eq!(new_addresses[1].index, gap_limit + 2);
@@ -1471,7 +1489,7 @@ mod tests {
         .unwrap();
 
         pool.mark_index_used(5);
-        let new_addresses = pool.maintain_gap_limit(&key_source, 100).unwrap();
+        let new_addresses = pool.maintain_gap_limit(&key_source, 100, 0).unwrap();
         assert!(!new_addresses.is_empty());
         assert_eq!(pool.sync_ranges.len(), 1);
         assert_eq!(pool.sync_ranges[0].since_height, 100);
@@ -1540,6 +1558,66 @@ mod tests {
         });
         pool.collapse_adjacent_ranges();
         assert_eq!(pool.sync_ranges.len(), 2);
+    }
+
+    /// On snapshot replay or block reprocessing, `maintain_gap_limit` may
+    /// derive new addresses for a height the wallet's `synced_height` is
+    /// already past. The resulting sync range covers already-scanned
+    /// territory and must be born complete so the prune pass discards it
+    /// on insert; otherwise the backfill worker re-scans dozens of ranges
+    /// that cover already-covered heights (the reported snapshot-replay
+    /// regression on active wallets).
+    #[test]
+    fn maintain_gap_limit_born_complete_when_retroactive() {
+        let base_path = DerivationPath::from(vec![ChildNumber::from_normal_idx(0).unwrap()]);
+        let key_source = test_key_source();
+        let gap_limit = 5;
+        let mut pool = AddressPool::new(
+            base_path,
+            AddressPoolType::External,
+            gap_limit,
+            Network::Testnet,
+            &key_source,
+        )
+        .unwrap();
+
+        pool.mark_index_used(0);
+        let new_addresses = pool.maintain_gap_limit(&key_source, 100, 200).unwrap();
+        assert!(!new_addresses.is_empty(), "an address must still be derived to maintain the gap");
+        assert!(
+            pool.sync_ranges.is_empty(),
+            "retroactive derivation must be born complete and dropped on insert, got {:?}",
+            pool.sync_ranges,
+        );
+    }
+
+    /// When the wallet's `synced_height` is below `since_height`, the new
+    /// addresses joined the monitored set genuinely-new and the recorded
+    /// range must remain pending so the backfill worker scans
+    /// `[birth..since-1]` against the new address set.
+    #[test]
+    fn maintain_gap_limit_pending_when_forward_sync() {
+        let base_path = DerivationPath::from(vec![ChildNumber::from_normal_idx(0).unwrap()]);
+        let key_source = test_key_source();
+        let gap_limit = 5;
+        let mut pool = AddressPool::new(
+            base_path,
+            AddressPoolType::External,
+            gap_limit,
+            Network::Testnet,
+            &key_source,
+        )
+        .unwrap();
+
+        pool.mark_index_used(0);
+        let new_addresses = pool.maintain_gap_limit(&key_source, 200, 100).unwrap();
+        assert!(!new_addresses.is_empty());
+        assert_eq!(pool.sync_ranges.len(), 1);
+        assert_eq!(pool.sync_ranges[0].since_height, 200);
+        assert_eq!(
+            pool.sync_ranges[0].caught_up_to, None,
+            "genuinely-new derivation must have caught_up_to = None so backfill picks it up",
+        );
     }
 
     #[cfg(feature = "serde")]

--- a/key-wallet/src/managed_account/managed_platform_account.rs
+++ b/key-wallet/src/managed_account/managed_platform_account.rs
@@ -96,12 +96,15 @@ impl ManagedPlatformAccount {
     /// and a `KeySource` is provided, the address will be marked as used
     /// and the gap limit will be maintained. `since_height` is the chain
     /// height used as the floor for any newly recorded sync range.
+    /// `wallet_synced_height` is the wallet's forward-edge watermark used
+    /// to detect retroactive derivations.
     pub fn set_address_credit_balance(
         &mut self,
         address: PlatformP2PKHAddress,
         credit_balance: u64,
         key_source: Option<&KeySource>,
         since_height: CoreBlockHeight,
+        wallet_synced_height: CoreBlockHeight,
     ) {
         let old_balance = self.address_balances.get(&address).copied().unwrap_or(0);
         let was_unfunded = old_balance == 0;
@@ -115,7 +118,7 @@ impl ManagedPlatformAccount {
         // If address became funded and we have a key source, update address pool
         if was_unfunded && is_now_funded {
             if let Some(ks) = key_source {
-                self.mark_and_maintain_gap_limit(&address, ks, since_height);
+                self.mark_and_maintain_gap_limit(&address, ks, since_height, wallet_synced_height);
             }
         }
     }
@@ -127,12 +130,15 @@ impl ManagedPlatformAccount {
     /// and a `KeySource` is provided, the address will be marked as used
     /// and the gap limit will be maintained. `since_height` is the chain
     /// height used as the floor for any newly recorded sync range.
+    /// `wallet_synced_height` is the wallet's forward-edge watermark used
+    /// to detect retroactive derivations.
     pub fn add_address_credit_balance(
         &mut self,
         address: PlatformP2PKHAddress,
         amount: u64,
         key_source: Option<&KeySource>,
         since_height: CoreBlockHeight,
+        wallet_synced_height: CoreBlockHeight,
     ) -> u64 {
         let current = self.address_balances.get(&address).copied().unwrap_or(0);
         let was_unfunded = current == 0;
@@ -146,7 +152,7 @@ impl ManagedPlatformAccount {
         // If address became funded and we have a key source, update address pool
         if was_unfunded && is_now_funded {
             if let Some(ks) = key_source {
-                self.mark_and_maintain_gap_limit(&address, ks, since_height);
+                self.mark_and_maintain_gap_limit(&address, ks, since_height, wallet_synced_height);
             }
         }
 
@@ -270,13 +276,14 @@ impl ManagedPlatformAccount {
         address: &PlatformP2PKHAddress,
         key_source: &KeySource,
         since_height: CoreBlockHeight,
+        wallet_synced_height: CoreBlockHeight,
     ) {
         // Mark the address as used
         self.mark_platform_address_used(address);
 
         // Maintain gap limit - generate new addresses if needed
         // We ignore errors here since this is a best-effort operation
-        let _ = self.addresses.maintain_gap_limit(key_source, since_height);
+        let _ = self.addresses.maintain_gap_limit(key_source, since_height, wallet_synced_height);
     }
 
     /// Maintain the gap limit for the address pool
@@ -287,9 +294,10 @@ impl ManagedPlatformAccount {
         &mut self,
         key_source: &KeySource,
         since_height: CoreBlockHeight,
+        wallet_synced_height: CoreBlockHeight,
     ) -> Result<Vec<AddressInfo>> {
         self.addresses
-            .maintain_gap_limit(key_source, since_height)
+            .maintain_gap_limit(key_source, since_height, wallet_synced_height)
             .map_err(|e| Error::InvalidParameter(format!("Failed to maintain gap limit: {}", e)))
     }
 
@@ -425,19 +433,19 @@ mod tests {
 
         // Set address credit balance (this also updates total)
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 500, None, 0);
+        account.set_address_credit_balance(addr, 500, None, 0, 0);
         assert_eq!(account.address_credit_balance(&addr), 500);
         assert_eq!(account.total_credit_balance(), 500);
         assert_eq!(account.duff_balance(), 0); // 500 credits = 0 duffs (integer division)
 
         // Add to address credit balance
-        let new_balance = account.add_address_credit_balance(addr, 500, None, 0);
+        let new_balance = account.add_address_credit_balance(addr, 500, None, 0, 0);
         assert_eq!(new_balance, 1000);
         assert_eq!(account.total_credit_balance(), 1000);
         assert_eq!(account.duff_balance(), 1); // 1000 credits = 1 duff
 
         // Add more
-        let new_balance = account.add_address_credit_balance(addr, 200, None, 0);
+        let new_balance = account.add_address_credit_balance(addr, 200, None, 0, 0);
         assert_eq!(new_balance, 1200);
         assert_eq!(account.total_credit_balance(), 1200);
 
@@ -447,7 +455,7 @@ mod tests {
         assert_eq!(account.total_credit_balance(), 1100);
 
         // Update address balance directly (replacing existing)
-        account.set_address_credit_balance(addr, 600, None, 0);
+        account.set_address_credit_balance(addr, 600, None, 0, 0);
         assert_eq!(account.address_credit_balance(&addr), 600);
         assert_eq!(account.total_credit_balance(), 600);
     }
@@ -502,15 +510,15 @@ mod tests {
         let addr2 = PlatformP2PKHAddress::new([0x22; 20]);
         let addr3 = PlatformP2PKHAddress::new([0x33; 20]);
 
-        account.set_address_credit_balance(addr1, 100, None, 0);
-        account.set_address_credit_balance(addr2, 200, None, 0);
-        account.set_address_credit_balance(addr3, 300, None, 0);
+        account.set_address_credit_balance(addr1, 100, None, 0, 0);
+        account.set_address_credit_balance(addr2, 200, None, 0, 0);
+        account.set_address_credit_balance(addr3, 300, None, 0, 0);
 
         assert_eq!(account.total_credit_balance(), 600);
         assert_eq!(account.funded_address_count(), 3);
 
         // Set one to zero
-        account.set_address_credit_balance(addr2, 0, None, 0);
+        account.set_address_credit_balance(addr2, 0, None, 0, 0);
         assert_eq!(account.total_credit_balance(), 400);
         assert_eq!(account.funded_address_count(), 2);
     }
@@ -521,7 +529,7 @@ mod tests {
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
 
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 1000, None, 0);
+        account.set_address_credit_balance(addr, 1000, None, 0, 0);
 
         account.clear_balances();
         assert_eq!(account.total_credit_balance(), 0);
@@ -537,9 +545,9 @@ mod tests {
         let addr2 = PlatformP2PKHAddress::new([0x22; 20]);
         let addr3 = PlatformP2PKHAddress::new([0x33; 20]);
 
-        account.set_address_credit_balance(addr1, 100, None, 0);
-        account.set_address_credit_balance(addr2, 0, None, 0); // Zero balance
-        account.set_address_credit_balance(addr3, 300, None, 0);
+        account.set_address_credit_balance(addr1, 100, None, 0, 0);
+        account.set_address_credit_balance(addr2, 0, None, 0, 0); // Zero balance
+        account.set_address_credit_balance(addr3, 300, None, 0, 0);
 
         let funded = account.funded_addresses();
         assert_eq!(funded.len(), 2);
@@ -559,7 +567,7 @@ mod tests {
         assert!(!account.address_balances.contains_key(&addr));
 
         // Add to balances
-        account.set_address_credit_balance(addr, 100, None, 0);
+        account.set_address_credit_balance(addr, 100, None, 0, 0);
         assert!(account.contains_platform_address(&addr));
     }
 }

--- a/key-wallet/src/managed_account/managed_platform_account.rs
+++ b/key-wallet/src/managed_account/managed_platform_account.rs
@@ -15,6 +15,7 @@ use super::address_pool::{AddressInfo, AddressPool, KeySource};
 use super::platform_address::PlatformP2PKHAddress;
 use crate::error::{Error, Result};
 use crate::Network;
+use dashcore::prelude::CoreBlockHeight;
 use dashcore::Address;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -93,12 +94,14 @@ impl ManagedPlatformAccount {
     /// This also updates the total balance by applying the delta.
     /// If the address was previously unfunded (balance 0) and becomes funded,
     /// and a `KeySource` is provided, the address will be marked as used
-    /// and the gap limit will be maintained.
+    /// and the gap limit will be maintained. `since_height` is the chain
+    /// height used as the floor for any newly recorded sync range.
     pub fn set_address_credit_balance(
         &mut self,
         address: PlatformP2PKHAddress,
         credit_balance: u64,
         key_source: Option<&KeySource>,
+        since_height: CoreBlockHeight,
     ) {
         let old_balance = self.address_balances.get(&address).copied().unwrap_or(0);
         let was_unfunded = old_balance == 0;
@@ -112,7 +115,7 @@ impl ManagedPlatformAccount {
         // If address became funded and we have a key source, update address pool
         if was_unfunded && is_now_funded {
             if let Some(ks) = key_source {
-                self.mark_and_maintain_gap_limit(&address, ks);
+                self.mark_and_maintain_gap_limit(&address, ks, since_height);
             }
         }
     }
@@ -122,12 +125,14 @@ impl ManagedPlatformAccount {
     /// Returns the new credit balance for the address.
     /// If the address was previously unfunded (balance 0) and becomes funded,
     /// and a `KeySource` is provided, the address will be marked as used
-    /// and the gap limit will be maintained.
+    /// and the gap limit will be maintained. `since_height` is the chain
+    /// height used as the floor for any newly recorded sync range.
     pub fn add_address_credit_balance(
         &mut self,
         address: PlatformP2PKHAddress,
         amount: u64,
         key_source: Option<&KeySource>,
+        since_height: CoreBlockHeight,
     ) -> u64 {
         let current = self.address_balances.get(&address).copied().unwrap_or(0);
         let was_unfunded = current == 0;
@@ -141,7 +146,7 @@ impl ManagedPlatformAccount {
         // If address became funded and we have a key source, update address pool
         if was_unfunded && is_now_funded {
             if let Some(ks) = key_source {
-                self.mark_and_maintain_gap_limit(&address, ks);
+                self.mark_and_maintain_gap_limit(&address, ks, since_height);
             }
         }
 
@@ -264,22 +269,27 @@ impl ManagedPlatformAccount {
         &mut self,
         address: &PlatformP2PKHAddress,
         key_source: &KeySource,
+        since_height: CoreBlockHeight,
     ) {
         // Mark the address as used
         self.mark_platform_address_used(address);
 
         // Maintain gap limit - generate new addresses if needed
         // We ignore errors here since this is a best-effort operation
-        let _ = self.addresses.maintain_gap_limit(key_source);
+        let _ = self.addresses.maintain_gap_limit(key_source, since_height);
     }
 
     /// Maintain the gap limit for the address pool
     ///
     /// This generates new addresses if needed to maintain the gap limit.
     /// Returns the newly generated address info entries (in derivation order).
-    pub fn maintain_gap_limit(&mut self, key_source: &KeySource) -> Result<Vec<AddressInfo>> {
+    pub fn maintain_gap_limit(
+        &mut self,
+        key_source: &KeySource,
+        since_height: CoreBlockHeight,
+    ) -> Result<Vec<AddressInfo>> {
         self.addresses
-            .maintain_gap_limit(key_source)
+            .maintain_gap_limit(key_source, since_height)
             .map_err(|e| Error::InvalidParameter(format!("Failed to maintain gap limit: {}", e)))
     }
 
@@ -415,19 +425,19 @@ mod tests {
 
         // Set address credit balance (this also updates total)
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 500, None);
+        account.set_address_credit_balance(addr, 500, None, 0);
         assert_eq!(account.address_credit_balance(&addr), 500);
         assert_eq!(account.total_credit_balance(), 500);
         assert_eq!(account.duff_balance(), 0); // 500 credits = 0 duffs (integer division)
 
         // Add to address credit balance
-        let new_balance = account.add_address_credit_balance(addr, 500, None);
+        let new_balance = account.add_address_credit_balance(addr, 500, None, 0);
         assert_eq!(new_balance, 1000);
         assert_eq!(account.total_credit_balance(), 1000);
         assert_eq!(account.duff_balance(), 1); // 1000 credits = 1 duff
 
         // Add more
-        let new_balance = account.add_address_credit_balance(addr, 200, None);
+        let new_balance = account.add_address_credit_balance(addr, 200, None, 0);
         assert_eq!(new_balance, 1200);
         assert_eq!(account.total_credit_balance(), 1200);
 
@@ -437,7 +447,7 @@ mod tests {
         assert_eq!(account.total_credit_balance(), 1100);
 
         // Update address balance directly (replacing existing)
-        account.set_address_credit_balance(addr, 600, None);
+        account.set_address_credit_balance(addr, 600, None, 0);
         assert_eq!(account.address_credit_balance(&addr), 600);
         assert_eq!(account.total_credit_balance(), 600);
     }
@@ -492,15 +502,15 @@ mod tests {
         let addr2 = PlatformP2PKHAddress::new([0x22; 20]);
         let addr3 = PlatformP2PKHAddress::new([0x33; 20]);
 
-        account.set_address_credit_balance(addr1, 100, None);
-        account.set_address_credit_balance(addr2, 200, None);
-        account.set_address_credit_balance(addr3, 300, None);
+        account.set_address_credit_balance(addr1, 100, None, 0);
+        account.set_address_credit_balance(addr2, 200, None, 0);
+        account.set_address_credit_balance(addr3, 300, None, 0);
 
         assert_eq!(account.total_credit_balance(), 600);
         assert_eq!(account.funded_address_count(), 3);
 
         // Set one to zero
-        account.set_address_credit_balance(addr2, 0, None);
+        account.set_address_credit_balance(addr2, 0, None, 0);
         assert_eq!(account.total_credit_balance(), 400);
         assert_eq!(account.funded_address_count(), 2);
     }
@@ -511,7 +521,7 @@ mod tests {
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
 
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 1000, None);
+        account.set_address_credit_balance(addr, 1000, None, 0);
 
         account.clear_balances();
         assert_eq!(account.total_credit_balance(), 0);
@@ -527,9 +537,9 @@ mod tests {
         let addr2 = PlatformP2PKHAddress::new([0x22; 20]);
         let addr3 = PlatformP2PKHAddress::new([0x33; 20]);
 
-        account.set_address_credit_balance(addr1, 100, None);
-        account.set_address_credit_balance(addr2, 0, None); // Zero balance
-        account.set_address_credit_balance(addr3, 300, None);
+        account.set_address_credit_balance(addr1, 100, None, 0);
+        account.set_address_credit_balance(addr2, 0, None, 0); // Zero balance
+        account.set_address_credit_balance(addr3, 300, None, 0);
 
         let funded = account.funded_addresses();
         assert_eq!(funded.len(), 2);
@@ -549,7 +559,7 @@ mod tests {
         assert!(!account.address_balances.contains_key(&addr));
 
         // Add to balances
-        account.set_address_credit_balance(addr, 100, None);
+        account.set_address_credit_balance(addr, 100, None, 0);
         assert!(account.contains_platform_address(&addr));
     }
 }

--- a/key-wallet/src/tests/performance_tests.rs
+++ b/key-wallet/src/tests/performance_tests.rs
@@ -349,7 +349,7 @@ fn test_gap_limit_scan_performance() {
 
     // Scan for gap limit
     let start = Instant::now();
-    pool.maintain_gap_limit(&key_source, 0).unwrap();
+    pool.maintain_gap_limit(&key_source, 0, 0).unwrap();
     let elapsed = start.elapsed();
 
     // Assert gap limit maintenance performance

--- a/key-wallet/src/tests/performance_tests.rs
+++ b/key-wallet/src/tests/performance_tests.rs
@@ -349,7 +349,7 @@ fn test_gap_limit_scan_performance() {
 
     // Scan for gap limit
     let start = Instant::now();
-    pool.maintain_gap_limit(&key_source).unwrap();
+    pool.maintain_gap_limit(&key_source, 0).unwrap();
     let elapsed = start.elapsed();
 
     // Assert gap limit maintenance performance

--- a/key-wallet/src/transaction_checking/platform_checker.rs
+++ b/key-wallet/src/transaction_checking/platform_checker.rs
@@ -119,6 +119,7 @@ impl WalletPlatformChecker for ManagedWalletInfo {
                     credit_balance,
                     key_source,
                     since_height,
+                    since_height,
                 );
                 return true;
             }
@@ -139,7 +140,13 @@ impl WalletPlatformChecker for ManagedWalletInfo {
             if !account.contains_platform_address(&address) {
                 return false;
             }
-            account.set_address_credit_balance(address, credit_balance, key_source, since_height);
+            account.set_address_credit_balance(
+                address,
+                credit_balance,
+                key_source,
+                since_height,
+                since_height,
+            );
             true
         } else {
             false
@@ -155,8 +162,13 @@ impl WalletPlatformChecker for ManagedWalletInfo {
         let since_height = self.metadata.birth_height;
         for account in self.accounts.platform_payment_accounts.values_mut() {
             if account.contains_platform_address(address) {
-                let new_balance =
-                    account.add_address_credit_balance(*address, amount, key_source, since_height);
+                let new_balance = account.add_address_credit_balance(
+                    *address,
+                    amount,
+                    key_source,
+                    since_height,
+                    since_height,
+                );
                 return Some(new_balance);
             }
         }
@@ -176,8 +188,13 @@ impl WalletPlatformChecker for ManagedWalletInfo {
             if !account.contains_platform_address(&address) {
                 return None;
             }
-            let new_balance =
-                account.add_address_credit_balance(address, amount, key_source, since_height);
+            let new_balance = account.add_address_credit_balance(
+                address,
+                amount,
+                key_source,
+                since_height,
+                since_height,
+            );
             Some(new_balance)
         } else {
             None
@@ -255,7 +272,7 @@ mod tests {
 
         // Add some balance
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 5000, None, 0);
+        account.set_address_credit_balance(addr, 5000, None, 0, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,
@@ -275,13 +292,13 @@ mod tests {
         let pool1 = create_test_pool();
         let mut account1 = ManagedPlatformAccount::new(0, 0, pool1, false);
         let addr1 = PlatformP2PKHAddress::new([0x11; 20]);
-        account1.set_address_credit_balance(addr1, 3000, None, 0);
+        account1.set_address_credit_balance(addr1, 3000, None, 0, 0);
 
         // Create second platform account
         let pool2 = create_test_pool();
         let mut account2 = ManagedPlatformAccount::new(1, 0, pool2, false);
         let addr2 = PlatformP2PKHAddress::new([0x22; 20]);
-        account2.set_address_credit_balance(addr2, 2000, None, 0);
+        account2.set_address_credit_balance(addr2, 2000, None, 0, 0);
 
         wallet_info.accounts.platform_payment_accounts.insert(
             PlatformPaymentAccountKey {
@@ -310,7 +327,7 @@ mod tests {
         let pool = create_test_pool();
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 1000, None, 0);
+        account.set_address_credit_balance(addr, 1000, None, 0, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,
@@ -337,7 +354,7 @@ mod tests {
         let pool = create_test_pool();
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 1000, None, 0);
+        account.set_address_credit_balance(addr, 1000, None, 0, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,
@@ -364,7 +381,7 @@ mod tests {
         let pool = create_test_pool();
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 5000, None, 0);
+        account.set_address_credit_balance(addr, 5000, None, 0, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,
@@ -389,7 +406,7 @@ mod tests {
         let pool = create_test_pool();
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 3000, None, 0);
+        account.set_address_credit_balance(addr, 3000, None, 0, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,
@@ -416,7 +433,7 @@ mod tests {
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
         // First set initial balance so the address is known to the account
-        account.set_address_credit_balance(addr, 1000, None, 0);
+        account.set_address_credit_balance(addr, 1000, None, 0, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,

--- a/key-wallet/src/transaction_checking/platform_checker.rs
+++ b/key-wallet/src/transaction_checking/platform_checker.rs
@@ -108,10 +108,18 @@ impl WalletPlatformChecker for ManagedWalletInfo {
         credit_balance: u64,
         key_source: Option<&KeySource>,
     ) -> bool {
-        // Find the account that contains this address
+        // Platform call sites have no block height in scope; the wallet's
+        // birth height is the safest floor for any sync range produced by
+        // gap-limit extension here.
+        let since_height = self.metadata.birth_height;
         for account in self.accounts.platform_payment_accounts.values_mut() {
             if account.contains_platform_address(address) {
-                account.set_address_credit_balance(*address, credit_balance, key_source);
+                account.set_address_credit_balance(
+                    *address,
+                    credit_balance,
+                    key_source,
+                    since_height,
+                );
                 return true;
             }
         }
@@ -125,12 +133,13 @@ impl WalletPlatformChecker for ManagedWalletInfo {
         credit_balance: u64,
         key_source: Option<&KeySource>,
     ) -> bool {
+        let since_height = self.metadata.birth_height;
         if let Some(account) = self.accounts.platform_payment_accounts.get_mut(account_key) {
             // Verify the address belongs to this account before modifying
             if !account.contains_platform_address(&address) {
                 return false;
             }
-            account.set_address_credit_balance(address, credit_balance, key_source);
+            account.set_address_credit_balance(address, credit_balance, key_source, since_height);
             true
         } else {
             false
@@ -143,10 +152,11 @@ impl WalletPlatformChecker for ManagedWalletInfo {
         amount: u64,
         key_source: Option<&KeySource>,
     ) -> Option<u64> {
-        // Find the account that contains this address
+        let since_height = self.metadata.birth_height;
         for account in self.accounts.platform_payment_accounts.values_mut() {
             if account.contains_platform_address(address) {
-                let new_balance = account.add_address_credit_balance(*address, amount, key_source);
+                let new_balance =
+                    account.add_address_credit_balance(*address, amount, key_source, since_height);
                 return Some(new_balance);
             }
         }
@@ -160,12 +170,14 @@ impl WalletPlatformChecker for ManagedWalletInfo {
         amount: u64,
         key_source: Option<&KeySource>,
     ) -> Option<u64> {
+        let since_height = self.metadata.birth_height;
         if let Some(account) = self.accounts.platform_payment_accounts.get_mut(account_key) {
             // Verify the address belongs to this account before modifying
             if !account.contains_platform_address(&address) {
                 return None;
             }
-            let new_balance = account.add_address_credit_balance(address, amount, key_source);
+            let new_balance =
+                account.add_address_credit_balance(address, amount, key_source, since_height);
             Some(new_balance)
         } else {
             None
@@ -243,7 +255,7 @@ mod tests {
 
         // Add some balance
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 5000, None);
+        account.set_address_credit_balance(addr, 5000, None, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,
@@ -263,13 +275,13 @@ mod tests {
         let pool1 = create_test_pool();
         let mut account1 = ManagedPlatformAccount::new(0, 0, pool1, false);
         let addr1 = PlatformP2PKHAddress::new([0x11; 20]);
-        account1.set_address_credit_balance(addr1, 3000, None);
+        account1.set_address_credit_balance(addr1, 3000, None, 0);
 
         // Create second platform account
         let pool2 = create_test_pool();
         let mut account2 = ManagedPlatformAccount::new(1, 0, pool2, false);
         let addr2 = PlatformP2PKHAddress::new([0x22; 20]);
-        account2.set_address_credit_balance(addr2, 2000, None);
+        account2.set_address_credit_balance(addr2, 2000, None, 0);
 
         wallet_info.accounts.platform_payment_accounts.insert(
             PlatformPaymentAccountKey {
@@ -298,7 +310,7 @@ mod tests {
         let pool = create_test_pool();
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 1000, None);
+        account.set_address_credit_balance(addr, 1000, None, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,
@@ -325,7 +337,7 @@ mod tests {
         let pool = create_test_pool();
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 1000, None);
+        account.set_address_credit_balance(addr, 1000, None, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,
@@ -352,7 +364,7 @@ mod tests {
         let pool = create_test_pool();
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 5000, None);
+        account.set_address_credit_balance(addr, 5000, None, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,
@@ -377,7 +389,7 @@ mod tests {
         let pool = create_test_pool();
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
-        account.set_address_credit_balance(addr, 3000, None);
+        account.set_address_credit_balance(addr, 3000, None, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,
@@ -404,7 +416,7 @@ mod tests {
         let mut account = ManagedPlatformAccount::new(0, 0, pool, false);
         let addr = PlatformP2PKHAddress::new([0x11; 20]);
         // First set initial balance so the address is known to the account
-        account.set_address_credit_balance(addr, 1000, None);
+        account.set_address_credit_balance(addr, 1000, None, 0);
 
         let key = PlatformPaymentAccountKey {
             account: 0,

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -56,6 +56,19 @@ impl WalletTransactionChecker for ManagedWalletInfo {
         // Classify the transaction
         let tx_type = TransactionRouter::classify_transaction(tx);
 
+        // Floor used for new sync ranges when this transaction triggers
+        // gap-limit extension. For confirmed contexts the block height is
+        // exact; mempool / IS-only contexts use `last_processed_height + 1`
+        // since the address must be scanned from the next block forward.
+        let since_height = match &context {
+            TransactionContext::InBlock(info) | TransactionContext::InChainLockedBlock(info) => {
+                info.height()
+            }
+            TransactionContext::Mempool | TransactionContext::InstantSend(_) => {
+                self.last_processed_height().saturating_add(1)
+            }
+        };
+
         // Get relevant account types for this transaction type
         let relevant_types = TransactionRouter::get_relevant_account_types(&tx_type);
 
@@ -190,7 +203,7 @@ impl WalletTransactionChecker for ManagedWalletInfo {
             let owning_account_type = account.managed_account_type().to_account_type();
             for pool in account.managed_account_type_mut().address_pools_mut() {
                 let pool_type = pool.pool_type;
-                match pool.maintain_gap_limit(&key_source) {
+                match pool.maintain_gap_limit(&key_source, since_height) {
                     Ok(infos) => result.new_addresses.extend(infos.into_iter().map(|info| {
                         super::account_checker::DerivedAddressInfo {
                             account_type: owning_account_type,

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -160,7 +160,14 @@ impl WalletTransactionChecker for ManagedWalletInfo {
             }
         }
 
-        // Process each affected account
+        // Process each affected account. Snapshot `synced_height` once
+        // before taking the mutable account borrow inside the loop so the
+        // borrow checker accepts both the read on `self` and the mutable
+        // walk over `self.accounts`. The value is also stable across this
+        // batch — `synced_height` is only mutated via `update_synced_height`,
+        // which the loop does not invoke.
+        let wallet_synced_height = self.synced_height();
+
         for account_match in result.affected_accounts.clone() {
             let Some(mut account) =
                 self.accounts.get_by_account_type_match_mut(&account_match.account_type_match)
@@ -203,7 +210,7 @@ impl WalletTransactionChecker for ManagedWalletInfo {
             let owning_account_type = account.managed_account_type().to_account_type();
             for pool in account.managed_account_type_mut().address_pools_mut() {
                 let pool_type = pool.pool_type;
-                match pool.maintain_gap_limit(&key_source, since_height) {
+                match pool.maintain_gap_limit(&key_source, since_height, wallet_synced_height) {
                     Ok(infos) => result.new_addresses.extend(infos.into_iter().map(|info| {
                         super::account_checker::DerivedAddressInfo {
                             account_type: owning_account_type,

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -100,7 +100,46 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     fn last_processed_height(&self) -> CoreBlockHeight;
 
     /// Return the durable wallet sync checkpoint height.
+    ///
+    /// This is the strictly monotonic forward edge advanced by forward
+    /// sync. Pair it with [`Self::convergence_height`] when a consumer
+    /// needs the looser "everything below this is final" semantics.
     fn synced_height(&self) -> CoreBlockHeight;
+
+    /// Highest height at which every currently-monitored address has been
+    /// scanned.
+    ///
+    /// Returns `Some(synced_height)` when no sync ranges are pending.
+    /// Otherwise returns the minimum of `synced_height` and the lowest
+    /// `caught_up_to.unwrap_or(birth_height.saturating_sub(1))` across all
+    /// pending ranges.
+    ///
+    /// Unlike [`Self::synced_height`], this value is **not monotonic**: it
+    /// drops when a new sync range is created (e.g. via gap-limit
+    /// extension) and rises as the backfill worker catches up.
+    fn convergence_height(&self) -> Option<CoreBlockHeight> {
+        let synced = self.synced_height();
+        let birth = self.birth_height();
+        let mut min_progress: Option<CoreBlockHeight> = None;
+
+        for account in self.accounts().all_accounts() {
+            for pool in account.managed_account_type().address_pools() {
+                for range in pool.pending_sync_ranges() {
+                    let progress =
+                        range.caught_up_to.unwrap_or_else(|| birth.saturating_sub(1));
+                    min_progress = Some(match min_progress {
+                        Some(m) => m.min(progress),
+                        None => progress,
+                    });
+                }
+            }
+        }
+
+        match min_progress {
+            Some(p) => Some(synced.min(p)),
+            None => Some(synced),
+        }
+    }
 
     /// Update chain state and process any matured transactions
     /// This should be called when the chain tip advances to a new height

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -358,3 +358,23 @@ impl WalletInfoInterface for ManagedWalletInfo {
         self.accounts.all_accounts().iter().map(|a| a.monitor_revision()).sum()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_wallet_with_no_sync_ranges_converges_at_synced_height() {
+        let mut info = ManagedWalletInfo::dummy(0);
+        info.update_synced_height(1000);
+        assert_eq!(info.synced_height(), 1000);
+        assert_eq!(info.convergence_height(), Some(1000));
+    }
+
+    #[test]
+    fn fresh_wallet_with_no_sync_ranges_converges_at_birth_synced_height() {
+        let info = ManagedWalletInfo::dummy(0);
+        let synced = info.synced_height();
+        assert_eq!(info.convergence_height(), Some(synced));
+    }
+}

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -125,8 +125,7 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
         for account in self.accounts().all_accounts() {
             for pool in account.managed_account_type().address_pools() {
                 for range in pool.pending_sync_ranges() {
-                    let progress =
-                        range.caught_up_to.unwrap_or_else(|| birth.saturating_sub(1));
+                    let progress = range.caught_up_to.unwrap_or_else(|| birth.saturating_sub(1));
                     min_progress = Some(match min_progress {
                         Some(m) => m.min(progress),
                         None => progress,


### PR DESCRIPTION
## Summary

Closes [#133](https://github.com/xdustinface/rust-dashcore/issues/133).

Reframes filter scanning as a coverage problem with two independent watermarks. Existing `wallet_synced_height` keeps its monotonic forward-edge semantics. New `convergence_height` returns the *strictly* lowest height through which every currently-monitored address has been scanned. A `BackfillWorker` services pending `AddressSyncRange` obligations via a sweep-line scan that shares one disk read across overlapping ranges.

- `AddressPool` gains `sync_ranges: Vec<AddressSyncRange>` and a lifecycle (`push_sync_range`, `advance_caught_up_to`, `clamp_caught_up_to`, `collapse_adjacent_ranges`); complete ranges drop on insert/advance so wallet state stays bounded regardless of historical gap-extension count.
- `WalletInterface` gains `wallet_convergence_height`, `wallets_pending_convergence`, `pending_rescans`, `advance_rescan`, and `on_chain_reorg`. `WalletInfoInterface` gains `convergence_height`.
- New `WalletEvent` variants: `ConvergenceChanged` (non-monotonic, equality-coalesced), `RescanProgressed` (advisory, per-chunk), `RescanBlockProcessed` (atomic — bundles tx records and the `caught_up_to` advance for atomic persistence).
- `BackfillWorker` walks the union of `[resume_from..=ceiling]` height windows in chunks of `BATCH_PROCESSING_SIZE`, sharing a single `check_compact_filters_for_addresses` pass per chunk. Matched block hashes route through `SyncEvent::BackfillBlocksNeeded` and dedup against forward sync via the existing `BlockMatchTracker`.

## Design notes

A few intentional deviations from the issue body, called out so the reviewer doesn't try to "fix" them:

- **Step 4 dropped (forward-sync range advance).** The issue's Task 1.6 proposed crediting `caught_up_to` from forward sync when the batch end exceeds `since_height`. Analysis showed this corrupts the data model: `caught_up_to` represents *contiguous backfill from `birth_height` upward*, but forward sync at `H >> since_height` proves nothing about `[birth..since_height-1]` (those filters were originally scanned without these addresses). Crediting forward sync would silently re-create the original 9-output bug. The within-batch rescan in `try_commit_batches` already covers `[batch_start..since_height-1]`; the backfill worker is the only correct mechanism for `[birth..batch_start-1]`. Convergence stays below `synced_height` while a range is pending, then rises when backfill drops the range. No code change to `try_commit_batches`.
- **Sibling `SyncEvent::BackfillBlocksNeeded` instead of a `BlockRequestSource` discriminant** on the existing `BlocksNeeded`. Payloads differ (advance metadata vs. interested-wallet sets), so a sibling variant is cleaner than carrying an unused field on the forward path.
- **Separate `process_backfill_block_for_wallets`** method on `WalletInterface` instead of widening `process_block_for_wallets` with a `BlockProcessingSource` argument. Keeps the existing forward-sync signature stable across all callers and routes backfill emission to `RescanBlockProcessed` cleanly.
- **Polling-based backfill cadence** (driven from `SyncManager::tick`) rather than a cross-component wake channel from `maintain_gap_limit`. The polling check is `O(1)` when `pending_rescans()` is empty. Cross-component wake is a follow-up perf optimization.
- **dash-spv reorg wiring deferred.** Wallet-side `on_chain_reorg` and `clamp_caught_up_to` are in place and tested. No existing chain-reorg → wallet callback exists in dash-spv today; whoever adds chain-reorg detection in dash-spv next will wire `wallet.on_chain_reorg(fork_height)` from there.
- **Bincode + `#[serde(default)]` limitation.** Bincode 2 does NOT honor `#[serde(default)]` for missing fields. A pre-existing on-disk bincode snapshot lacking `sync_ranges` would fail to decode. No such snapshots are known to exist; tests cover the current shape's bincode round-trip and the serde-JSON migration story.

## Acceptance criteria status

- [x] `cargo test --workspace` clean (489 key-wallet, 45 key-wallet-manager, 432 dash-spv lib tests pass)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] Existing wallet snapshots load without forcing a rescan (synthesized empty `sync_ranges` round-trips via `#[serde(default)]`)
- [x] `wallet_synced_height` API remains backwards-compatible
- [x] `ConvergenceChanged` and `RescanProgressed` events documented and exposed; `RescanBlockProcessed` added for atomicity
- [x] Regression test reproducing the 9-output blind-spot bug (`backfill_recovers_missed_outputs_after_gap_limit_extension`)
- [x] Reorg test confirming `caught_up_to` clamps and backfill re-picks the work
- [x] Migration test for legacy snapshots
- [ ] **Manual reproduction with `crazy-task` testnet wallet** — out of scope for unit tests; needs human verification per the issue.

## Test plan

- [ ] Manual: load `crazy-task` wallet on testnet, verify all 10 outputs of `56bdab0a` are matched after sync
- [ ] CI green on push
- [ ] Manki review

## Commits (will be squash-merged)

1. `feat(key-wallet)`: add `AddressSyncRange` and `sync_ranges` to `AddressPool`
2. `feat(key-wallet-manager)`: add `convergence_height` and rescan API
3. `feat(key-wallet-manager)`: emit `ConvergenceChanged` and add `RescanProgressed` variant
4. `test(key-wallet)`: cover legacy snapshot loading without forced rescan
5. `feat(dash-spv)`: add backfill worker for pending sync ranges
6. `feat(key-wallet-manager)`: wallet-side chain-reorg sync range clamp
7. `feat(dash-spv)`: wire backfill matched-block dispatch end-to-end
8. `test`: regression and integration coverage for sync range backfill
9. `chore`: pr cleanup
