### PR TITLE
ci: upgrade manki to v5 and sync default workflow

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -1,29 +1,36 @@
-name: Manki Review
+name: Manki
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created]
   issue_comment:
     types: [created, edited]
-  pull_request_review:
-    types: [submitted]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
   id-token: write
-
-concurrency:
-  group: manki-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
-  cancel-in-progress: false
+  actions: read
 
 jobs:
   review:
+    if: github.actor != 'manki-review[bot]'
+    concurrency:
+      group: manki-${{ (github.event_name == 'issue_comment' && github.event.comment.id) || format('pr-{0}', github.event.pull_request.number || github.event.issue.number) }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: manki-review/manki@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Manki Review
+        uses: manki-review/manki@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Bumps `manki-review/manki` from `@v4` to `@v5` in `.github/workflows/manki.yml`. The `@v4` floating tag was last advanced to `v4.7.0` on 2026-04-28 and never moved when the v5 series shipped, so every run since the v5 launch resolved `@v4` to `v4.7.0` and produced an older report shape (no `Manki context` JSON, no round-cap enforcement, no prior-round memory)
- Syncs the rest of the workflow to the canonical [`manki-review/manki/SETUP.md`](https://github.com/manki-review/manki/blob/main/SETUP.md) snippet plus the v5.1.0 "Action required for downstream installs" notice: drops `github.event_name` from `concurrency.group`, moves the `concurrency:` block to job scope, adds `pull_request_review_comment` + `pull_request_review.dismissed` + `ready_for_review` triggers, adds `actions: read` permission, adds the `if: github.actor != 'manki-review[bot]'` guard, and pins Node 24 via `actions/setup-node@v4`

Mirrors [PR #148](https://github.com/xdustinface/rust-dashcore/pull/148) which applied the same change to the `dev` branch. This PR brings `v0.42-dev` (the default branch) to parity.

## Why this matters

[PR #149](https://github.com/xdustinface/rust-dashcore/pull/149) round 6 ran on `manki-version: 4.7.0` (after rounds 1-5 ran on `5.2.0`), lost the prior-round memory, and re-flagged a finding the v5 rounds had already addressed. This PR closes that hole on the default branch