### PR TITLE
feat(dash-spv): reorg execution, ChainReorg event, cascade to downstream managers

### DIFF
--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -133,6 +133,20 @@ extern "C" fn on_sync_complete(header_tip: u32, cycle: u32, _user_data: *mut c_v
     println!("[Sync] Sync complete at height: {} (cycle {})", header_tip, cycle);
 }
 
+extern "C" fn on_chain_reorg(
+    fork_height: u32,
+    _old_tip: *const [u8; 32],
+    _new_tip: *const [u8; 32],
+    generation: u64,
+    _user_data: *mut c_void,
+) {
+    println!("[Sync] Chain reorg at fork_height={} generation={}", fork_height, generation);
+}
+
+extern "C" fn on_deep_reorg_detected(fork_height: u32, depth: u32, _user_data: *mut c_void) {
+    println!("[Sync] Deep reorg detected at fork_height={} depth={}", fork_height, depth);
+}
+
 // ============================================================================
 // Network Event Callbacks
 // ============================================================================
@@ -511,6 +525,8 @@ fn main() {
                 on_instantlock_received: Some(on_instantlock_received),
                 on_manager_error: Some(on_manager_error),
                 on_sync_complete: Some(on_sync_complete),
+                on_chain_reorg: Some(on_chain_reorg),
+                on_deep_reorg_detected: Some(on_deep_reorg_detected),
                 user_data: ptr::null_mut(),
             },
             network: FFINetworkEventCallbacks {

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -226,6 +226,25 @@ pub type OnManagerErrorCallback =
 pub type OnSyncCompleteCallback =
     Option<extern "C" fn(header_tip: u32, cycle: u32, user_data: *mut c_void)>;
 
+/// Callback for `SyncEvent::ChainReorg`.
+///
+/// The `old_tip` and `new_tip` pointers are borrowed and only valid for the
+/// duration of the callback. Callers must memcpy them if they need to retain
+/// the values after the callback returns.
+pub type OnChainReorgCallback = Option<
+    extern "C" fn(
+        fork_height: u32,
+        old_tip: *const [u8; 32],
+        new_tip: *const [u8; 32],
+        generation: u64,
+        user_data: *mut c_void,
+    ),
+>;
+
+/// Callback for `SyncEvent::DeepReorgDetected`.
+pub type OnDeepReorgDetectedCallback =
+    Option<extern "C" fn(fork_height: u32, depth: u32, user_data: *mut c_void)>;
+
 /// Sync event callbacks - one callback per SyncEvent variant.
 ///
 /// Set only the callbacks you're interested in; unset callbacks will be ignored.
@@ -250,6 +269,8 @@ pub struct FFISyncEventCallbacks {
     pub on_instantlock_received: OnInstantLockReceivedCallback,
     pub on_manager_error: OnManagerErrorCallback,
     pub on_sync_complete: OnSyncCompleteCallback,
+    pub on_chain_reorg: OnChainReorgCallback,
+    pub on_deep_reorg_detected: OnDeepReorgDetectedCallback,
     pub user_data: *mut c_void,
 }
 
@@ -282,6 +303,8 @@ impl Default for FFISyncEventCallbacks {
             on_instantlock_received: None,
             on_manager_error: None,
             on_sync_complete: None,
+            on_chain_reorg: None,
+            on_deep_reorg_detected: None,
             user_data: std::ptr::null_mut(),
         }
     }
@@ -436,6 +459,32 @@ impl FFISyncEventCallbacks {
             } => {
                 if let Some(cb) = self.on_sync_complete {
                     cb(*header_tip, *cycle, self.user_data);
+                }
+            }
+            SyncEvent::ChainReorg {
+                fork_height,
+                old_tip,
+                new_tip,
+                generation,
+            } => {
+                if let Some(cb) = self.on_chain_reorg {
+                    let old_bytes = old_tip.as_byte_array();
+                    let new_bytes = new_tip.as_byte_array();
+                    cb(
+                        *fork_height,
+                        old_bytes as *const [u8; 32],
+                        new_bytes as *const [u8; 32],
+                        *generation,
+                        self.user_data,
+                    );
+                }
+            }
+            SyncEvent::DeepReorgDetected {
+                fork_height,
+                depth,
+            } => {
+                if let Some(cb) = self.on_deep_reorg_detected {
+                    cb(*fork_height, *depth, self.user_data);
                 }
             }
         }

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -593,6 +593,8 @@ pub(super) fn create_sync_callbacks(tracker: &Arc<CallbackTracker>) -> FFISyncEv
         on_instantlock_received: Some(on_instantlock_received),
         on_manager_error: Some(on_manager_error),
         on_sync_complete: Some(on_sync_complete),
+        on_chain_reorg: None,
+        on_deep_reorg_detected: None,
         user_data: Arc::as_ptr(tracker) as *mut c_void,
     }
 }

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -30,6 +30,8 @@ pub(super) struct CallbackTracker {
     pub(super) instantlock_received_count: AtomicU32,
     pub(super) manager_error_count: AtomicU32,
     pub(super) sync_complete_count: AtomicU32,
+    pub(super) chain_reorg_count: AtomicU32,
+    pub(super) deep_reorg_count: AtomicU32,
 
     // Network event tracking
     pub(super) peer_connected_count: AtomicU32,
@@ -573,6 +575,28 @@ extern "C" fn on_sync_height_advanced(
     tracing::info!("on_sync_height_advanced: wallet={}, height={}", wallet_str, height);
 }
 
+extern "C" fn on_chain_reorg(
+    fork_height: u32,
+    _old_tip: *const [u8; 32],
+    _new_tip: *const [u8; 32],
+    generation: u64,
+    user_data: *mut c_void,
+) {
+    let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
+        return;
+    };
+    tracker.chain_reorg_count.fetch_add(1, Ordering::SeqCst);
+    tracing::info!("on_chain_reorg: fork_height={}, generation={}", fork_height, generation);
+}
+
+extern "C" fn on_deep_reorg_detected(fork_height: u32, depth: u32, user_data: *mut c_void) {
+    let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
+        return;
+    };
+    tracker.deep_reorg_count.fetch_add(1, Ordering::SeqCst);
+    tracing::info!("on_deep_reorg_detected: fork_height={}, depth={}", fork_height, depth);
+}
+
 /// Create sync callbacks with all event handlers wired to the tracker.
 ///
 /// The `user_data` pointer borrows the tracker Arc. The caller must ensure the
@@ -593,8 +617,8 @@ pub(super) fn create_sync_callbacks(tracker: &Arc<CallbackTracker>) -> FFISyncEv
         on_instantlock_received: Some(on_instantlock_received),
         on_manager_error: Some(on_manager_error),
         on_sync_complete: Some(on_sync_complete),
-        on_chain_reorg: None,
-        on_deep_reorg_detected: None,
+        on_chain_reorg: Some(on_chain_reorg),
+        on_deep_reorg_detected: Some(on_deep_reorg_detected),
         user_data: Arc::as_ptr(tracker) as *mut c_void,
     }
 }

--- a/dash-spv-ffi/tests/unit/test_async_operations.rs
+++ b/dash-spv-ffi/tests/unit/test_async_operations.rs
@@ -78,6 +78,8 @@ mod tests {
                 on_instantlock_received: None,
                 on_manager_error: None,
                 on_sync_complete: Some(on_sync_complete),
+                on_chain_reorg: None,
+                on_deep_reorg_detected: None,
                 user_data: &event_data as *const _ as *mut c_void,
             };
 

--- a/dash-spv/src/chain/chain_tip.rs
+++ b/dash-spv/src/chain/chain_tip.rs
@@ -53,9 +53,4 @@ impl ForkCandidate {
             .map(|h| *h.hash())
             .expect("ForkCandidate must carry at least one header")
     }
-
-    /// Height of the candidate's tip header.
-    pub(crate) fn tip_height(&self) -> u32 {
-        self.ancestor_height + self.headers.len() as u32
-    }
 }

--- a/dash-spv/src/chain/chain_tip.rs
+++ b/dash-spv/src/chain/chain_tip.rs
@@ -44,3 +44,18 @@ pub(crate) struct ForkCandidate {
     pub(crate) headers: Vec<HashedBlockHeader>,
     pub(crate) total_work: ChainWork,
 }
+
+impl ForkCandidate {
+    /// Hash of the candidate's tip header.
+    pub(crate) fn tip_hash(&self) -> BlockHash {
+        self.headers
+            .last()
+            .map(|h| *h.hash())
+            .expect("ForkCandidate must carry at least one header")
+    }
+
+    /// Height of the candidate's tip header.
+    pub(crate) fn tip_height(&self) -> u32 {
+        self.ancestor_height + self.headers.len() as u32
+    }
+}

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -24,7 +24,7 @@ use dashcore::network::constants::NetworkExt;
 use dashcore::sml::masternode_list_engine::MasternodeListEngine;
 use dashcore_hashes::Hash;
 use key_wallet_manager::WalletInterface;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU32, AtomicU64};
 use std::sync::Arc;
 use tokio::sync::{watch, Mutex, RwLock};
 
@@ -72,13 +72,24 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         };
         let checkpoint_manager = Arc::new(CheckpointManager::new(checkpoints));
         let reorg_generation = Arc::new(AtomicU64::new(0));
+        let chainlock_height = Arc::new(AtomicU32::new(0));
+        let (filter_header_storage_arg, filter_storage_arg, block_storage_arg) =
+            if config.enable_filters {
+                (Some(storage.filter_headers()), Some(storage.filters()), Some(storage.blocks()))
+            } else {
+                (None, None, None)
+            };
         managers.block_headers = Some(
             BlockHeadersManager::new(
                 storage.block_headers(),
                 storage.metadata(),
+                filter_header_storage_arg,
+                filter_storage_arg,
+                block_storage_arg,
                 checkpoint_manager,
                 config.network,
                 reorg_generation.clone(),
+                chainlock_height.clone(),
             )
             .await?,
         );
@@ -131,6 +142,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
                     storage.block_headers(),
                     storage.metadata(),
                     masternode_list_engine.clone(),
+                    chainlock_height.clone(),
                 )
                 .await,
             );

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -160,7 +160,11 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
             ));
         }
 
-        let sync_coordinator = SyncCoordinator::new(managers, reorg_generation).await;
+        // `reorg_generation` is held by each manager (via clones threaded in
+        // above); the coordinator itself never reads it directly, so we
+        // don't need to keep an additional handle past this point.
+        drop(reorg_generation);
+        let sync_coordinator = SyncCoordinator::new(managers).await;
 
         // Wrap storage in Arc<Mutex>
         let storage = Arc::new(Mutex::new(storage));

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -24,6 +24,7 @@ use dashcore::network::constants::NetworkExt;
 use dashcore::sml::masternode_list_engine::MasternodeListEngine;
 use dashcore_hashes::Hash;
 use key_wallet_manager::WalletInterface;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::sync::{watch, Mutex, RwLock};
 
@@ -70,20 +71,26 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
             _ => Vec::new(),
         };
         let checkpoint_manager = Arc::new(CheckpointManager::new(checkpoints));
+        let reorg_generation = Arc::new(AtomicU64::new(0));
         managers.block_headers = Some(
             BlockHeadersManager::new(
                 storage.block_headers(),
                 storage.metadata(),
                 checkpoint_manager,
                 config.network,
+                reorg_generation.clone(),
             )
             .await?,
         );
 
         if config.enable_filters {
             managers.filter_headers = Some(
-                FilterHeadersManager::new(storage.block_headers(), storage.filter_headers())
-                    .await?,
+                FilterHeadersManager::new(
+                    storage.block_headers(),
+                    storage.filter_headers(),
+                    reorg_generation.clone(),
+                )
+                .await?,
             );
             managers.filters = Some(
                 FiltersManager::new(
@@ -91,11 +98,18 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
                     storage.block_headers(),
                     storage.filter_headers(),
                     storage.filters(),
+                    reorg_generation.clone(),
                 )
                 .await,
             );
             managers.blocks = Some(
-                BlocksManager::new(wallet.clone(), storage.block_headers(), storage.blocks()).await,
+                BlocksManager::new(
+                    wallet.clone(),
+                    storage.block_headers(),
+                    storage.blocks(),
+                    reorg_generation.clone(),
+                )
+                .await,
             );
         }
 
@@ -134,7 +148,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
             ));
         }
 
-        let sync_coordinator = SyncCoordinator::new(managers).await;
+        let sync_coordinator = SyncCoordinator::new(managers, reorg_generation).await;
 
         // Wrap storage in Arc<Mutex>
         let storage = Arc::new(Mutex::new(storage));

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -8,10 +8,14 @@
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
+use tokio::sync::Mutex;
+
 use crate::chain::{ChainWork, CheckpointManager, ForkCandidate};
+use crate::sync::reorg::ReorgState;
 use crate::error::{SyncError, SyncResult};
 use crate::network::RequestSender;
 use crate::storage::{BlockHeaderStorage, BlockHeaderTip, MetadataStorage};
@@ -56,6 +60,17 @@ pub struct BlockHeadersManager<H: BlockHeaderStorage, M: MetadataStorage> {
     /// Populated whenever a fork batch is buffered so that subsequent batches
     /// extending the same branch are routed to `ingest_fork` correctly.
     fork_tip_index: HashMap<BlockHash, u32>,
+    /// Shared generation counter bumped by `handle_reorg` once a cascade
+    /// commits, used to invalidate stale in-flight responses in downstream
+    /// managers.
+    pub(super) reorg_generation: Arc<AtomicU64>,
+    /// Single-flight reorg state plus the deny-list of fork tip hashes that
+    /// have been rejected by a guard (checkpoint floor, chainlock floor,
+    /// depth cap).
+    pub(super) reorg_state: Arc<Mutex<ReorgState>>,
+    /// Headers seen on a chainlocked-conflicting fork. Recorded for
+    /// monitoring without penalizing the peer.
+    pub(super) side_headers: Vec<(u32, BlockHash)>,
 }
 
 impl<H: BlockHeaderStorage, M: MetadataStorage> std::fmt::Debug for BlockHeadersManager<H, M> {
@@ -74,6 +89,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
         metadata_storage: Arc<RwLock<M>>,
         checkpoint_manager: Arc<CheckpointManager>,
         network: Network,
+        reorg_generation: Arc<AtomicU64>,
     ) -> SyncResult<Self> {
         let tip = header_storage
             .read()
@@ -103,7 +119,15 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
             fork_buffer: ForkBuffer::new(Params::new(network)),
             pending_fork_candidate: None,
             fork_tip_index: HashMap::new(),
+            reorg_generation,
+            reorg_state: Arc::new(Mutex::new(ReorgState::default())),
+            side_headers: Vec::new(),
         })
+    }
+
+    /// Current reorg generation counter snapshot.
+    pub(crate) fn current_generation(&self) -> u64 {
+        self.reorg_generation.load(Ordering::Acquire)
     }
 
     /// Number of ancestor headers DGW v3 requires to compute next bits.
@@ -444,6 +468,7 @@ mod tests {
             storage.metadata(),
             checkpoint_manager,
             Network::Testnet,
+            Arc::new(AtomicU64::new(0)),
         )
         .await
         .expect("Failed to create BlockHeadersManager")
@@ -743,6 +768,7 @@ mod tests {
             storage.metadata(),
             checkpoint_manager,
             Network::Testnet,
+            Arc::new(AtomicU64::new(0)),
         )
         .await
         .unwrap();
@@ -825,6 +851,7 @@ mod tests {
             storage.metadata(),
             checkpoint_manager,
             Network::Regtest,
+            Arc::new(AtomicU64::new(0)),
         )
         .await
         .expect("failed to create regtest manager");

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -175,11 +175,6 @@ impl<
         })
     }
 
-    /// Current reorg generation counter snapshot.
-    pub(crate) fn current_generation(&self) -> u64 {
-        self.reorg_generation.load(Ordering::Acquire)
-    }
-
     /// Best chainlock height as `Option<u32>`. `0` is mapped to `None`
     /// (no chainlock yet).
     pub(super) fn best_chainlock_height(&self) -> Option<u32> {
@@ -241,12 +236,12 @@ impl<
             if ancestor_height <= cl_height {
                 tracing::warn!(
                     "flagging chainlock-conflicting fork from {} at ancestor {} (chainlock {})",
-                    peer, ancestor_height, cl_height
+                    peer,
+                    ancestor_height,
+                    cl_height
                 );
-                let mut height = ancestor_height + 1;
-                for h in headers {
+                for (height, h) in (ancestor_height + 1..).zip(headers.iter()) {
                     self.side_headers.push((height, h.block_hash()));
-                    height += 1;
                 }
                 return Ok(());
             }
@@ -1219,8 +1214,7 @@ mod tests {
         let peer: SocketAddr = "1.2.3.4:9999".parse().unwrap();
         let (sender, _rx) = create_test_request_sender();
 
-        let events =
-            manager.handle_headers_pipeline(&[fork_header], peer, &sender).await.unwrap();
+        let events = manager.handle_headers_pipeline(&[fork_header], peer, &sender).await.unwrap();
         assert!(events.is_empty(), "chainlock-conflicting fork produces no events");
         assert_eq!(manager.fork_buffer.len(), 0, "fork buffer must stay empty");
         assert_eq!(manager.side_headers.len(), 1, "side_headers must record the header");

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -231,7 +231,7 @@ impl<
         // Accept-and-flag: a fork whose ancestor is at or below the best
         // chainlock height cannot become canonical, so route the headers to
         // a side-list for monitoring instead of pulling them through the
-        // fork buffer. The peer is NOT banned, just observed.
+        // fork buffer. The peer is not banned, just observed.
         if let Some(cl_height) = self.best_chainlock_height() {
             if ancestor_height <= cl_height {
                 tracing::warn!(
@@ -548,7 +548,9 @@ mod tests {
     };
     use crate::sync::block_headers::fork_buffer::MAX_FORK_HEADERS_PER_PEER;
     use crate::sync::{ManagerIdentifier, SyncManager, SyncManagerProgress};
+    use dashcore::block::Version;
     use dashcore::network::message::NetworkMessage;
+    use dashcore::{CompactTarget, TxMerkleNode};
     use dashcore_hashes::Hash;
     use tokio::sync::mpsc::unbounded_channel;
 
@@ -1177,7 +1179,6 @@ mod tests {
     /// is observed, not banned.
     #[tokio::test]
     async fn chainlock_conflicting_fork_is_flagged_without_banning_peer() {
-        use dashcore::{block::Version, CompactTarget, TxMerkleNode};
         let easy_bits = CompactTarget::from_consensus(0x207fffff);
 
         let (mut manager, chain) = create_regtest_manager_with_chain(5).await;
@@ -1233,7 +1234,6 @@ mod tests {
         // Build a 3-header fork extending chain[4]. Use `ingest_fork` so the
         // candidate flows through the normal path and ends up in
         // `pending_fork_candidate`.
-        use dashcore::{block::Version, CompactTarget, TxMerkleNode};
         let easy_bits = CompactTarget::from_consensus(0x207fffff);
         let ancestor = chain[4];
         let mut prev = ancestor.block_hash();

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -214,6 +214,10 @@ impl<
     /// Number of ancestor headers DGW v3 requires to compute next bits.
     const DGW_HISTORY: u32 = 24;
 
+    /// Maximum number of entries kept in `side_headers`. Oldest entries are
+    /// evicted when the cap is reached to bound memory usage.
+    const MAX_SIDE_HEADERS: usize = 10_000;
+
     /// Consume the fork candidate set when a buffered branch overtook the
     /// active chain. The sync coordinator calls this to perform the actual reorg.
     pub(crate) fn take_pending_fork_candidate(&mut self) -> Option<ForkCandidate> {
@@ -228,18 +232,28 @@ impl<
         headers: &[Header],
         ancestor_height: u32,
     ) -> SyncResult<()> {
-        // Accept-and-flag: a fork whose ancestor is at or below the best
-        // chainlock height cannot become canonical, so route the headers to
-        // a side-list for monitoring instead of pulling them through the
-        // fork buffer. The peer is not banned, just observed.
+        // Accept-and-flag: a fork whose ancestor is strictly below the best
+        // chainlock height rewrites at least one finalised block and cannot
+        // become canonical, so route the headers to a side-list for monitoring
+        // instead of pulling them through the fork buffer. A fork that shares
+        // the chainlocked block as its last common ancestor (ancestor_height ==
+        // cl_height) diverges at cl_height+1 and does not rewrite any
+        // finalized block, so it is still eligible for the normal fork path.
+        // The peer is not banned, just observed.
         if let Some(cl_height) = self.best_chainlock_height() {
-            if ancestor_height <= cl_height {
+            if ancestor_height < cl_height {
                 tracing::warn!(
                     "flagging chainlock-conflicting fork from {} at ancestor {} (chainlock {})",
                     peer,
                     ancestor_height,
                     cl_height
                 );
+                let incoming = headers.len();
+                let cap = Self::MAX_SIDE_HEADERS;
+                if self.side_headers.len() + incoming > cap {
+                    let excess = (self.side_headers.len() + incoming).saturating_sub(cap);
+                    self.side_headers.drain(..excess);
+                }
                 for (height, h) in (ancestor_height + 1..).zip(headers.iter()) {
                     self.side_headers.push((height, h.block_hash()));
                 }
@@ -1293,5 +1307,82 @@ mod tests {
         let new_tip = manager.tip().await.unwrap();
         assert_eq!(new_tip.height(), 7);
         assert_eq!(*new_tip.hash(), new_tip_hash);
+
+        // Verify the old-chain headers at the reorged heights are gone and the
+        // fork headers now occupy those slots.
+        let storage = manager.header_storage.read().await;
+        let old_hashes: Vec<BlockHash> = chain[5..].iter().map(|h| h.block_hash()).collect();
+        for old_hash in &old_hashes {
+            let height_opt = storage.get_header_height_by_hash(old_hash).await.unwrap();
+            assert!(
+                height_opt.is_none(),
+                "old-chain header {} should not be indexed after reorg",
+                old_hash
+            );
+        }
+        for (i, fork_h) in fork_headers.iter().enumerate() {
+            let stored = storage.get_header(5 + i as u32).await.unwrap();
+            assert!(stored.is_some(), "fork header at height {} must be stored", 5 + i as u32);
+            assert_eq!(
+                stored.unwrap().block_hash(),
+                fork_h.block_hash(),
+                "stored header at height {} must match fork header",
+                5 + i as u32
+            );
+        }
+    }
+
+    /// `drive_reorg` must return `Ok(None)` when a guard rejects the candidate
+    /// without panicking or looping. Uses the chainlock floor guard: ancestor
+    /// strictly below the best chainlock height is denied.
+    #[tokio::test]
+    async fn drive_reorg_returns_none_when_guard_rejects_candidate() {
+        let easy_bits = CompactTarget::from_consensus(0x207fffff);
+        let (mut manager, chain) = create_regtest_manager_with_chain(8).await;
+
+        let initial_gen = manager.reorg_generation.load(Ordering::Acquire);
+
+        // Set chainlock at height 6 so a fork whose ancestor is at height 4 is
+        // below the floor and must be rejected.
+        manager.chainlock_height.store(6, Ordering::Release);
+
+        let ancestor = chain[4];
+        let mut prev = ancestor.block_hash();
+        let mut fork_headers: Vec<crate::types::HashedBlockHeader> = Vec::new();
+        for i in 0..2u32 {
+            let time = ancestor.time + 11 * 600 + 1 + i * 600;
+            let mut header = None;
+            for nonce in 0u32..64 {
+                let h = dashcore::block::Header {
+                    version: Version::ONE,
+                    prev_blockhash: prev,
+                    merkle_root: TxMerkleNode::all_zeros(),
+                    time,
+                    bits: easy_bits,
+                    nonce,
+                };
+                if h.target().is_met_by(h.block_hash()) {
+                    header = Some(h);
+                    break;
+                }
+            }
+            let h = header.expect("nonce space exhausted");
+            prev = h.block_hash();
+            fork_headers.push(crate::types::HashedBlockHeader::from(&h));
+        }
+
+        let candidate = ForkCandidate {
+            ancestor_height: 4,
+            headers: fork_headers,
+            total_work: crate::chain::ChainWork::zero(),
+        };
+
+        let result = manager.drive_reorg(candidate).await.unwrap();
+        assert!(result.is_none(), "guard-rejected candidate must return None");
+        assert_eq!(
+            manager.reorg_generation.load(Ordering::Acquire),
+            initial_gen,
+            "generation must not change on guard rejection"
+        );
     }
 }

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -233,6 +233,25 @@ impl<
         headers: &[Header],
         ancestor_height: u32,
     ) -> SyncResult<()> {
+        // Accept-and-flag: a fork whose ancestor is at or below the best
+        // chainlock height cannot become canonical, so route the headers to
+        // a side-list for monitoring instead of pulling them through the
+        // fork buffer. The peer is NOT banned, just observed.
+        if let Some(cl_height) = self.best_chainlock_height() {
+            if ancestor_height <= cl_height {
+                tracing::warn!(
+                    "flagging chainlock-conflicting fork from {} at ancestor {} (chainlock {})",
+                    peer, ancestor_height, cl_height
+                );
+                let mut height = ancestor_height + 1;
+                for h in headers {
+                    self.side_headers.push((height, h.block_hash()));
+                    height += 1;
+                }
+                return Ok(());
+            }
+        }
+
         let storage = self.header_storage.read().await;
         let history_start = ancestor_height.saturating_sub(Self::DGW_HISTORY);
         let history = storage.load_headers(history_start..ancestor_height + 1).await?;
@@ -1156,5 +1175,56 @@ mod tests {
             }
             other => panic!("expected GetHeaders, got {:?}", other),
         }
+    }
+
+    /// A fork whose ancestor sits at or below the best chainlock height
+    /// gets routed to `side_headers` instead of the fork buffer. The peer
+    /// is observed, not banned.
+    #[tokio::test]
+    async fn chainlock_conflicting_fork_is_flagged_without_banning_peer() {
+        use dashcore::{block::Version, CompactTarget, TxMerkleNode};
+        let easy_bits = CompactTarget::from_consensus(0x207fffff);
+
+        let (mut manager, chain) = create_regtest_manager_with_chain(5).await;
+        let tip = manager.tip().await.unwrap();
+        let tip_hash = *tip.hash();
+
+        manager.pipeline.init(0, tip_hash, tip.height());
+        manager.pipeline.mark_tip_complete();
+        manager.progress.set_state(SyncState::Synced);
+
+        // Publish a chainlock at height 3 so a fork ancestor at height 1
+        // conflicts with it.
+        manager.chainlock_height.store(3, Ordering::Release);
+
+        let ancestor = chain[1];
+        let fork_time = ancestor.time + 11 * 600 + 1;
+        let mut fork_header = None;
+        for nonce in 0u32..64 {
+            let h = Header {
+                version: Version::ONE,
+                prev_blockhash: ancestor.block_hash(),
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: fork_time,
+                bits: easy_bits,
+                nonce,
+            };
+            if h.target().is_met_by(h.block_hash()) {
+                fork_header = Some(h);
+                break;
+            }
+        }
+        let fork_header = fork_header.expect("nonce space exhausted");
+
+        let peer: SocketAddr = "1.2.3.4:9999".parse().unwrap();
+        let (sender, _rx) = create_test_request_sender();
+
+        let events =
+            manager.handle_headers_pipeline(&[fork_header], peer, &sender).await.unwrap();
+        assert!(events.is_empty(), "chainlock-conflicting fork produces no events");
+        assert_eq!(manager.fork_buffer.len(), 0, "fork buffer must stay empty");
+        assert_eq!(manager.side_headers.len(), 1, "side_headers must record the header");
+        assert_eq!(manager.side_headers[0].0, 2, "recorded height = ancestor_height + 1");
+        assert_eq!(manager.side_headers[0].1, fork_header.block_hash());
     }
 }

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -23,7 +23,7 @@ use crate::storage::{
 };
 use crate::sync::block_headers::fork_buffer::ForkBuffer;
 use crate::sync::block_headers::HeadersPipeline;
-use crate::sync::reorg::{handle_reorg, ReorgState, ReorgStorages};
+use crate::sync::reorg::{handle_reorg, is_below_chainlock_floor, ReorgState, ReorgStorages};
 use crate::sync::{BlockHeadersProgress, ProgressPercentage, SyncEvent, SyncManager, SyncState};
 use crate::types::HashedBlockHeader;
 use crate::validation::{BlockHeaderValidator, Validator};
@@ -241,7 +241,7 @@ impl<
         // finalized block, so it is still eligible for the normal fork path.
         // The peer is not banned, just observed.
         if let Some(cl_height) = self.best_chainlock_height() {
-            if ancestor_height < cl_height {
+            if is_below_chainlock_floor(ancestor_height, cl_height) {
                 tracing::warn!(
                     "flagging chainlock-conflicting fork from {} at ancestor {} (chainlock {})",
                     peer,
@@ -1385,6 +1385,63 @@ mod tests {
             manager.reorg_generation.load(Ordering::Acquire),
             initial_gen,
             "generation must not change on guard rejection"
+        );
+    }
+
+    /// A fork whose ancestor is exactly at the chainlocked height must pass
+    /// the chainlock floor guard (`ancestor_height < cl_height` is false when
+    /// equal) and drive a successful reorg cascade.
+    #[tokio::test]
+    async fn drive_reorg_accepts_candidate_anchored_at_chainlock_height() {
+        let easy_bits = CompactTarget::from_consensus(0x207fffff);
+        let (mut manager, chain) = create_regtest_manager_with_chain(8).await;
+
+        let initial_gen = manager.reorg_generation.load(Ordering::Acquire);
+
+        // Chainlock at height 4 — a fork anchored exactly at 4 must be accepted
+        // because it only diverges at height 5 and does not rewrite block 4.
+        manager.chainlock_height.store(4, Ordering::Release);
+
+        let ancestor = chain[4];
+        let mut prev = ancestor.block_hash();
+        let mut fork_headers: Vec<crate::types::HashedBlockHeader> = Vec::new();
+        for i in 0..3u32 {
+            let time = ancestor.time + 11 * 600 + 1 + i * 600;
+            let mut header = None;
+            for nonce in 0u32..64 {
+                let h = dashcore::block::Header {
+                    version: Version::ONE,
+                    prev_blockhash: prev,
+                    merkle_root: TxMerkleNode::all_zeros(),
+                    time,
+                    bits: easy_bits,
+                    nonce,
+                };
+                if h.target().is_met_by(h.block_hash()) {
+                    header = Some(h);
+                    break;
+                }
+            }
+            let h = header.expect("nonce space exhausted");
+            prev = h.block_hash();
+            fork_headers.push(crate::types::HashedBlockHeader::from(&h));
+        }
+
+        let candidate = ForkCandidate {
+            ancestor_height: 4,
+            headers: fork_headers,
+            total_work: crate::chain::ChainWork::zero(),
+        };
+
+        let result = manager.drive_reorg(candidate).await.unwrap();
+        assert!(
+            result.is_some(),
+            "fork anchored at chainlocked height must not be rejected by the chainlock floor guard"
+        );
+        assert_eq!(
+            manager.reorg_generation.load(Ordering::Acquire),
+            initial_gen + 1,
+            "generation must be bumped on successful reorg"
         );
     }
 }

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -1227,4 +1227,77 @@ mod tests {
         assert_eq!(manager.side_headers[0].0, 2, "recorded height = ancestor_height + 1");
         assert_eq!(manager.side_headers[0].1, fork_header.block_hash());
     }
+
+    /// End-to-end shallow reorg via `drive_reorg`: storage truncates to the
+    /// fork ancestor, the fork headers replace the old tip, a `ChainReorg`
+    /// event surfaces, and the generation counter is bumped.
+    #[tokio::test]
+    async fn shallow_reorg_cascade_truncates_storage_and_emits_chain_reorg() {
+        let (mut manager, chain) = create_regtest_manager_with_chain(8).await;
+        let old_tip_hash = chain.last().unwrap().block_hash();
+
+        // Build a 3-header fork extending chain[4]. Use `ingest_fork` so the
+        // candidate flows through the normal path and ends up in
+        // `pending_fork_candidate`.
+        use dashcore::{block::Version, CompactTarget, TxMerkleNode};
+        let easy_bits = CompactTarget::from_consensus(0x207fffff);
+        let ancestor = chain[4];
+        let mut prev = ancestor.block_hash();
+        let mut fork_headers: Vec<Header> = Vec::new();
+        for i in 0..3u32 {
+            let time = ancestor.time + 11 * 600 + 1 + i * 600;
+            let mut header = None;
+            for nonce in 0u32..64 {
+                let h = Header {
+                    version: Version::ONE,
+                    prev_blockhash: prev,
+                    merkle_root: TxMerkleNode::all_zeros(),
+                    time,
+                    bits: easy_bits,
+                    nonce,
+                };
+                if h.target().is_met_by(h.block_hash()) {
+                    header = Some(h);
+                    break;
+                }
+            }
+            let h = header.expect("nonce space exhausted");
+            prev = h.block_hash();
+            fork_headers.push(h);
+        }
+        let new_tip_hash = fork_headers.last().unwrap().block_hash();
+
+        // Drive `ingest_fork` directly so the candidate sits in `fork_buffer`.
+        let peer: SocketAddr = "1.2.3.4:9999".parse().unwrap();
+        manager.ingest_fork(peer, &fork_headers, 4).await.unwrap();
+        // The fork ingest doesn't yet declare a winner because the active
+        // extension is heavier in some cases, so force-promote via a higher
+        // total_work fork. Easier: directly take the candidate by triggering
+        // the buffer's `take_winning_candidate` with zero active work.
+        let candidate = manager
+            .fork_buffer
+            .take_winning_candidate(crate::chain::ChainWork::zero())
+            .expect("fork should win against zero active work");
+
+        let initial_gen = manager.reorg_generation.load(Ordering::Acquire);
+        let event = manager.drive_reorg(candidate).await.unwrap().expect("ChainReorg event");
+        match event {
+            SyncEvent::ChainReorg {
+                fork_height,
+                old_tip,
+                new_tip,
+                generation,
+            } => {
+                assert_eq!(fork_height, 4);
+                assert_eq!(old_tip, old_tip_hash);
+                assert_eq!(new_tip, new_tip_hash);
+                assert_eq!(generation, initial_gen + 1);
+            }
+            other => panic!("expected ChainReorg, got {:?}", other),
+        }
+        assert_eq!(manager.reorg_generation.load(Ordering::Acquire), initial_gen + 1);
+        let new_tip = manager.tip().await.unwrap();
+        assert_eq!(new_tip.height(), 7);
+        assert_eq!(*new_tip.hash(), new_tip_hash);
+    }
 }

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -8,19 +8,22 @@
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
 use tokio::sync::Mutex;
 
 use crate::chain::{ChainWork, CheckpointManager, ForkCandidate};
-use crate::sync::reorg::ReorgState;
 use crate::error::{SyncError, SyncResult};
 use crate::network::RequestSender;
-use crate::storage::{BlockHeaderStorage, BlockHeaderTip, MetadataStorage};
+use crate::storage::{
+    BlockHeaderStorage, BlockHeaderTip, BlockStorage, FilterHeaderStorage, FilterStorage,
+    MetadataStorage,
+};
 use crate::sync::block_headers::fork_buffer::ForkBuffer;
 use crate::sync::block_headers::HeadersPipeline;
+use crate::sync::reorg::{handle_reorg, ReorgState, ReorgStorages};
 use crate::sync::{BlockHeadersProgress, ProgressPercentage, SyncEvent, SyncManager, SyncState};
 use crate::types::HashedBlockHeader;
 use crate::validation::{BlockHeaderValidator, Validator};
@@ -36,14 +39,33 @@ use tokio::sync::RwLock;
 /// - Initial header sync using parallel pipeline (checkpoint-based segments)
 /// - Post-sync header updates via inventory announcements
 ///
-/// Generic over `H: BlockHeaderStorage` to allow different storage implementations.
-pub struct BlockHeadersManager<H: BlockHeaderStorage, M: MetadataStorage> {
+/// Generic over the four storage types to allow different storage
+/// implementations and to give the manager direct handles for the reorg
+/// cascade.
+pub struct BlockHeadersManager<
+    H: BlockHeaderStorage,
+    FH: FilterHeaderStorage,
+    F: FilterStorage,
+    B: BlockStorage,
+    M: MetadataStorage,
+> {
     /// Current progress of the manager.
     pub(super) progress: BlockHeadersProgress,
     /// Block header storage.
     pub(super) header_storage: Arc<RwLock<H>>,
     /// Metadata storage for persisting the best peer tip height.
     pub(super) metadata_storage: Arc<RwLock<M>>,
+    /// Filter header storage, truncated by the reorg cascade. `None` when
+    /// filter sync is disabled.
+    pub(super) filter_header_storage: Option<Arc<RwLock<FH>>>,
+    /// Filter storage, truncated by the reorg cascade. `None` when filter
+    /// sync is disabled.
+    pub(super) filter_storage: Option<Arc<RwLock<F>>>,
+    /// Block storage, truncated by the reorg cascade. `None` when filter
+    /// sync is disabled.
+    pub(super) block_storage: Option<Arc<RwLock<B>>>,
+    /// Checkpoint manager, consulted by the cascade's checkpoint floor.
+    pub(super) checkpoint_manager: Arc<CheckpointManager>,
     /// Pipeline for parallel header downloads (used for both initial sync and post-sync).
     pub(super) pipeline: HeadersPipeline,
     /// Pending block announcements waiting for headers message (post-sync).
@@ -64,6 +86,10 @@ pub struct BlockHeadersManager<H: BlockHeaderStorage, M: MetadataStorage> {
     /// commits, used to invalidate stale in-flight responses in downstream
     /// managers.
     pub(super) reorg_generation: Arc<AtomicU64>,
+    /// Best validated chainlock height. `0` means "no chainlock observed
+    /// yet". Updated by `ChainLockManager` and read by the cascade as the
+    /// floor below which a fork ancestor cannot land.
+    pub(super) chainlock_height: Arc<AtomicU32>,
     /// Single-flight reorg state plus the deny-list of fork tip hashes that
     /// have been rejected by a guard (checkpoint floor, chainlock floor,
     /// depth cap).
@@ -73,7 +99,14 @@ pub struct BlockHeadersManager<H: BlockHeaderStorage, M: MetadataStorage> {
     pub(super) side_headers: Vec<(u32, BlockHash)>,
 }
 
-impl<H: BlockHeaderStorage, M: MetadataStorage> std::fmt::Debug for BlockHeadersManager<H, M> {
+impl<
+        H: BlockHeaderStorage,
+        FH: FilterHeaderStorage,
+        F: FilterStorage,
+        B: BlockStorage,
+        M: MetadataStorage,
+    > std::fmt::Debug for BlockHeadersManager<H, FH, F, B, M>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BlockHeadersManager")
             .field("progress", &self.progress)
@@ -82,14 +115,26 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> std::fmt::Debug for BlockHeaders
     }
 }
 
-impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
+impl<
+        H: BlockHeaderStorage,
+        FH: FilterHeaderStorage,
+        F: FilterStorage,
+        B: BlockStorage,
+        M: MetadataStorage,
+    > BlockHeadersManager<H, FH, F, B, M>
+{
     /// Create a new headers manager with the given storage and checkpoint manager.
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         header_storage: Arc<RwLock<H>>,
         metadata_storage: Arc<RwLock<M>>,
+        filter_header_storage: Option<Arc<RwLock<FH>>>,
+        filter_storage: Option<Arc<RwLock<F>>>,
+        block_storage: Option<Arc<RwLock<B>>>,
         checkpoint_manager: Arc<CheckpointManager>,
         network: Network,
         reorg_generation: Arc<AtomicU64>,
+        chainlock_height: Arc<AtomicU32>,
     ) -> SyncResult<Self> {
         let tip = header_storage
             .read()
@@ -113,6 +158,10 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
             progress: initial_progress,
             header_storage,
             metadata_storage,
+            filter_header_storage,
+            filter_storage,
+            block_storage,
+            checkpoint_manager: checkpoint_manager.clone(),
             pipeline: HeadersPipeline::new(checkpoint_manager),
             pending_announcements: HashMap::new(),
             announced_peers: HashSet::new(),
@@ -120,6 +169,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
             pending_fork_candidate: None,
             fork_tip_index: HashMap::new(),
             reorg_generation,
+            chainlock_height,
             reorg_state: Arc::new(Mutex::new(ReorgState::default())),
             side_headers: Vec::new(),
         })
@@ -128,6 +178,42 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
     /// Current reorg generation counter snapshot.
     pub(crate) fn current_generation(&self) -> u64 {
         self.reorg_generation.load(Ordering::Acquire)
+    }
+
+    /// Best chainlock height as `Option<u32>`. `0` is mapped to `None`
+    /// (no chainlock yet).
+    pub(super) fn best_chainlock_height(&self) -> Option<u32> {
+        match self.chainlock_height.load(Ordering::Acquire) {
+            0 => None,
+            h => Some(h),
+        }
+    }
+
+    /// Drive the reorg cascade for a buffered fork candidate.
+    pub(super) async fn drive_reorg(
+        &mut self,
+        candidate: ForkCandidate,
+    ) -> SyncResult<Option<SyncEvent>> {
+        let current_tip = self.tip().await?;
+        let current_tip_height = current_tip.height();
+        let current_tip_hash = *current_tip.hash();
+        let storages: ReorgStorages<'_, H, FH, F, B> = ReorgStorages {
+            block_header_storage: &self.header_storage,
+            filter_header_storage: self.filter_header_storage.as_ref(),
+            filter_storage: self.filter_storage.as_ref(),
+            block_storage: self.block_storage.as_ref(),
+        };
+        handle_reorg(
+            candidate,
+            &self.reorg_state,
+            &self.reorg_generation,
+            storages,
+            &self.checkpoint_manager,
+            self.best_chainlock_height(),
+            current_tip_height,
+            current_tip_hash,
+        )
+        .await
     }
 
     /// Number of ancestor headers DGW v3 requires to compute next bits.
@@ -442,7 +528,9 @@ mod tests {
     use crate::chain::checkpoints::testnet_checkpoints;
     use crate::network::{MessageType, NetworkEvent, NetworkRequest, RequestSender};
     use crate::storage::{
-        DiskStorageManager, PersistentBlockHeaderStorage, PersistentMetadataStorage, StorageManager,
+        DiskStorageManager, PersistentBlockHeaderStorage, PersistentBlockStorage,
+        PersistentFilterHeaderStorage, PersistentFilterStorage, PersistentMetadataStorage,
+        StorageManager,
     };
     use crate::sync::block_headers::fork_buffer::MAX_FORK_HEADERS_PER_PEER;
     use crate::sync::{ManagerIdentifier, SyncManager, SyncManagerProgress};
@@ -450,8 +538,13 @@ mod tests {
     use dashcore_hashes::Hash;
     use tokio::sync::mpsc::unbounded_channel;
 
-    type TestBlockHeadersManager =
-        BlockHeadersManager<PersistentBlockHeaderStorage, PersistentMetadataStorage>;
+    type TestBlockHeadersManager = BlockHeadersManager<
+        PersistentBlockHeaderStorage,
+        PersistentFilterHeaderStorage,
+        PersistentFilterStorage,
+        PersistentBlockStorage,
+        PersistentMetadataStorage,
+    >;
 
     fn create_test_checkpoint_manager() -> Arc<CheckpointManager> {
         Arc::new(CheckpointManager::new(testnet_checkpoints()))
@@ -463,12 +556,22 @@ mod tests {
         let genesis = Header::dummy_batch(0..1);
         storage.store_headers(&genesis).await.unwrap();
         let checkpoint_manager = create_test_checkpoint_manager();
-        BlockHeadersManager::new(
+        BlockHeadersManager::<
+            PersistentBlockHeaderStorage,
+            PersistentFilterHeaderStorage,
+            PersistentFilterStorage,
+            PersistentBlockStorage,
+            PersistentMetadataStorage,
+        >::new(
             storage.block_headers(),
             storage.metadata(),
+            None,
+            None,
+            None,
             checkpoint_manager,
             Network::Testnet,
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
         )
         .await
         .expect("Failed to create BlockHeadersManager")
@@ -763,12 +866,16 @@ mod tests {
         // First header in dummy_chain has prev = all_zeros (treat as genesis).
         storage.store_headers(&chain).await.unwrap();
         let checkpoint_manager = create_test_checkpoint_manager();
-        let manager = BlockHeadersManager::new(
+        let manager: TestBlockHeadersManager = BlockHeadersManager::new(
             storage.block_headers(),
             storage.metadata(),
+            None,
+            None,
+            None,
             checkpoint_manager,
             Network::Testnet,
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
         )
         .await
         .unwrap();
@@ -846,12 +953,16 @@ mod tests {
         }
         storage.store_headers(&chain).await.unwrap();
         let checkpoint_manager = Arc::new(CheckpointManager::new(vec![]));
-        let manager = BlockHeadersManager::new(
+        let manager: TestBlockHeadersManager = BlockHeadersManager::new(
             storage.block_headers(),
             storage.metadata(),
+            None,
+            None,
+            None,
             checkpoint_manager,
             Network::Regtest,
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
         )
         .await
         .expect("failed to create regtest manager");

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -251,7 +251,9 @@ impl<
                 let incoming = headers.len();
                 let cap = Self::MAX_SIDE_HEADERS;
                 if self.side_headers.len() + incoming > cap {
-                    let excess = (self.side_headers.len() + incoming).saturating_sub(cap);
+                    let excess = (self.side_headers.len() + incoming)
+                        .saturating_sub(cap)
+                        .min(self.side_headers.len());
                     self.side_headers.drain(..excess);
                 }
                 for (height, h) in (ancestor_height + 1..).zip(headers.iter()) {

--- a/dash-spv/src/sync/block_headers/sync_manager.rs
+++ b/dash-spv/src/sync/block_headers/sync_manager.rs
@@ -1,6 +1,8 @@
 use crate::error::SyncResult;
 use crate::network::{Message, MessageType, NetworkEvent, RequestSender};
-use crate::storage::{BlockHeaderStorage, MetadataStorage};
+use crate::storage::{
+    BlockHeaderStorage, BlockStorage, FilterHeaderStorage, FilterStorage, MetadataStorage,
+};
 use crate::sync::sync_manager::ensure_not_started;
 use crate::sync::{
     BlockHeadersManager, ManagerIdentifier, ProgressPercentage, SyncEvent, SyncManager,
@@ -18,7 +20,14 @@ pub(super) const UNSOLICITED_HEADERS_WAIT_TIMEOUT: Duration = Duration::from_sec
 pub(super) const FORK_BUFFER_TTL: Duration = Duration::from_secs(60);
 
 #[async_trait]
-impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for BlockHeadersManager<H, M> {
+impl<
+        H: BlockHeaderStorage,
+        FH: FilterHeaderStorage,
+        F: FilterStorage,
+        B: BlockStorage,
+        M: MetadataStorage,
+    > SyncManager for BlockHeadersManager<H, FH, F, B, M>
+{
     fn identifier(&self) -> ManagerIdentifier {
         ManagerIdentifier::BlockHeader
     }
@@ -131,16 +140,23 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for BlockHeadersMana
             tracing::debug!("Expired {} stale fork branches", evicted);
             self.prune_fork_tip_index();
         }
+
+        // Evict deny-list entries that the chainlock floor has caught up to.
+        if let Some(cl_height) = self.best_chainlock_height() {
+            let mut state = self.reorg_state.lock().await;
+            state.evict_expired_denials(cl_height);
+        }
+
+        let mut events: Vec<SyncEvent> = Vec::new();
         if let Some(candidate) = self.take_pending_fork_candidate() {
-            // Reorg promotion is not yet wired into the coordinator. Log here
-            // so detection can be confirmed end-to-end before that lands.
-            tracing::warn!(
-                "Fork candidate ready (ancestor={} headers={} work_bytes={:?}), \
-                 reorg promotion not yet wired",
+            tracing::info!(
+                "driving reorg cascade: ancestor={} headers={}",
                 candidate.ancestor_height,
-                candidate.headers.len(),
-                candidate.total_work.as_bytes()
+                candidate.headers.len()
             );
+            if let Some(event) = self.drive_reorg(candidate).await? {
+                events.push(event);
+            }
         }
 
         // During initial sync, send more requests and log progress.
@@ -153,7 +169,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for BlockHeadersMana
                 tracing::debug!("Tick: pipeline sent {} more requests", sent);
             }
 
-            return Ok(vec![]);
+            return Ok(events);
         }
 
         // Post-sync: check for stale block announcements
@@ -185,7 +201,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for BlockHeadersMana
             }
         }
 
-        Ok(vec![])
+        Ok(events)
     }
 
     async fn handle_network_event(

--- a/dash-spv/src/sync/block_headers/sync_manager.rs
+++ b/dash-spv/src/sync/block_headers/sync_manager.rs
@@ -150,9 +150,10 @@ impl<
         let mut events: Vec<SyncEvent> = Vec::new();
         if let Some(candidate) = self.take_pending_fork_candidate() {
             tracing::info!(
-                "driving reorg cascade: ancestor={} headers={}",
+                "driving reorg cascade: ancestor={} headers={} work_bytes={:?}",
                 candidate.ancestor_height,
-                candidate.headers.len()
+                candidate.headers.len(),
+                candidate.total_work.as_bytes()
             );
             if let Some(event) = self.drive_reorg(candidate).await? {
                 events.push(event);

--- a/dash-spv/src/sync/blocks/manager.rs
+++ b/dash-spv/src/sync/blocks/manager.rs
@@ -3,6 +3,7 @@
 //! Downloads blocks that matched wallet filters and processes them in height order.
 //! Subscribes to BlockNeeded events and emits BlockProcessed events.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -39,6 +40,9 @@ pub struct BlocksManager<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterf
     pub(super) pipeline: BlocksPipeline,
     /// Whether FiltersSyncComplete has been received.
     pub(super) filters_sync_complete: bool,
+    /// Shared generation counter used to invalidate stale `Block` responses
+    /// delivered after a reorg cascade.
+    pub(super) reorg_generation: Arc<AtomicU64>,
 }
 
 impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H, B, W> {
@@ -47,6 +51,7 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
         wallet: Arc<RwLock<W>>,
         header_storage: Arc<RwLock<H>>,
         block_storage: Arc<RwLock<B>>,
+        reorg_generation: Arc<AtomicU64>,
     ) -> Self {
         let last_processed_height = wallet.read().await.last_processed_height();
 
@@ -60,11 +65,18 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface> BlocksManager<H
             wallet,
             pipeline: BlocksPipeline::new(),
             filters_sync_complete: false,
+            reorg_generation,
         }
     }
 
+    /// Current reorg generation counter snapshot.
+    pub(super) fn current_generation(&self) -> u64 {
+        self.reorg_generation.load(Ordering::Acquire)
+    }
+
     pub(super) async fn send_pending(&mut self, requests: &RequestSender) -> SyncResult<()> {
-        let sent = self.pipeline.send_pending(requests).await?;
+        let sent =
+            self.pipeline.send_pending_with_generation(requests, self.current_generation()).await?;
         if sent > 0 {
             self.progress.add_requested(sent as u32);
         }
@@ -183,7 +195,13 @@ mod tests {
     async fn create_test_manager() -> TestBlocksManager {
         let storage = DiskStorageManager::with_temp_dir().await.unwrap();
         let wallet = Arc::new(RwLock::new(MockWallet::new()));
-        BlocksManager::new(wallet, storage.block_headers(), storage.blocks()).await
+        BlocksManager::new(
+            wallet,
+            storage.block_headers(),
+            storage.blocks(),
+            Arc::new(AtomicU64::new(0)),
+        )
+        .await
     }
 
     #[tokio::test]
@@ -296,7 +314,13 @@ mod tests {
             PersistentBlockHeaderStorage,
             PersistentBlockStorage,
             MultiMockWallet,
-        > = BlocksManager::new(multi.clone(), storage.block_headers(), storage.blocks()).await;
+        > = BlocksManager::new(
+            multi.clone(),
+            storage.block_headers(),
+            storage.blocks(),
+            Arc::new(AtomicU64::new(0)),
+        )
+        .await;
         manager.progress.set_state(SyncState::Syncing);
 
         let header = Header {

--- a/dash-spv/src/sync/blocks/manager.rs
+++ b/dash-spv/src/sync/blocks/manager.rs
@@ -388,4 +388,47 @@ mod tests {
         assert!(!manager.pipeline.is_complete(), "downloaded buffer must survive on_disconnect");
         assert!(manager.filters_sync_complete);
     }
+
+    /// `SyncEvent::ChainReorg` must reset the pipeline, clear
+    /// `filters_sync_complete`, and move the manager back to `WaitForEvents`.
+    #[tokio::test]
+    async fn chain_reorg_event_resets_pipeline_and_state() {
+        use dashcore::block::Header;
+        use dashcore::{Block, TxMerkleNode};
+        use dashcore_hashes::Hash;
+
+        let mut manager = create_test_manager().await;
+        manager.filters_sync_complete = true;
+        manager.progress.set_state(SyncState::Syncing);
+
+        let header = Header {
+            version: dashcore::blockdata::block::Version::from_consensus(1),
+            prev_blockhash: dashcore::BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 0,
+            bits: dashcore::CompactTarget::from_consensus(0),
+            nonce: 0,
+        };
+        let block = Block {
+            header,
+            txdata: vec![],
+        };
+        manager.pipeline.add_from_storage(block, 100, BTreeSet::from([MOCK_WALLET_ID]));
+        assert!(!manager.pipeline.is_complete(), "pipeline must have pending work before reorg");
+
+        let network = MockNetworkManager::new();
+        let requests = network.request_sender();
+        let event = SyncEvent::ChainReorg {
+            fork_height: 50,
+            old_tip: dashcore::BlockHash::all_zeros(),
+            new_tip: dashcore::BlockHash::all_zeros(),
+            generation: 1,
+        };
+
+        let events = manager.handle_sync_event(&event, &requests).await.unwrap();
+        assert!(events.is_empty());
+        assert!(manager.pipeline.is_complete(), "pipeline must be empty after ChainReorg");
+        assert!(!manager.filters_sync_complete, "filters_sync_complete must be cleared");
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
+    }
 }

--- a/dash-spv/src/sync/blocks/pipeline.rs
+++ b/dash-spv/src/sync/blocks/pipeline.rs
@@ -103,17 +103,12 @@ impl BlocksPipeline {
         self.coordinator.available_to_send() > 0
     }
 
-    /// Send pending block requests up to the concurrency limit.
-    ///
-    /// Sends multiple smaller GetData messages to distribute requests across peers.
-    /// Returns the number of blocks requested.
-    pub(super) async fn send_pending(&mut self, requests: &RequestSender) -> SyncResult<usize> {
-        self.send_pending_with_generation(requests, 0).await
-    }
-
     /// Send pending block requests up to the concurrency limit, tagging each
     /// in-flight slot with the current reorg generation so stale block
     /// responses can be dropped.
+    ///
+    /// Sends multiple smaller GetData messages to distribute requests across peers.
+    /// Returns the number of blocks requested.
     pub(super) async fn send_pending_with_generation(
         &mut self,
         requests: &RequestSender,

--- a/dash-spv/src/sync/blocks/pipeline.rs
+++ b/dash-spv/src/sync/blocks/pipeline.rs
@@ -108,6 +108,17 @@ impl BlocksPipeline {
     /// Sends multiple smaller GetData messages to distribute requests across peers.
     /// Returns the number of blocks requested.
     pub(super) async fn send_pending(&mut self, requests: &RequestSender) -> SyncResult<usize> {
+        self.send_pending_with_generation(requests, 0).await
+    }
+
+    /// Send pending block requests up to the concurrency limit, tagging each
+    /// in-flight slot with the current reorg generation so stale block
+    /// responses can be dropped.
+    pub(super) async fn send_pending_with_generation(
+        &mut self,
+        requests: &RequestSender,
+        generation: u64,
+    ) -> SyncResult<usize> {
         let mut total_sent = 0;
 
         while self.coordinator.available_to_send() > 0 {
@@ -119,18 +130,25 @@ impl BlocksPipeline {
             }
 
             requests.request_blocks(hashes.clone())?;
-            self.coordinator.mark_sent(&hashes);
+            self.coordinator.mark_sent_with_generation(&hashes, generation);
             total_sent += hashes.len();
 
             tracing::debug!(
-                "Requested {} blocks ({} downloading, {} pending)",
+                "Requested {} blocks ({} downloading, {} pending, generation {})",
                 hashes.len(),
                 self.coordinator.active_count(),
-                self.coordinator.pending_count()
+                self.coordinator.pending_count(),
+                generation
             );
         }
 
         Ok(total_sent)
+    }
+
+    /// Look up the generation snapshot recorded when the block download for
+    /// `hash` was sent.
+    pub(super) fn generation_for_hash(&self, hash: &BlockHash) -> Option<u64> {
+        self.coordinator.generation_for(hash)
     }
 
     /// Handle a received block using internal height mapping.

--- a/dash-spv/src/sync/blocks/sync_manager.rs
+++ b/dash-spv/src/sync/blocks/sync_manager.rs
@@ -185,6 +185,23 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface + 'static> SyncM
             return self.process_buffered_blocks().await;
         }
 
+        // React to a cascade-driven reorg: drop all in-flight block work so the
+        // truncated chain's filter pipeline can re-issue downloads from scratch.
+        if let SyncEvent::ChainReorg {
+            fork_height,
+            ..
+        } = event
+        {
+            tracing::info!(
+                "BlocksManager: cascading ChainReorg, resetting pipeline at {}",
+                fork_height
+            );
+            self.pipeline = super::pipeline::BlocksPipeline::new();
+            self.filters_sync_complete = false;
+            self.set_state(SyncState::WaitForEvents);
+            return Ok(vec![]);
+        }
+
         // React to FiltersSyncComplete - filters are done, no more BlocksNeeded events coming
         if let SyncEvent::FiltersSyncComplete {
             ..

--- a/dash-spv/src/sync/blocks/sync_manager.rs
+++ b/dash-spv/src/sync/blocks/sync_manager.rs
@@ -73,6 +73,17 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface + 'static> SyncM
 
         let hashed_block = HashedBlock::from(block);
 
+        let current_gen = self.current_generation();
+        if let Some(req_gen) = self.pipeline.generation_for_hash(hashed_block.hash()) {
+            if req_gen != current_gen {
+                tracing::debug!(
+                    "dropping stale Block {}: generation {} != {}",
+                    hashed_block.hash(), req_gen, current_gen
+                );
+                return Ok(vec![]);
+            }
+        }
+
         // Check if this is a block we requested (pipeline handles buffering with height)
         if !self.pipeline.receive_block(block) {
             tracing::debug!("Received unrequested block {}", hashed_block.hash());

--- a/dash-spv/src/sync/blocks/sync_manager.rs
+++ b/dash-spv/src/sync/blocks/sync_manager.rs
@@ -78,7 +78,9 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface + 'static> SyncM
             if req_gen != current_gen {
                 tracing::debug!(
                     "dropping stale Block {}: generation {} != {}",
-                    hashed_block.hash(), req_gen, current_gen
+                    hashed_block.hash(),
+                    req_gen,
+                    current_gen
                 );
                 return Ok(vec![]);
             }

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -285,12 +285,6 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> ChainLockManager<H, M> {
         self.best_chainlock.as_ref()
     }
 
-    /// Height of the best validated ChainLock, if any. Used by the reorg
-    /// pipeline as the lower bound below which a fork ancestor cannot land.
-    pub(crate) fn best_chainlock_height(&self) -> Option<u32> {
-        self.best_chainlock.as_ref().map(|cl| cl.block_height)
-    }
-
     /// Check if a block at the given height is chainlocked.
     /// All blocks at or below the best validated ChainLock height are considered locked.
     pub fn is_block_chainlocked(&self, height: u32) -> bool {

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -5,6 +5,7 @@
 //! (all blocks below the best ChainLock are implicitly locked), we only track
 //! the best validated ChainLock.
 
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use dashcore::ephemerealdata::chain_lock::ChainLock;
@@ -48,6 +49,10 @@ pub struct ChainLockManager<H: BlockHeaderStorage, M: MetadataStorage> {
     /// so we don't lose a chainlock that landed during the gap between
     /// the chainlock manager starting and masternode sync completing.
     pending_validation: Option<ChainLock>,
+    /// Shared snapshot of the best validated chainlock height. `0` means
+    /// "no chainlock observed yet". Read by `BlockHeadersManager` as the
+    /// floor for the reorg cascade.
+    chainlock_height: Arc<AtomicU32>,
 }
 
 impl<H: BlockHeaderStorage, M: MetadataStorage> ChainLockManager<H, M> {
@@ -56,6 +61,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> ChainLockManager<H, M> {
         header_storage: Arc<RwLock<H>>,
         metadata_storage: Arc<RwLock<M>>,
         masternode_engine: Arc<RwLock<MasternodeListEngine>>,
+        chainlock_height: Arc<AtomicU32>,
     ) -> Self {
         let mut manager = Self {
             progress: ChainLockProgress::default(),
@@ -66,10 +72,14 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> ChainLockManager<H, M> {
             requested_chainlocks: HashSet::new(),
             masternode_ready: false,
             pending_validation: None,
+            chainlock_height,
         };
 
         // TODO: Move load_best_chainlock() and save_best_chainlock() to MetadataStorage trait.
         manager.load_best_chainlock().await;
+        if let Some(cl) = &manager.best_chainlock {
+            manager.chainlock_height.store(cl.block_height, Ordering::Release);
+        }
 
         manager
     }
@@ -99,7 +109,9 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> ChainLockManager<H, M> {
             if self.verify_block_hash(&pending).await && self.validate_signature(&pending).await {
                 self.progress.add_valid(1);
                 self.progress.update_best_validated_height(pending.block_height);
+                let height = pending.block_height;
                 self.best_chainlock = Some(pending);
+                self.chainlock_height.store(height, Ordering::Release);
                 self.save_best_chainlock().await;
             } else {
                 self.progress.add_invalid(1);
@@ -168,6 +180,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> ChainLockManager<H, M> {
 
             // Update best ChainLock and persist to storage
             self.best_chainlock = Some(chainlock.clone());
+            self.chainlock_height.store(height, Ordering::Release);
             self.save_best_chainlock().await;
         } else {
             self.progress.add_invalid(1);
@@ -315,7 +328,13 @@ mod tests {
         let storage = DiskStorageManager::with_temp_dir().await.unwrap();
         let engine =
             Arc::new(RwLock::new(MasternodeListEngine::default_for_network(Network::Testnet)));
-        ChainLockManager::new(storage.block_headers(), storage.metadata(), engine).await
+        ChainLockManager::new(
+            storage.block_headers(),
+            storage.metadata(),
+            engine,
+            Arc::new(AtomicU32::new(0)),
+        )
+        .await
     }
 
     async fn create_test_manager_with_storage(
@@ -323,7 +342,13 @@ mod tests {
     ) -> TestChainLockManager {
         let engine =
             Arc::new(RwLock::new(MasternodeListEngine::default_for_network(Network::Testnet)));
-        ChainLockManager::new(storage.block_headers(), storage.metadata(), engine).await
+        ChainLockManager::new(
+            storage.block_headers(),
+            storage.metadata(),
+            engine,
+            Arc::new(AtomicU32::new(0)),
+        )
+        .await
     }
 
     fn create_test_chainlock(height: u32) -> ChainLock {

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -272,6 +272,12 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> ChainLockManager<H, M> {
         self.best_chainlock.as_ref()
     }
 
+    /// Height of the best validated ChainLock, if any. Used by the reorg
+    /// pipeline as the lower bound below which a fork ancestor cannot land.
+    pub(crate) fn best_chainlock_height(&self) -> Option<u32> {
+        self.best_chainlock.as_ref().map(|cl| cl.block_height)
+    }
+
     /// Check if a block at the given height is chainlocked.
     /// All blocks at or below the best validated ChainLock height are considered locked.
     pub fn is_block_chainlocked(&self, height: u32) -> bool {

--- a/dash-spv/src/sync/download_coordinator.rs
+++ b/dash-spv/src/sync/download_coordinator.rs
@@ -58,6 +58,9 @@ pub(crate) struct DownloadCoordinator<K: Hash + Eq + Clone> {
     pending: VecDeque<K>,
     /// Items currently in-flight (key -> sent time).
     in_flight: HashMap<K, Instant>,
+    /// Generation snapshot taken when each in-flight key was marked sent.
+    /// Used by reorg-aware pipelines to drop stale responses.
+    generations: HashMap<K, u64>,
     /// Retry counts per key.
     retry_counts: HashMap<K, u32>,
     /// Configuration.
@@ -78,6 +81,7 @@ impl<K: Hash + Eq + Clone> DownloadCoordinator<K> {
         Self {
             pending: VecDeque::new(),
             in_flight: HashMap::new(),
+            generations: HashMap::new(),
             retry_counts: HashMap::new(),
             config,
             last_progress: Instant::now(),
@@ -88,6 +92,7 @@ impl<K: Hash + Eq + Clone> DownloadCoordinator<K> {
     pub(crate) fn clear(&mut self) {
         self.pending.clear();
         self.in_flight.clear();
+        self.generations.clear();
         self.retry_counts.clear();
         self.last_progress = Instant::now();
     }
@@ -103,6 +108,9 @@ impl<K: Hash + Eq + Clone> DownloadCoordinator<K> {
         let items: Vec<K> = self.in_flight.drain().map(|(k, _)| k).collect();
         if items.is_empty() {
             return;
+        }
+        for item in &items {
+            self.generations.remove(item);
         }
         for item in items.into_iter().rev() {
             self.pending.push_front(item);
@@ -152,11 +160,27 @@ impl<K: Hash + Eq + Clone> DownloadCoordinator<K> {
         }
     }
 
+    /// Mark items as sent and tag them with a generation snapshot, so a later
+    /// `receive` from a stale generation can be detected and dropped.
+    pub(crate) fn mark_sent_with_generation(&mut self, items: &[K], generation: u64) {
+        let now = Instant::now();
+        for item in items {
+            self.in_flight.insert(item.clone(), now);
+            self.generations.insert(item.clone(), generation);
+        }
+    }
+
+    /// Read the generation snapshot recorded for an in-flight key.
+    pub(crate) fn generation_for(&self, key: &K) -> Option<u64> {
+        self.generations.get(key).copied()
+    }
+
     /// Handle a received item.
     ///
     /// Returns true if the item was being tracked, false if unexpected.
     pub(crate) fn receive(&mut self, key: &K) -> bool {
         if self.in_flight.remove(key).is_some() {
+            self.generations.remove(key);
             self.retry_counts.remove(key);
             self.last_progress = Instant::now();
             true
@@ -175,6 +199,7 @@ impl<K: Hash + Eq + Clone> DownloadCoordinator<K> {
     pub(crate) fn cancel_pending(&mut self, key: &K) {
         self.pending.retain(|k| k != key);
         self.retry_counts.remove(key);
+        self.generations.remove(key);
     }
 
     /// Check if an item is currently in-flight.
@@ -197,6 +222,7 @@ impl<K: Hash + Eq + Clone> DownloadCoordinator<K> {
 
         for key in &timed_out {
             self.in_flight.remove(key);
+            self.generations.remove(key);
         }
 
         if !timed_out.is_empty() {

--- a/dash-spv/src/sync/events.rs
+++ b/dash-spv/src/sync/events.rs
@@ -176,6 +176,37 @@ pub enum SyncEvent {
         /// Sync cycle (0 = initial, 1+ = incremental)
         cycle: u32,
     },
+
+    /// A reorg cascade has truncated downstream storages and bumped the
+    /// generation counter. Downstream managers (`FilterHeadersManager`,
+    /// `FiltersManager`, `BlocksManager`) listen for this and reset their
+    /// pipelines at `fork_height`.
+    ///
+    /// Emitted by: `BlockHeadersManager`
+    /// Consumed by: `FilterHeadersManager`, `FiltersManager`, `BlocksManager`
+    ChainReorg {
+        /// Common-ancestor height in the active chain prior to truncation.
+        fork_height: u32,
+        /// Previous chain tip hash before truncation.
+        old_tip: BlockHash,
+        /// New tip hash of the promoted fork branch.
+        new_tip: BlockHash,
+        /// Generation counter value after the cascade. Used by managers
+        /// to discard stale in-flight responses tagged with prior values.
+        generation: u64,
+    },
+
+    /// A fork branch deeper than the depth cap was detected and denied.
+    /// No truncation occurs.
+    ///
+    /// Emitted by: `BlockHeadersManager`
+    /// Consumed by: External listeners (monitoring only)
+    DeepReorgDetected {
+        /// Common-ancestor height that the fork claims.
+        fork_height: u32,
+        /// Depth of the proposed reorg (active_tip_height - fork_height).
+        depth: u32,
+    },
 }
 
 impl fmt::Display for SyncEvent {
@@ -260,6 +291,20 @@ impl fmt::Display for SyncEvent {
                 header_tip,
                 cycle,
             } => write!(f, "SyncComplete(tip={}, cycle={})", header_tip, cycle),
+            SyncEvent::ChainReorg {
+                fork_height,
+                old_tip,
+                new_tip,
+                generation,
+            } => write!(
+                f,
+                "ChainReorg(fork_height={}, old_tip={}, new_tip={}, generation={})",
+                fork_height, old_tip, new_tip, generation
+            ),
+            SyncEvent::DeepReorgDetected {
+                fork_height,
+                depth,
+            } => write!(f, "DeepReorgDetected(fork_height={}, depth={})", fork_height, depth),
         }
     }
 }

--- a/dash-spv/src/sync/filter_headers/manager.rs
+++ b/dash-spv/src/sync/filter_headers/manager.rs
@@ -3,6 +3,7 @@
 //! Downloads compact block filter headers (BIP 157/158). Reacts to BlockHeadersStored
 //! events to know when new headers are available. Emits FilterHeadersStored events.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use dashcore::network::message_filter::CFHeaders;
@@ -40,6 +41,9 @@ pub struct FilterHeadersManager<H: BlockHeaderStorage, FH: FilterHeaderStorage> 
     /// Whether block header sync has completed. Gates FilterHeadersSyncComplete emission
     /// to ensure it never fires before BlockHeaderSyncComplete.
     pub(super) block_headers_synced: bool,
+    /// Shared generation counter used to invalidate stale `CFHeaders`
+    /// responses delivered after a reorg cascade.
+    pub(super) reorg_generation: Arc<AtomicU64>,
 }
 
 impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> FilterHeadersManager<H, FH> {
@@ -69,6 +73,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> FilterHeadersManager<H, FH>
     pub async fn new(
         header_storage: Arc<RwLock<H>>,
         filter_header_storage: Arc<RwLock<FH>>,
+        reorg_generation: Arc<AtomicU64>,
     ) -> SyncResult<Self> {
         // Load current filter tip
         let filter_tip =
@@ -90,7 +95,13 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> FilterHeadersManager<H, FH>
             pipeline: FilterHeadersPipeline::default(),
             checkpoint_start_height: None,
             block_headers_synced: false,
+            reorg_generation,
         })
+    }
+
+    /// Current reorg generation counter snapshot.
+    pub(super) fn current_generation(&self) -> u64 {
+        self.reorg_generation.load(Ordering::Acquire)
     }
 
     /// Process a CFHeaders response - store headers and update state.
@@ -179,7 +190,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> FilterHeadersManager<H, FH>
         drop(header_storage);
 
         // Send initial requests
-        self.pipeline.send_pending(requests)?;
+        self.pipeline.send_pending_with_generation(requests, self.current_generation())?;
 
         self.set_state(SyncState::Syncing);
 
@@ -227,7 +238,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> FilterHeadersManager<H, FH>
                         .await?;
                 }
                 drop(header_storage);
-                self.pipeline.send_pending(requests)?;
+                self.pipeline.send_pending_with_generation(requests, self.current_generation())?;
                 Ok(vec![])
             }
             SyncState::WaitingForConnections | SyncState::WaitForEvents => {
@@ -262,9 +273,13 @@ mod tests {
 
     async fn create_test_manager() -> TestFilterHeadersManager {
         let storage = DiskStorageManager::with_temp_dir().await.unwrap();
-        FilterHeadersManager::new(storage.block_headers(), storage.filter_headers())
-            .await
-            .expect("Failed to create FilterHeadersManager")
+        FilterHeadersManager::new(
+            storage.block_headers(),
+            storage.filter_headers(),
+            Arc::new(AtomicU64::new(0)),
+        )
+        .await
+        .expect("Failed to create FilterHeadersManager")
     }
 
     fn create_test_request_sender(

--- a/dash-spv/src/sync/filter_headers/pipeline.rs
+++ b/dash-spv/src/sync/filter_headers/pipeline.rs
@@ -169,11 +169,6 @@ impl FilterHeadersPipeline {
         Ok(())
     }
 
-    /// Send pending requests using a RequestSender (synchronous).
-    pub(super) fn send_pending(&mut self, requests: &RequestSender) -> SyncResult<usize> {
-        self.send_pending_with_generation(requests, 0)
-    }
-
     /// Send pending requests, tagging each in-flight slot with the current
     /// reorg generation so stale `CFHeaders` responses can be dropped.
     pub(super) fn send_pending_with_generation(
@@ -435,7 +430,7 @@ mod tests {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let requests = RequestSender::new(tx);
 
-        let err = pipeline.send_pending(&requests).unwrap_err();
+        let err = pipeline.send_pending_with_generation(&requests, 0).unwrap_err();
         assert!(matches!(err, SyncError::InvalidState(_)));
     }
 

--- a/dash-spv/src/sync/filter_headers/pipeline.rs
+++ b/dash-spv/src/sync/filter_headers/pipeline.rs
@@ -171,6 +171,16 @@ impl FilterHeadersPipeline {
 
     /// Send pending requests using a RequestSender (synchronous).
     pub(super) fn send_pending(&mut self, requests: &RequestSender) -> SyncResult<usize> {
+        self.send_pending_with_generation(requests, 0)
+    }
+
+    /// Send pending requests, tagging each in-flight slot with the current
+    /// reorg generation so stale `CFHeaders` responses can be dropped.
+    pub(super) fn send_pending_with_generation(
+        &mut self,
+        requests: &RequestSender,
+        generation: u64,
+    ) -> SyncResult<usize> {
         let count = self.coordinator.available_to_send();
         if count == 0 {
             return Ok(0);
@@ -189,20 +199,27 @@ impl FilterHeadersPipeline {
 
             requests.request_filter_headers(start_height, stop_hash)?;
 
-            self.coordinator.mark_sent(&[stop_hash]);
+            self.coordinator.mark_sent_with_generation(&[stop_hash], generation);
 
             tracing::debug!(
-                "Sent GetCFHeaders: start={}, stop={} ({} active, {} pending)",
+                "Sent GetCFHeaders: start={}, stop={} ({} active, {} pending, generation {})",
                 start_height,
                 stop_hash,
                 self.coordinator.active_count(),
-                self.coordinator.pending_count()
+                self.coordinator.pending_count(),
+                generation
             );
 
             sent += 1;
         }
 
         Ok(sent)
+    }
+
+    /// Look up the generation snapshot recorded when the batch ending at
+    /// `stop_hash` was sent.
+    pub(super) fn generation_for_stop_hash(&self, stop_hash: &BlockHash) -> Option<u64> {
+        self.coordinator.generation_for(stop_hash)
     }
 
     /// Try to match an incoming message to a pipeline response.

--- a/dash-spv/src/sync/filter_headers/sync_manager.rs
+++ b/dash-spv/src/sync/filter_headers/sync_manager.rs
@@ -152,6 +152,20 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> SyncManager for FilterHeade
             SyncEvent::BlockHeadersStored {
                 tip_height,
             } => self.handle_new_headers(*tip_height, requests).await,
+            SyncEvent::ChainReorg {
+                fork_height,
+                ..
+            } => {
+                tracing::info!(
+                    "FilterHeadersManager: cascading ChainReorg, resetting pipeline at {}",
+                    fork_height
+                );
+                self.pipeline = FilterHeadersPipeline::default();
+                self.checkpoint_start_height = None;
+                self.progress.update_current_height(*fork_height);
+                self.set_state(SyncState::WaitForEvents);
+                Ok(vec![])
+            }
             _ => Ok(vec![]),
         }
     }

--- a/dash-spv/src/sync/filter_headers/sync_manager.rs
+++ b/dash-spv/src/sync/filter_headers/sync_manager.rs
@@ -57,7 +57,9 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> SyncManager for FilterHeade
             if req_gen != current_gen {
                 tracing::debug!(
                     "dropping stale CFHeaders stop_hash {}: generation {} != {}",
-                    cfheaders.stop_hash, req_gen, current_gen
+                    cfheaders.stop_hash,
+                    req_gen,
+                    current_gen
                 );
                 return Ok(vec![]);
             }

--- a/dash-spv/src/sync/filter_headers/sync_manager.rs
+++ b/dash-spv/src/sync/filter_headers/sync_manager.rs
@@ -52,6 +52,17 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> SyncManager for FilterHeade
             return Ok(vec![]);
         };
 
+        let current_gen = self.current_generation();
+        if let Some(req_gen) = self.pipeline.generation_for_stop_hash(&cfheaders.stop_hash) {
+            if req_gen != current_gen {
+                tracing::debug!(
+                    "dropping stale CFHeaders stop_hash {}: generation {} != {}",
+                    cfheaders.stop_hash, req_gen, current_gen
+                );
+                return Ok(vec![]);
+            }
+        }
+
         let mut events = Vec::new();
 
         // Try to receive (may buffer if out of order)
@@ -115,7 +126,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> SyncManager for FilterHeade
         }
 
         // Send more requests
-        self.pipeline.send_pending(requests)?;
+        self.pipeline.send_pending_with_generation(requests, self.current_generation())?;
 
         if self.pipeline.is_complete() {
             if let Some(event) = self.try_complete_sync() {
@@ -150,7 +161,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> SyncManager for FilterHeade
         self.pipeline.handle_timeouts();
 
         // Send pending requests (including retries)
-        self.pipeline.send_pending(requests)?;
+        self.pipeline.send_pending_with_generation(requests, self.current_generation())?;
 
         Ok(vec![])
     }

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -5,6 +5,7 @@
 //! Emits FiltersStored, FiltersSyncComplete and BlocksNeeded events.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use dashcore::bip158::BlockFilter;
@@ -71,6 +72,9 @@ pub struct FiltersManager<
     /// `BlockProcessed` and the per-wallet record of which wallets already
     /// have a given processed block applied.
     pub(super) tracker: BlockMatchTracker,
+    /// Shared generation counter used to invalidate stale `CFilter`
+    /// responses delivered after a reorg cascade.
+    pub(super) reorg_generation: Arc<AtomicU64>,
 }
 
 impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: WalletInterface>
@@ -82,6 +86,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         header_storage: Arc<RwLock<H>>,
         filter_header_storage: Arc<RwLock<FH>>,
         filter_storage: Arc<RwLock<F>>,
+        reorg_generation: Arc<AtomicU64>,
     ) -> Self {
         let committed_height = wallet.read().await.synced_height();
         let stored_height = filter_storage.read().await.filter_tip_height().await.unwrap_or(0);
@@ -115,7 +120,13 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             active_batches: BTreeMap::new(),
             processing_height: 0,
             tracker: BlockMatchTracker::new(),
+            reorg_generation,
         }
+    }
+
+    /// Current reorg generation counter snapshot.
+    pub(super) fn current_generation(&self) -> u64 {
+        self.reorg_generation.load(Ordering::Acquire)
     }
 
     /// Returns true if there is no in-flight processing state.
@@ -234,7 +245,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         if download_start <= self.progress.filter_header_tip_height() {
             self.filter_pipeline.init(download_start, self.progress.filter_header_tip_height());
             let header_storage = self.header_storage.read().await;
-            self.filter_pipeline.send_pending(requests, &*header_storage).await?;
+            self.filter_pipeline.send_pending(requests, &*header_storage, self.current_generation()).await?;
             drop(header_storage);
         } else {
             // No new filters to download, scanning stored filters only
@@ -890,7 +901,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                 self.filter_pipeline.extend_target(tip_height);
                 if self.progress.stored_height() < self.progress.filter_header_tip_height() {
                     let header_storage = self.header_storage.read().await;
-                    self.filter_pipeline.send_pending(requests, &*header_storage).await?;
+                    self.filter_pipeline.send_pending(requests, &*header_storage, self.current_generation()).await?;
                 }
 
                 if self.active_batches.is_empty() {
@@ -962,6 +973,7 @@ mod tests {
             storage.block_headers(),
             storage.filter_headers(),
             storage.filters(),
+            Arc::new(AtomicU64::new(0)),
         )
         .await
     }
@@ -975,6 +987,7 @@ mod tests {
             storage.block_headers(),
             storage.filter_headers(),
             storage.filters(),
+            Arc::new(AtomicU64::new(0)),
         )
         .await
     }
@@ -1041,6 +1054,7 @@ mod tests {
             storage.block_headers(),
             storage.filter_headers(),
             storage.filters(),
+            Arc::new(AtomicU64::new(0)),
         )
         .await;
 

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -257,7 +257,9 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         if download_start <= self.progress.filter_header_tip_height() {
             self.filter_pipeline.init(download_start, self.progress.filter_header_tip_height());
             let header_storage = self.header_storage.read().await;
-            self.filter_pipeline.send_pending(requests, &*header_storage, self.current_generation()).await?;
+            self.filter_pipeline
+                .send_pending(requests, &*header_storage, self.current_generation())
+                .await?;
             drop(header_storage);
         } else {
             // No new filters to download, scanning stored filters only
@@ -913,7 +915,9 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                 self.filter_pipeline.extend_target(tip_height);
                 if self.progress.stored_height() < self.progress.filter_header_tip_height() {
                     let header_storage = self.header_storage.read().await;
-                    self.filter_pipeline.send_pending(requests, &*header_storage, self.current_generation()).await?;
+                    self.filter_pipeline
+                        .send_pending(requests, &*header_storage, self.current_generation())
+                        .await?;
                 }
 
                 if self.active_batches.is_empty() {

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -149,6 +149,18 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         self.filter_pipeline = FiltersPipeline::new();
     }
 
+    /// Reset all sync state to begin again at `fork_height` after a reorg
+    /// cascade. Clears in-flight batches and rewinds the per-batch
+    /// processing cursors so the next `FilterHeadersStored` event drives a
+    /// fresh download starting at the truncated ancestor.
+    pub(super) fn reset_for_reorg(&mut self, fork_height: u32) {
+        self.reset_for_rescan();
+        self.next_batch_to_store = fork_height;
+        self.processing_height = fork_height;
+        self.progress.update_committed_height(fork_height);
+        self.progress.update_stored_height(fork_height);
+    }
+
     async fn load_filters(
         &self,
         start_height: u32,

--- a/dash-spv/src/sync/filters/pipeline.rs
+++ b/dash-spv/src/sync/filters/pipeline.rs
@@ -1095,6 +1095,35 @@ mod tests {
         );
     }
 
+    /// `send_pending` with a generation tag records the snapshot on the
+    /// coordinator and `generation_for_height` returns it back exactly,
+    /// while a later generation bump means the same height now reports a
+    /// "different" generation so the manager-side check drops the response.
+    #[tokio::test]
+    async fn test_generation_tagging_round_trips_through_pipeline() {
+        let headers = Header::dummy_batch(0..1000);
+        let tmp_dir = TempDir::new().unwrap();
+        let mut storage = PersistentBlockHeaderStorage::open(tmp_dir.path()).await.unwrap();
+        storage.store_headers(&headers).await.unwrap();
+
+        let mut pipeline = FiltersPipeline::new();
+        pipeline.init(0, 999);
+
+        let (sender, _rx) = create_test_request_sender();
+        let sent = pipeline.send_pending(&sender, &storage, 7).await.unwrap();
+        assert_eq!(sent, 1);
+
+        // The pipeline now stamps the in-flight batch with generation 7;
+        // every height covered by the batch returns the same snapshot.
+        assert_eq!(pipeline.generation_for_height(0), Some(7));
+        assert_eq!(pipeline.generation_for_height(500), Some(7));
+        assert_eq!(pipeline.generation_for_height(999), Some(7));
+
+        // A height outside any in-flight batch returns None so unsolicited
+        // responses are never accidentally dropped as "stale".
+        assert_eq!(pipeline.generation_for_height(2000), None);
+    }
+
     #[tokio::test]
     async fn test_send_pending_requeues_on_missing_header() {
         // Headers 0..999 exist, but NOT 1999 (stop hash for batch 1000-1999).

--- a/dash-spv/src/sync/filters/pipeline.rs
+++ b/dash-spv/src/sync/filters/pipeline.rs
@@ -128,11 +128,14 @@ impl FiltersPipeline {
         }
     }
 
-    /// Send pending filter requests up to the concurrency limit.
+    /// Send pending filter requests up to the concurrency limit, tagging each
+    /// in-flight slot with the current reorg generation so stale responses
+    /// can be dropped.
     pub(super) async fn send_pending(
         &mut self,
         requests: &RequestSender,
         storage: &impl BlockHeaderStorage,
+        generation: u64,
     ) -> SyncResult<usize> {
         let count = self.coordinator.available_to_send();
         if count == 0 {
@@ -180,19 +183,28 @@ impl FiltersPipeline {
 
             requests.request_filters(start_height, header.block_hash())?;
 
-            self.coordinator.mark_sent(&[start_height]);
+            self.coordinator.mark_sent_with_generation(&[start_height], generation);
 
             tracing::debug!(
-                "Sent GetCFilters: {} to {} ({} active batches)",
+                "Sent GetCFilters: {} to {} ({} active batches, generation {})",
                 start_height,
                 batch_end,
-                self.coordinator.active_count()
+                self.coordinator.active_count(),
+                generation
             );
 
             sent += 1;
         }
 
         Ok(sent)
+    }
+
+    /// Look up the generation snapshot recorded when the batch containing
+    /// `height` was sent. Returns `None` when no in-flight batch covers the
+    /// height (e.g. the response is unsolicited).
+    pub(super) fn generation_for_height(&self, height: u32) -> Option<u64> {
+        let batch_start = self.find_batch_for_height(height)?;
+        self.coordinator.generation_for(&batch_start)
     }
 
     /// Handle a received CFilter message with filter data.
@@ -438,7 +450,7 @@ mod tests {
         pipeline.extend_target(5000);
 
         let (sender, _rx) = create_test_request_sender();
-        pipeline.send_pending(&sender, &storage).await.unwrap();
+        pipeline.send_pending(&sender, &storage, 0).await.unwrap();
 
         let mut ranges: Vec<(u32, u32)> = pipeline
             .batch_trackers
@@ -836,7 +848,7 @@ mod tests {
 
         let (sender, mut rx) = create_test_request_sender();
 
-        let count = pipeline.send_pending(&sender, &storage).await.unwrap();
+        let count = pipeline.send_pending(&sender, &storage, 0).await.unwrap();
 
         assert_eq!(count, 1);
         assert_eq!(pipeline.coordinator.active_count(), 1);
@@ -870,7 +882,7 @@ mod tests {
 
         let (sender, _rx) = create_test_request_sender();
 
-        let count = pipeline.send_pending(&sender, &storage).await.unwrap();
+        let count = pipeline.send_pending(&sender, &storage, 0).await.unwrap();
 
         // 25 batches needed, but only 20 can be in-flight at once
         assert_eq!(count, MAX_CONCURRENT_FILTER_BATCHES);
@@ -892,7 +904,7 @@ mod tests {
 
         let (sender, _rx) = create_test_request_sender();
 
-        let count = pipeline.send_pending(&sender, &storage).await.unwrap();
+        let count = pipeline.send_pending(&sender, &storage, 0).await.unwrap();
 
         assert_eq!(count, 2);
 
@@ -917,7 +929,7 @@ mod tests {
 
         let (sender, _rx) = create_test_request_sender();
 
-        let count = pipeline.send_pending(&sender, &storage).await.unwrap();
+        let count = pipeline.send_pending(&sender, &storage, 0).await.unwrap();
 
         // Should send all 3 batches: 0-999, 1000-1999, 2000-2500
         assert_eq!(count, 3);
@@ -938,11 +950,11 @@ mod tests {
         let (sender, _rx) = create_test_request_sender();
 
         // First send exhausts the queue
-        let count = pipeline.send_pending(&sender, &storage).await.unwrap();
+        let count = pipeline.send_pending(&sender, &storage, 0).await.unwrap();
         assert_eq!(count, 1);
 
         // Second send has nothing to do
-        let count = pipeline.send_pending(&sender, &storage).await.unwrap();
+        let count = pipeline.send_pending(&sender, &storage, 0).await.unwrap();
         assert_eq!(count, 0);
     }
 
@@ -963,7 +975,7 @@ mod tests {
         let (sender, _rx) = create_test_request_sender();
 
         // Send request
-        let sent = pipeline.send_pending(&sender, &storage).await.unwrap();
+        let sent = pipeline.send_pending(&sender, &storage, 0).await.unwrap();
         assert_eq!(sent, 1);
         assert_eq!(pipeline.coordinator.active_count(), 1);
 
@@ -998,7 +1010,7 @@ mod tests {
         let (sender, _rx) = create_test_request_sender();
 
         // Send initial request
-        pipeline.send_pending(&sender, &storage).await.unwrap();
+        pipeline.send_pending(&sender, &storage, 0).await.unwrap();
         assert_eq!(pipeline.coordinator.active_count(), 1);
         assert_eq!(pipeline.coordinator.pending_count(), 0);
 
@@ -1014,7 +1026,7 @@ mod tests {
         assert!(pipeline.batch_trackers.contains_key(&0));
 
         // Can retry by sending again
-        pipeline.send_pending(&sender, &storage).await.unwrap();
+        pipeline.send_pending(&sender, &storage, 0).await.unwrap();
         assert_eq!(pipeline.coordinator.active_count(), 1);
 
         // Existing tracker is reused (not replaced)
@@ -1062,7 +1074,7 @@ mod tests {
         let (sender, _rx) = create_test_request_sender();
 
         // Only 2 batches sent, batch 2000 stays queued
-        pipeline.send_pending(&sender, &storage).await.unwrap();
+        pipeline.send_pending(&sender, &storage, 0).await.unwrap();
         assert_eq!(pipeline.coordinator.active_count(), 2);
         assert_eq!(pipeline.coordinator.pending_count(), 1);
 
@@ -1074,7 +1086,7 @@ mod tests {
             let hash = headers[h as usize].block_hash();
             pipeline.receive_with_data(h, hash, &dummy_filter_data(h));
         }
-        pipeline.send_pending(&sender, &storage).await.unwrap();
+        pipeline.send_pending(&sender, &storage, 0).await.unwrap();
 
         assert_eq!(
             pipeline.batch_trackers.get(&2000).unwrap().end_height(),
@@ -1098,7 +1110,7 @@ mod tests {
         let (sender, mut rx) = create_test_request_sender();
 
         // Batch 0 succeeds (header 999 exists), batch 1000 re-queued (header 1999 missing)
-        let sent = pipeline.send_pending(&sender, &storage).await.unwrap();
+        let sent = pipeline.send_pending(&sender, &storage, 0).await.unwrap();
         assert_eq!(sent, 1);
         assert_eq!(pipeline.coordinator.active_count(), 1);
         assert_eq!(pipeline.coordinator.pending_count(), 1);
@@ -1116,7 +1128,7 @@ mod tests {
         let more_headers = Header::dummy_batch(1000..2000);
         storage.store_headers(&more_headers).await.unwrap();
 
-        let sent = pipeline.send_pending(&sender, &storage).await.unwrap();
+        let sent = pipeline.send_pending(&sender, &storage, 0).await.unwrap();
         assert_eq!(sent, 1);
         assert_eq!(pipeline.coordinator.active_count(), 2);
         assert_eq!(pipeline.coordinator.pending_count(), 0);

--- a/dash-spv/src/sync/filters/sync_manager.rs
+++ b/dash-spv/src/sync/filters/sync_manager.rs
@@ -175,6 +175,19 @@ impl<
                 return self.handle_new_filter_headers(*tip_height, requests).await;
             }
 
+            SyncEvent::ChainReorg {
+                fork_height,
+                ..
+            } => {
+                tracing::info!(
+                    "FiltersManager: cascading ChainReorg, resetting state at {}",
+                    fork_height
+                );
+                self.reset_for_reorg(*fork_height);
+                self.set_state(SyncState::WaitForEvents);
+                return Ok(vec![]);
+            }
+
             // React to BlockProcessed events from the BlocksManager
             SyncEvent::BlockProcessed {
                 block_hash,

--- a/dash-spv/src/sync/filters/sync_manager.rs
+++ b/dash-spv/src/sync/filters/sync_manager.rs
@@ -57,7 +57,13 @@ impl<
         // insert a fresh batch at `scan_start` and clobber the existing one,
         // leaking its `pending_blocks` counter forever.
         if !self.active_batches.is_empty() {
-            self.filter_pipeline.send_pending(requests, &*self.header_storage.read().await, self.current_generation()).await?;
+            self.filter_pipeline
+                .send_pending(
+                    requests,
+                    &*self.header_storage.read().await,
+                    self.current_generation(),
+                )
+                .await?;
             self.set_state(SyncState::Syncing);
             return Ok(vec![]);
         }
@@ -139,7 +145,9 @@ impl<
             if req_gen != current_gen {
                 tracing::debug!(
                     "dropping stale CFilter at height {}: generation {} != {}",
-                    h, req_gen, current_gen
+                    h,
+                    req_gen,
+                    current_gen
                 );
                 return Ok(vec![]);
             }
@@ -150,7 +158,9 @@ impl<
 
         // Send more requests if there are free slots
         let header_storage = self.header_storage.read().await;
-        self.filter_pipeline.send_pending(requests, &*header_storage, self.current_generation()).await?;
+        self.filter_pipeline
+            .send_pending(requests, &*header_storage, self.current_generation())
+            .await?;
         drop(header_storage);
 
         Ok(self.store_and_match_batches().await?)
@@ -276,7 +286,9 @@ impl<
 
         // Send pending requests (decoupled from processing)
         let header_storage = self.header_storage.read().await;
-        self.filter_pipeline.send_pending(requests, &*header_storage, self.current_generation()).await?;
+        self.filter_pipeline
+            .send_pending(requests, &*header_storage, self.current_generation())
+            .await?;
         drop(header_storage);
 
         // Store completed batches and do speculative matching

--- a/dash-spv/src/sync/filters/sync_manager.rs
+++ b/dash-spv/src/sync/filters/sync_manager.rs
@@ -57,7 +57,7 @@ impl<
         // insert a fresh batch at `scan_start` and clobber the existing one,
         // leaking its `pending_blocks` counter forever.
         if !self.active_batches.is_empty() {
-            self.filter_pipeline.send_pending(requests, &*self.header_storage.read().await).await?;
+            self.filter_pipeline.send_pending(requests, &*self.header_storage.read().await, self.current_generation()).await?;
             self.set_state(SyncState::Syncing);
             return Ok(vec![]);
         }
@@ -134,12 +134,23 @@ impl<
             )));
         };
 
+        let current_gen = self.current_generation();
+        if let Some(req_gen) = self.filter_pipeline.generation_for_height(h) {
+            if req_gen != current_gen {
+                tracing::debug!(
+                    "dropping stale CFilter at height {}: generation {} != {}",
+                    h, req_gen, current_gen
+                );
+                return Ok(vec![]);
+            }
+        }
+
         // Buffer filter in pipeline
         self.filter_pipeline.receive_with_data(h, cfilter.block_hash, &cfilter.filter);
 
         // Send more requests if there are free slots
         let header_storage = self.header_storage.read().await;
-        self.filter_pipeline.send_pending(requests, &*header_storage).await?;
+        self.filter_pipeline.send_pending(requests, &*header_storage, self.current_generation()).await?;
         drop(header_storage);
 
         Ok(self.store_and_match_batches().await?)
@@ -252,7 +263,7 @@ impl<
 
         // Send pending requests (decoupled from processing)
         let header_storage = self.header_storage.read().await;
-        self.filter_pipeline.send_pending(requests, &*header_storage).await?;
+        self.filter_pipeline.send_pending(requests, &*header_storage, self.current_generation()).await?;
         drop(header_storage);
 
         // Store completed batches and do speculative matching

--- a/dash-spv/src/sync/mod.rs
+++ b/dash-spv/src/sync/mod.rs
@@ -12,6 +12,7 @@ mod instantsend;
 mod masternodes;
 mod mempool;
 mod progress;
+pub(crate) mod reorg;
 mod sync_coordinator;
 mod sync_manager;
 

--- a/dash-spv/src/sync/reorg.rs
+++ b/dash-spv/src/sync/reorg.rs
@@ -106,10 +106,7 @@ where
             return Ok(None);
         }
         if state.deny_list.contains_key(&candidate_tip_hash) {
-            tracing::debug!(
-                "fork tip {} is on the deny-list, skipping",
-                candidate_tip_hash
-            );
+            tracing::debug!("fork tip {} is on the deny-list, skipping", candidate_tip_hash);
             return Ok(None);
         }
         state.in_flight = true;
@@ -158,10 +155,7 @@ where
             "rejecting reorg: ancestor {} at or below last checkpoint",
             candidate.ancestor_height
         );
-        let ttl = checkpoint_manager
-            .last_checkpoint()
-            .map(|cp| cp.height)
-            .unwrap_or(u32::MAX);
+        let ttl = checkpoint_manager.last_checkpoint().map(|cp| cp.height).unwrap_or(u32::MAX);
         state.lock().await.deny_list.insert(candidate_tip_hash, ttl);
         return Ok(None);
     }
@@ -180,10 +174,8 @@ where
             }
         }
         None => {
-            let checkpoint_height = checkpoint_manager
-                .last_checkpoint()
-                .map(|cp| cp.height)
-                .unwrap_or(0);
+            let checkpoint_height =
+                checkpoint_manager.last_checkpoint().map(|cp| cp.height).unwrap_or(0);
             let recent_floor = current_tip_height.saturating_sub(FRESH_CLIENT_FORK_FLOOR);
             let floor = checkpoint_height.max(recent_floor);
             if candidate.ancestor_height < floor {
@@ -201,11 +193,7 @@ where
     // Depth cap.
     let depth = current_tip_height.saturating_sub(candidate.ancestor_height);
     if depth > MAX_REORG_DEPTH {
-        tracing::warn!(
-            "rejecting reorg: depth {} exceeds cap {}",
-            depth,
-            MAX_REORG_DEPTH
-        );
+        tracing::warn!("rejecting reorg: depth {} exceeds cap {}", depth, MAX_REORG_DEPTH);
         state.lock().await.deny_list.insert(candidate_tip_hash, u32::MAX);
         return Ok(Some(SyncEvent::DeepReorgDetected {
             fork_height: candidate.ancestor_height,
@@ -334,8 +322,7 @@ mod tests {
         let filters = storage.filters();
         let blocks = storage.blocks();
 
-        let candidate =
-            fork_candidate_from(5, chain[5].block_hash(), 3, 1_700_010_000);
+        let candidate = fork_candidate_from(5, chain[5].block_hash(), 3, 1_700_010_000);
 
         let state = Mutex::new(ReorgState::default());
         let generation = AtomicU64::new(7);
@@ -402,12 +389,12 @@ mod tests {
         let filters = storage.filters();
         let blocks = storage.blocks();
 
-        let candidate =
-            fork_candidate_from(2, chain[2].block_hash(), 2, 1_700_010_000);
+        let candidate = fork_candidate_from(2, chain[2].block_hash(), 2, 1_700_010_000);
 
-        let mut state_inner = ReorgState::default();
-        state_inner.in_flight = true;
-        let state = Mutex::new(state_inner);
+        let state = Mutex::new(ReorgState {
+            in_flight: true,
+            ..ReorgState::default()
+        });
         let generation = AtomicU64::new(3);
         let checkpoint_manager = CheckpointManager::new(vec![]);
 
@@ -451,8 +438,7 @@ mod tests {
         let filters = storage.filters();
         let blocks = storage.blocks();
 
-        let candidate =
-            fork_candidate_from(3, chain[3].block_hash(), 2, 1_700_010_000);
+        let candidate = fork_candidate_from(3, chain[3].block_hash(), 2, 1_700_010_000);
         let candidate_tip = candidate.tip_hash();
 
         let state = Mutex::new(ReorgState::default());
@@ -502,8 +488,7 @@ mod tests {
         let blocks = storage.blocks();
 
         // ancestor at 10, tip at 119 → depth 109 > 100.
-        let candidate =
-            fork_candidate_from(10, chain[10].block_hash(), 3, 1_700_100_000);
+        let candidate = fork_candidate_from(10, chain[10].block_hash(), 3, 1_700_100_000);
         let candidate_tip = candidate.tip_hash();
 
         let state = Mutex::new(ReorgState::default());
@@ -562,8 +547,7 @@ mod tests {
         let filters = storage.filters();
         let blocks = storage.blocks();
 
-        let candidate =
-            fork_candidate_from(5, chain[5].block_hash(), 2, 1_700_010_000);
+        let candidate = fork_candidate_from(5, chain[5].block_hash(), 2, 1_700_010_000);
 
         let state = Mutex::new(ReorgState::default());
         let generation = AtomicU64::new(0);

--- a/dash-spv/src/sync/reorg.rs
+++ b/dash-spv/src/sync/reorg.rs
@@ -8,16 +8,35 @@
 //! the common ancestor.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use dashcore::BlockHash;
+use tokio::sync::{Mutex, RwLock};
+
+use crate::chain::{CheckpointManager, ForkCandidate};
+use crate::error::SyncResult;
+use crate::storage::{BlockHeaderStorage, BlockStorage, FilterHeaderStorage, FilterStorage};
+use crate::sync::SyncEvent;
+
+/// Maximum reorg depth (active_tip_height - fork_ancestor_height) the
+/// cascade will accept. Anything deeper is rejected and added to the
+/// deny-list.
+pub(crate) const MAX_REORG_DEPTH: u32 = 100;
+
+/// Fallback floor distance used when no chainlock has been observed yet.
+/// A fork ancestor below `current_tip_height - FRESH_CLIENT_FORK_FLOOR` is
+/// rejected to prevent deep reorgs on a fresh client that has no chainlock
+/// guidance.
+pub(crate) const FRESH_CLIENT_FORK_FLOOR: u32 = 100;
 
 /// Single-flight gate plus deny-list of fork tip hashes that have been
 /// rejected by a guard.
 ///
 /// The deny-list maps a rejected fork tip hash to the chainlock height at
-/// which it should be evicted. `0` means "expire only on explicit reset";
-/// non-zero TTLs let chainlock-floor rejections drop out once the local node
-/// has progressed past the floor.
+/// which it should be evicted. A TTL of `u32::MAX` means "expire only on
+/// explicit reset"; lower TTLs let chainlock-floor rejections drop out once
+/// the local node has progressed past the floor.
 #[derive(Debug, Default)]
 pub(crate) struct ReorgState {
     pub(super) deny_list: HashMap<BlockHash, u32>,
@@ -34,10 +53,560 @@ impl ReorgState {
     }
 }
 
+/// Storage handles passed into [`handle_reorg`]. All four storages are
+/// truncated in lockstep so downstream caches don't outlive the truncated
+/// header chain.
+pub(crate) struct ReorgStorages<'a, H, FH, F, B>
+where
+    H: BlockHeaderStorage,
+    FH: FilterHeaderStorage,
+    F: FilterStorage,
+    B: BlockStorage,
+{
+    pub(crate) block_header_storage: &'a Arc<RwLock<H>>,
+    pub(crate) filter_header_storage: Option<&'a Arc<RwLock<FH>>>,
+    pub(crate) filter_storage: Option<&'a Arc<RwLock<F>>>,
+    pub(crate) block_storage: Option<&'a Arc<RwLock<B>>>,
+}
+
+/// Drive the reorg cascade for a buffered fork candidate.
+///
+/// Runs guards before any storage mutation. If every guard passes, bumps the
+/// generation counter and truncates the four storage handles, then persists
+/// the fork's headers starting at `ancestor_height + 1`. Returns a
+/// `ChainReorg` event on success, a `DeepReorgDetected` event when the depth
+/// cap fires, or `Ok(None)` when an earlier guard short-circuits.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn handle_reorg<H, FH, F, B>(
+    candidate: ForkCandidate,
+    state: &Mutex<ReorgState>,
+    generation: &AtomicU64,
+    storages: ReorgStorages<'_, H, FH, F, B>,
+    checkpoint_manager: &CheckpointManager,
+    best_chainlock_height: Option<u32>,
+    current_tip_height: u32,
+    current_tip_hash: BlockHash,
+) -> SyncResult<Option<SyncEvent>>
+where
+    H: BlockHeaderStorage,
+    FH: FilterHeaderStorage,
+    F: FilterStorage,
+    B: BlockStorage,
+{
+    let candidate_tip_hash = candidate.tip_hash();
+
+    // Single-flight: try to claim `in_flight`, also short-circuit on deny-list.
+    {
+        let mut state = state.lock().await;
+        if state.in_flight {
+            tracing::debug!(
+                "reorg already in flight, ignoring candidate at ancestor {}",
+                candidate.ancestor_height
+            );
+            return Ok(None);
+        }
+        if state.deny_list.contains_key(&candidate_tip_hash) {
+            tracing::debug!(
+                "fork tip {} is on the deny-list, skipping",
+                candidate_tip_hash
+            );
+            return Ok(None);
+        }
+        state.in_flight = true;
+    }
+
+    let result = run_guards_and_cascade(
+        &candidate,
+        candidate_tip_hash,
+        state,
+        generation,
+        storages,
+        checkpoint_manager,
+        best_chainlock_height,
+        current_tip_height,
+        current_tip_hash,
+    )
+    .await;
+
+    // Always release the single-flight guard, even on error.
+    state.lock().await.in_flight = false;
+
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_guards_and_cascade<H, FH, F, B>(
+    candidate: &ForkCandidate,
+    candidate_tip_hash: BlockHash,
+    state: &Mutex<ReorgState>,
+    generation: &AtomicU64,
+    storages: ReorgStorages<'_, H, FH, F, B>,
+    checkpoint_manager: &CheckpointManager,
+    best_chainlock_height: Option<u32>,
+    current_tip_height: u32,
+    current_tip_hash: BlockHash,
+) -> SyncResult<Option<SyncEvent>>
+where
+    H: BlockHeaderStorage,
+    FH: FilterHeaderStorage,
+    F: FilterStorage,
+    B: BlockStorage,
+{
+    // Checkpoint floor.
+    if checkpoint_manager.should_reject_fork(candidate.ancestor_height) {
+        tracing::warn!(
+            "rejecting reorg: ancestor {} at or below last checkpoint",
+            candidate.ancestor_height
+        );
+        let ttl = checkpoint_manager
+            .last_checkpoint()
+            .map(|cp| cp.height)
+            .unwrap_or(u32::MAX);
+        state.lock().await.deny_list.insert(candidate_tip_hash, ttl);
+        return Ok(None);
+    }
+
+    // Chainlock floor or fresh-client fallback.
+    match best_chainlock_height {
+        Some(cl_height) => {
+            if candidate.ancestor_height <= cl_height {
+                tracing::warn!(
+                    "rejecting reorg: ancestor {} at or below best chainlock {}",
+                    candidate.ancestor_height,
+                    cl_height
+                );
+                state.lock().await.deny_list.insert(candidate_tip_hash, cl_height);
+                return Ok(None);
+            }
+        }
+        None => {
+            let checkpoint_height = checkpoint_manager
+                .last_checkpoint()
+                .map(|cp| cp.height)
+                .unwrap_or(0);
+            let recent_floor = current_tip_height.saturating_sub(FRESH_CLIENT_FORK_FLOOR);
+            let floor = checkpoint_height.max(recent_floor);
+            if candidate.ancestor_height < floor {
+                tracing::warn!(
+                    "rejecting reorg on fresh client: ancestor {} below floor {}",
+                    candidate.ancestor_height,
+                    floor
+                );
+                state.lock().await.deny_list.insert(candidate_tip_hash, floor);
+                return Ok(None);
+            }
+        }
+    }
+
+    // Depth cap.
+    let depth = current_tip_height.saturating_sub(candidate.ancestor_height);
+    if depth > MAX_REORG_DEPTH {
+        tracing::warn!(
+            "rejecting reorg: depth {} exceeds cap {}",
+            depth,
+            MAX_REORG_DEPTH
+        );
+        state.lock().await.deny_list.insert(candidate_tip_hash, u32::MAX);
+        return Ok(Some(SyncEvent::DeepReorgDetected {
+            fork_height: candidate.ancestor_height,
+            depth,
+        }));
+    }
+
+    // Cascade. Bump the generation first so any response that races with the
+    // truncation is tagged stale and dropped at the downstream manager.
+    let new_generation = generation.fetch_add(1, Ordering::AcqRel) + 1;
+
+    let ReorgStorages {
+        block_header_storage,
+        filter_header_storage,
+        filter_storage,
+        block_storage,
+    } = storages;
+
+    {
+        let mut headers = block_header_storage.write().await;
+        headers.truncate_above(candidate.ancestor_height).await?;
+        headers.store_hashed_headers(&candidate.headers).await?;
+    }
+
+    if let Some(fh) = filter_header_storage {
+        fh.write().await.truncate_above(candidate.ancestor_height).await?;
+    }
+    if let Some(fs) = filter_storage {
+        fs.write().await.truncate_above(candidate.ancestor_height).await?;
+    }
+    if let Some(bs) = block_storage {
+        bs.write().await.truncate_above(candidate.ancestor_height).await?;
+    }
+
+    tracing::info!(
+        "reorg cascade complete: fork_height={} new_tip={} generation={}",
+        candidate.ancestor_height,
+        candidate_tip_hash,
+        new_generation
+    );
+
+    Ok(Some(SyncEvent::ChainReorg {
+        fork_height: candidate.ancestor_height,
+        old_tip: current_tip_hash,
+        new_tip: candidate_tip_hash,
+        generation: new_generation,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chain::checkpoints::Checkpoint;
+    use crate::chain::ChainWork;
+    use crate::storage::{
+        DiskStorageManager, PersistentBlockHeaderStorage, PersistentBlockStorage,
+        PersistentFilterHeaderStorage, PersistentFilterStorage, StorageManager,
+    };
+    use crate::types::HashedBlockHeader;
+    use dashcore::block::{Header, Version};
+    use dashcore::{BlockHash, CompactTarget, Target, TxMerkleNode};
     use dashcore_hashes::Hash;
+
+    fn easy_target() -> Target {
+        Target::from_compact(CompactTarget::from_consensus(0x207fffff))
+    }
+
+    fn mined_header(prev: BlockHash, time: u32) -> Header {
+        let bits = CompactTarget::from_consensus(0x207fffff);
+        for nonce in 0u32..1024 {
+            let h = Header {
+                version: Version::ONE,
+                prev_blockhash: prev,
+                merkle_root: TxMerkleNode::all_zeros(),
+                time,
+                bits,
+                nonce,
+            };
+            if h.target().is_met_by(h.block_hash()) {
+                return h;
+            }
+        }
+        panic!("could not mine header");
+    }
+
+    fn mined_chain(count: u32, base_time: u32) -> Vec<Header> {
+        let mut prev = BlockHash::all_zeros();
+        let mut chain = Vec::with_capacity(count as usize);
+        for i in 0..count {
+            let h = mined_header(prev, base_time + i * 600);
+            prev = h.block_hash();
+            chain.push(h);
+        }
+        chain
+    }
+
+    fn fork_candidate_from(
+        ancestor_height: u32,
+        prev: BlockHash,
+        len: u32,
+        base_time: u32,
+    ) -> ForkCandidate {
+        let mut prev = prev;
+        let mut hashed = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            let h = mined_header(prev, base_time + i * 600);
+            prev = h.block_hash();
+            hashed.push(HashedBlockHeader::from(h));
+        }
+        ForkCandidate {
+            ancestor_height,
+            headers: hashed,
+            total_work: ChainWork::zero(),
+        }
+    }
+
+    /// All four storages are wired and truncate together on a successful
+    /// cascade.
+    #[tokio::test]
+    async fn cascade_truncates_all_storages_and_emits_chain_reorg() {
+        let mut storage = DiskStorageManager::with_temp_dir().await.unwrap();
+        let chain = mined_chain(10, 1_700_000_000);
+        storage.store_headers(&chain).await.unwrap();
+        let block_headers = storage.block_headers();
+        let filter_headers = storage.filter_headers();
+        let filters = storage.filters();
+        let blocks = storage.blocks();
+
+        let candidate =
+            fork_candidate_from(5, chain[5].block_hash(), 3, 1_700_010_000);
+
+        let state = Mutex::new(ReorgState::default());
+        let generation = AtomicU64::new(7);
+        let checkpoint_manager = CheckpointManager::new(vec![]);
+
+        let storages: ReorgStorages<
+            PersistentBlockHeaderStorage,
+            PersistentFilterHeaderStorage,
+            PersistentFilterStorage,
+            PersistentBlockStorage,
+        > = ReorgStorages {
+            block_header_storage: &block_headers,
+            filter_header_storage: Some(&filter_headers),
+            filter_storage: Some(&filters),
+            block_storage: Some(&blocks),
+        };
+
+        let old_tip_hash = chain.last().unwrap().block_hash();
+        let event = handle_reorg(
+            candidate.clone(),
+            &state,
+            &generation,
+            storages,
+            &checkpoint_manager,
+            Some(0),
+            9,
+            old_tip_hash,
+        )
+        .await
+        .unwrap()
+        .expect("ChainReorg event");
+
+        match event {
+            SyncEvent::ChainReorg {
+                fork_height,
+                old_tip,
+                new_tip,
+                generation: ev_gen,
+            } => {
+                assert_eq!(fork_height, 5);
+                assert_eq!(old_tip, old_tip_hash);
+                assert_eq!(new_tip, candidate.tip_hash());
+                assert_eq!(ev_gen, 8);
+            }
+            other => panic!("unexpected event: {:?}", other),
+        }
+        assert_eq!(generation.load(Ordering::SeqCst), 8);
+
+        // Header storage now reflects the fork.
+        let tip = block_headers.read().await.get_tip().await.unwrap();
+        assert_eq!(tip.height(), 8);
+        assert_eq!(*tip.hash(), candidate.tip_hash());
+    }
+
+    /// Single-flight: a second call while the first is in-flight is a
+    /// no-op.
+    #[tokio::test]
+    async fn second_call_short_circuits_when_in_flight() {
+        let mut storage = DiskStorageManager::with_temp_dir().await.unwrap();
+        let chain = mined_chain(5, 1_700_000_000);
+        storage.store_headers(&chain).await.unwrap();
+        let block_headers = storage.block_headers();
+        let filter_headers = storage.filter_headers();
+        let filters = storage.filters();
+        let blocks = storage.blocks();
+
+        let candidate =
+            fork_candidate_from(2, chain[2].block_hash(), 2, 1_700_010_000);
+
+        let mut state_inner = ReorgState::default();
+        state_inner.in_flight = true;
+        let state = Mutex::new(state_inner);
+        let generation = AtomicU64::new(3);
+        let checkpoint_manager = CheckpointManager::new(vec![]);
+
+        let storages: ReorgStorages<
+            PersistentBlockHeaderStorage,
+            PersistentFilterHeaderStorage,
+            PersistentFilterStorage,
+            PersistentBlockStorage,
+        > = ReorgStorages {
+            block_header_storage: &block_headers,
+            filter_header_storage: Some(&filter_headers),
+            filter_storage: Some(&filters),
+            block_storage: Some(&blocks),
+        };
+
+        let result = handle_reorg(
+            candidate,
+            &state,
+            &generation,
+            storages,
+            &checkpoint_manager,
+            Some(0),
+            4,
+            chain[4].block_hash(),
+        )
+        .await
+        .unwrap();
+        assert!(result.is_none());
+        assert_eq!(generation.load(Ordering::SeqCst), 3);
+    }
+
+    /// Chainlock floor: a fork whose ancestor is at or below the best
+    /// chainlock height is rejected and the tip hash lands on the deny-list.
+    #[tokio::test]
+    async fn chainlock_floor_rejects_and_adds_to_deny_list() {
+        let mut storage = DiskStorageManager::with_temp_dir().await.unwrap();
+        let chain = mined_chain(10, 1_700_000_000);
+        storage.store_headers(&chain).await.unwrap();
+        let block_headers = storage.block_headers();
+        let filter_headers = storage.filter_headers();
+        let filters = storage.filters();
+        let blocks = storage.blocks();
+
+        let candidate =
+            fork_candidate_from(3, chain[3].block_hash(), 2, 1_700_010_000);
+        let candidate_tip = candidate.tip_hash();
+
+        let state = Mutex::new(ReorgState::default());
+        let generation = AtomicU64::new(0);
+        let checkpoint_manager = CheckpointManager::new(vec![]);
+
+        let storages: ReorgStorages<
+            PersistentBlockHeaderStorage,
+            PersistentFilterHeaderStorage,
+            PersistentFilterStorage,
+            PersistentBlockStorage,
+        > = ReorgStorages {
+            block_header_storage: &block_headers,
+            filter_header_storage: Some(&filter_headers),
+            filter_storage: Some(&filters),
+            block_storage: Some(&blocks),
+        };
+
+        let result = handle_reorg(
+            candidate,
+            &state,
+            &generation,
+            storages,
+            &checkpoint_manager,
+            Some(5),
+            9,
+            chain[9].block_hash(),
+        )
+        .await
+        .unwrap();
+        assert!(result.is_none());
+        let state_guard = state.lock().await;
+        assert!(state_guard.deny_list.contains_key(&candidate_tip));
+        assert_eq!(generation.load(Ordering::SeqCst), 0);
+    }
+
+    /// Depth cap: a fork below the depth cap is denied with
+    /// `DeepReorgDetected` and the generation is NOT bumped.
+    #[tokio::test]
+    async fn depth_cap_emits_deep_reorg_event_without_cascade() {
+        let mut storage = DiskStorageManager::with_temp_dir().await.unwrap();
+        let chain = mined_chain(120, 1_700_000_000);
+        storage.store_headers(&chain).await.unwrap();
+        let block_headers = storage.block_headers();
+        let filter_headers = storage.filter_headers();
+        let filters = storage.filters();
+        let blocks = storage.blocks();
+
+        // ancestor at 10, tip at 119 → depth 109 > 100.
+        let candidate =
+            fork_candidate_from(10, chain[10].block_hash(), 3, 1_700_100_000);
+        let candidate_tip = candidate.tip_hash();
+
+        let state = Mutex::new(ReorgState::default());
+        let generation = AtomicU64::new(0);
+        let checkpoint_manager = CheckpointManager::new(vec![]);
+
+        let storages: ReorgStorages<
+            PersistentBlockHeaderStorage,
+            PersistentFilterHeaderStorage,
+            PersistentFilterStorage,
+            PersistentBlockStorage,
+        > = ReorgStorages {
+            block_header_storage: &block_headers,
+            filter_header_storage: Some(&filter_headers),
+            filter_storage: Some(&filters),
+            block_storage: Some(&blocks),
+        };
+
+        let event = handle_reorg(
+            candidate,
+            &state,
+            &generation,
+            storages,
+            &checkpoint_manager,
+            Some(0),
+            119,
+            chain[119].block_hash(),
+        )
+        .await
+        .unwrap()
+        .expect("DeepReorgDetected event");
+
+        match event {
+            SyncEvent::DeepReorgDetected {
+                fork_height,
+                depth,
+            } => {
+                assert_eq!(fork_height, 10);
+                assert_eq!(depth, 109);
+            }
+            other => panic!("unexpected event: {:?}", other),
+        }
+        assert_eq!(generation.load(Ordering::SeqCst), 0);
+        assert!(state.lock().await.deny_list.contains_key(&candidate_tip));
+    }
+
+    /// Checkpoint floor: a fork at or below the last checkpoint height is
+    /// rejected.
+    #[tokio::test]
+    async fn checkpoint_floor_rejects_fork_at_or_below_last_checkpoint() {
+        let mut storage = DiskStorageManager::with_temp_dir().await.unwrap();
+        let chain = mined_chain(10, 1_700_000_000);
+        storage.store_headers(&chain).await.unwrap();
+        let block_headers = storage.block_headers();
+        let filter_headers = storage.filter_headers();
+        let filters = storage.filters();
+        let blocks = storage.blocks();
+
+        let candidate =
+            fork_candidate_from(5, chain[5].block_hash(), 2, 1_700_010_000);
+
+        let state = Mutex::new(ReorgState::default());
+        let generation = AtomicU64::new(0);
+        let checkpoint_manager = CheckpointManager::new(vec![Checkpoint {
+            height: 5,
+            block_hash: chain[5].block_hash(),
+            prev_blockhash: BlockHash::all_zeros(),
+            timestamp: 0,
+            target: easy_target(),
+            merkle_root: None,
+            chain_work: String::new(),
+            masternode_list_name: None,
+            protocol_version: None,
+            nonce: 0,
+        }]);
+
+        let storages: ReorgStorages<
+            PersistentBlockHeaderStorage,
+            PersistentFilterHeaderStorage,
+            PersistentFilterStorage,
+            PersistentBlockStorage,
+        > = ReorgStorages {
+            block_header_storage: &block_headers,
+            filter_header_storage: Some(&filter_headers),
+            filter_storage: Some(&filters),
+            block_storage: Some(&blocks),
+        };
+
+        let result = handle_reorg(
+            candidate,
+            &state,
+            &generation,
+            storages,
+            &checkpoint_manager,
+            Some(0),
+            9,
+            chain[9].block_hash(),
+        )
+        .await
+        .unwrap();
+        assert!(result.is_none());
+        assert_eq!(generation.load(Ordering::SeqCst), 0);
+    }
 
     #[test]
     fn evict_expired_denials_drops_entries_at_or_below_height() {

--- a/dash-spv/src/sync/reorg.rs
+++ b/dash-spv/src/sync/reorg.rs
@@ -163,9 +163,9 @@ where
     // Chainlock floor or fresh-client fallback.
     match best_chainlock_height {
         Some(cl_height) => {
-            if candidate.ancestor_height <= cl_height {
+            if candidate.ancestor_height < cl_height {
                 tracing::warn!(
-                    "rejecting reorg: ancestor {} at or below best chainlock {}",
+                    "rejecting reorg: ancestor {} below best chainlock {}",
                     candidate.ancestor_height,
                     cl_height
                 );

--- a/dash-spv/src/sync/reorg.rs
+++ b/dash-spv/src/sync/reorg.rs
@@ -1,0 +1,55 @@
+//! Reorg cascade: guards, deny-list, and downstream storage truncation.
+//!
+//! This module owns the cross-manager logic that runs once a fork candidate
+//! has been promoted by the staged-fork pipeline. Guards (single-flight,
+//! deny-list, checkpoint floor, chainlock floor, depth cap) run before any
+//! storage mutation. If all guards pass, the cascade bumps the generation
+//! counter and truncates header, filter-header, filter, and block storage to
+//! the common ancestor.
+
+use std::collections::HashMap;
+
+use dashcore::BlockHash;
+
+/// Single-flight gate plus deny-list of fork tip hashes that have been
+/// rejected by a guard.
+///
+/// The deny-list maps a rejected fork tip hash to the chainlock height at
+/// which it should be evicted. `0` means "expire only on explicit reset";
+/// non-zero TTLs let chainlock-floor rejections drop out once the local node
+/// has progressed past the floor.
+#[derive(Debug, Default)]
+pub(crate) struct ReorgState {
+    pub(super) deny_list: HashMap<BlockHash, u32>,
+    pub(super) in_flight: bool,
+}
+
+impl ReorgState {
+    /// Drop deny-list entries whose TTL is at or below the current best
+    /// chainlock height. A wider chainlock floor means previously denied
+    /// branches are no longer reachable from the active chain, so the
+    /// deny-list entry can be released.
+    pub(crate) fn evict_expired_denials(&mut self, best_chainlock_height: u32) {
+        self.deny_list.retain(|_, ttl| *ttl > best_chainlock_height);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dashcore_hashes::Hash;
+
+    #[test]
+    fn evict_expired_denials_drops_entries_at_or_below_height() {
+        let mut state = ReorgState::default();
+        state.deny_list.insert(BlockHash::from_byte_array([1u8; 32]), 100);
+        state.deny_list.insert(BlockHash::from_byte_array([2u8; 32]), 200);
+        state.deny_list.insert(BlockHash::from_byte_array([3u8; 32]), 300);
+
+        state.evict_expired_denials(200);
+
+        assert!(!state.deny_list.contains_key(&BlockHash::from_byte_array([1u8; 32])));
+        assert!(!state.deny_list.contains_key(&BlockHash::from_byte_array([2u8; 32])));
+        assert!(state.deny_list.contains_key(&BlockHash::from_byte_array([3u8; 32])));
+    }
+}

--- a/dash-spv/src/sync/reorg.rs
+++ b/dash-spv/src/sync/reorg.rs
@@ -24,6 +24,13 @@ use crate::sync::SyncEvent;
 /// deny-list.
 pub(crate) const MAX_REORG_DEPTH: u32 = 100;
 
+/// Returns `true` when a fork's common ancestor lies strictly below the best
+/// chainlock height, meaning the fork rewrites at least one finalised block
+/// and can never become canonical.
+pub(crate) fn is_below_chainlock_floor(ancestor_height: u32, cl_height: u32) -> bool {
+    ancestor_height < cl_height
+}
+
 /// Fallback floor distance used when no chainlock has been observed yet.
 /// A fork ancestor below `current_tip_height - FRESH_CLIENT_FORK_FLOOR` is
 /// rejected to prevent deep reorgs on a fresh client that has no chainlock
@@ -163,7 +170,7 @@ where
     // Chainlock floor or fresh-client fallback.
     match best_chainlock_height {
         Some(cl_height) => {
-            if candidate.ancestor_height < cl_height {
+            if is_below_chainlock_floor(candidate.ancestor_height, cl_height) {
                 tracing::warn!(
                     "rejecting reorg: ancestor {} below best chainlock {}",
                     candidate.ancestor_height,

--- a/dash-spv/src/sync/sync_coordinator.rs
+++ b/dash-spv/src/sync/sync_coordinator.rs
@@ -4,8 +4,6 @@
 //! tokio task for true parallel processing. It tracks aggregate progress and
 //! coordinates graceful shutdown.
 
-use std::sync::atomic::AtomicU64;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::stream::{select_all, StreamExt};
@@ -138,11 +136,6 @@ where
     shutdown: CancellationToken,
     /// Handle for the progress aggregation task.
     progress_task: Option<tokio::task::JoinHandle<()>>,
-    /// Generation counter that bumps on every successful reorg cascade.
-    /// Managers clone this `Arc` at construction so they can tag outgoing
-    /// requests and drop responses whose snapshot disagrees with the
-    /// current value.
-    reorg_generation: Arc<AtomicU64>,
 }
 
 impl<H, FH, F, B, M, W> SyncCoordinator<H, FH, F, B, M, W>
@@ -155,10 +148,7 @@ where
     W: WalletInterface + 'static,
 {
     /// Create a new coordinator with the given config.
-    pub(crate) async fn new(
-        managers: Managers<H, FH, F, B, M, W>,
-        reorg_generation: Arc<AtomicU64>,
-    ) -> Self {
+    pub(crate) async fn new(managers: Managers<H, FH, F, B, M, W>) -> Self {
         let mut initial_progress = SyncProgress::default();
 
         try_update_progress(managers.block_headers.as_ref(), &mut initial_progress);
@@ -184,14 +174,7 @@ where
             sync_start_time: None,
             shutdown: CancellationToken::new(),
             progress_task: None,
-            reorg_generation,
         }
-    }
-
-    /// Clone the shared reorg generation `Arc`. Managers hold this clone so they
-    /// can tag requests and detect stale responses after a reorg cascade.
-    pub(crate) fn reorg_generation(&self) -> Arc<AtomicU64> {
-        self.reorg_generation.clone()
     }
 
     /// Subscribe to progress updates.

--- a/dash-spv/src/sync/sync_coordinator.rs
+++ b/dash-spv/src/sync/sync_coordinator.rs
@@ -73,7 +73,7 @@ where
     M: MetadataStorage,
     W: WalletInterface + 'static,
 {
-    pub block_headers: Option<BlockHeadersManager<H, M>>,
+    pub block_headers: Option<BlockHeadersManager<H, FH, F, B, M>>,
     pub filter_headers: Option<FilterHeadersManager<H, FH>>,
     pub filters: Option<FiltersManager<H, FH, F, W>>,
     pub blocks: Option<BlocksManager<H, B, W>>,

--- a/dash-spv/src/sync/sync_coordinator.rs
+++ b/dash-spv/src/sync/sync_coordinator.rs
@@ -4,6 +4,8 @@
 //! tokio task for true parallel processing. It tracks aggregate progress and
 //! coordinates graceful shutdown.
 
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::stream::{select_all, StreamExt};
@@ -136,6 +138,11 @@ where
     shutdown: CancellationToken,
     /// Handle for the progress aggregation task.
     progress_task: Option<tokio::task::JoinHandle<()>>,
+    /// Generation counter that bumps on every successful reorg cascade.
+    /// Managers clone this `Arc` at construction so they can tag outgoing
+    /// requests and drop responses whose snapshot disagrees with the
+    /// current value.
+    reorg_generation: Arc<AtomicU64>,
 }
 
 impl<H, FH, F, B, M, W> SyncCoordinator<H, FH, F, B, M, W>
@@ -148,7 +155,10 @@ where
     W: WalletInterface + 'static,
 {
     /// Create a new coordinator with the given config.
-    pub(crate) async fn new(managers: Managers<H, FH, F, B, M, W>) -> Self {
+    pub(crate) async fn new(
+        managers: Managers<H, FH, F, B, M, W>,
+        reorg_generation: Arc<AtomicU64>,
+    ) -> Self {
         let mut initial_progress = SyncProgress::default();
 
         try_update_progress(managers.block_headers.as_ref(), &mut initial_progress);
@@ -174,7 +184,14 @@ where
             sync_start_time: None,
             shutdown: CancellationToken::new(),
             progress_task: None,
+            reorg_generation,
         }
+    }
+
+    /// Clone the shared reorg generation `Arc`. Managers hold this clone so they
+    /// can tag requests and detect stale responses after a reorg cascade.
+    pub(crate) fn reorg_generation(&self) -> Arc<AtomicU64> {
+        self.reorg_generation.clone()
     }
 
     /// Subscribe to progress updates.


### PR DESCRIPTION
## Summary

Phase 3 of [#137](https://github.com/xdustinface/rust-dashcore/issues/137) (fork/reorg handling).

- Adds `SyncEvent::ChainReorg { fork_height, old_tip, new_tip, generation }` and `SyncEvent::DeepReorgDetected { fork_height, depth }` with matching FFI callbacks (`on_chain_reorg`, `on_deep_reorg_detected`).
- New `dash-spv/src/sync/reorg.rs` module: `handle_reorg` runs all five guards (single-flight, deny-list, checkpoint floor, chainlock floor, 100-block depth cap, fresh-client fallback) and then cascades the truncation: bump generation, truncate block headers → filter headers → filters → blocks, persist candidate headers, emit event.
- `reorg_generation: Arc<AtomicU64>` on the sync coordinator, cloned into each manager that sends `GetCFHeaders`, `GetCFilters`, `GetData`. Response handlers drop stale-generation responses.
- Downstream managers (`FilterHeadersManager`, `FiltersManager`, `BlocksManager`) consume `ChainReorg` and reset their pipelines.
- Chainlock-conflicting headers are flagged on a `side_headers` buffer rather than banning the peer (mirrors dashd's `BLOCK_CONFLICT_CHAINLOCK`).
- Wallet rewind is deferred to [#145](https://github.com/xdustinface/rust-dashcore/issues/145). The `ChainReorg` event carries the data needed for a downstream wallet listener.

Closes [#140](https://github.com/xdustinface/rust-dashcore/issues/140)

## Test plan

- [x] `cargo test -p dash-spv --lib` (488 pass / 0 fail, +10 new tests)
- [x] `cargo test -p dash-spv-ffi --lib` (46 pass / 0 fail)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `pre-commit run --all-files --hook-stage pre-push` clean
- [x] Unit tests cover: cascade ordering, single-flight contention, chainlock floor rejection, checkpoint floor rejection, deep-reorg detection, deny-list TTL eviction, generation tagging round-trip through filter pipeline, chainlock-conflicting fork flagged without ban, shallow reorg cascade truncates storage and emits `ChainReorg`.