### PR TITLE
ci: upgrade manki to v5 and sync default workflow

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -32,4 +32,5 @@ jobs:
       - name: Manki Review
         uses: manki-review/manki@v5
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'npm'
       - name: Manki Review
         uses: manki-review/manki@v5
         with:

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -1,29 +1,36 @@
-name: Manki Review
+name: Manki
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created]
   issue_comment:
     types: [created, edited]
-  pull_request_review:
-    types: [submitted]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
   id-token: write
-
-concurrency:
-  group: manki-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
-  cancel-in-progress: false
+  actions: read
 
 jobs:
   review:
+    if: github.actor != 'manki-review[bot]'
+    concurrency:
+      group: manki-${{ (github.event_name == 'issue_comment' && github.event.comment.id) || format('pr-{0}', github.event.pull_request.number || github.event.issue.number) }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: manki-review/manki@v4
+      - uses: actions/setup-node@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          node-version: '24'
+          cache: 'npm'
+      - name: Manki Review
+        uses: manki-review/manki@v5
+        with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Upgrades [`manki-review/manki`](https://github.com/manki-review/manki) from `@v4` to `@v5` (latest is [v5.1.1](https://github.com/manki-review/manki/releases/tag/v5.1.1)) and aligns `.github/workflows/manki.yml` with the [current upstream default](https://github.com/manki-review/manki/blob/main/SETUP.md#step-3-add-the-workflow).

### Workflow changes

- Add `ready_for_review` to `pull_request` triggers so draft PRs get reviewed when marked ready (head SHA unchanged, so the planner sees the same diff a `synchronize` would have produced).
- Add `pull_request_review_comment: [created]` trigger so replies to review comment threads reach Manki.
- Add `dismissed` to `pull_request_review` types so auto-approve re-checks when a review is dismissed.
- Add `actions: read` permission for OIDC run verification.
- Move `concurrency` onto the `review` job and split `issue_comment` events by `comment.id`. Distinct `/manki` commands no longer serialize against each other, while PR-scoped events still share a `pr-{N}` group.
- Guard the job with `if: github.actor != 'manki-review[bot]'` to prevent the bot from triggering on its own comments.
- Add `actions/setup-node@v4` with Node 24 (required by the v5 action).
- Drop the `github_token` input since the [Manki GitHub App](https://github.com/apps/manki-review) handles PR access.

### Auth

Keeping `claude_code_oauth_token` for now to avoid a secret migration. Anthropic [restricted Claude Code OAuth tokens for third-party tools on 2026-04-04](https://github.com/manki-review/manki/blob/main/SETUP.md#anthropic), so the action will emit a one-line deprecation warning per run, but it still works. Switch to `anthropic_api_key` when convenient.

## Test plan

- [ ] Workflow parses and runs on this PR
- [ ] Manki posts a review against the upgraded workflow
- [ ] `/manki` chat commands still function