### PR TITLE
feat(dash-spv): masternode list and quorum rewind across reorg

### DIFF
--- a/dash-spv/src/sync/block_headers/fork_buffer.rs
+++ b/dash-spv/src/sync/block_headers/fork_buffer.rs
@@ -44,6 +44,14 @@ struct BufferedBranch {
     arrived_at: Instant,
 }
 
+/// Result of extending a buffered branch with one or more continuation headers.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct BranchUpdate {
+    pub(super) new_tip: BlockHash,
+    pub(super) new_height: u32,
+    pub(super) new_work: ChainWork,
+}
+
 impl ForkBuffer {
     pub(super) fn new(params: Params) -> Self {
         Self {
@@ -89,55 +97,9 @@ impl ForkBuffer {
             "history.last() must be the ancestor header"
         );
 
-        // Chain continuity: each header must extend the previous.
-        let mut prev = ancestor_header;
-        let mut hashed: Vec<HashedBlockHeader> = Vec::with_capacity(headers.len());
         let mut rolling_history: Vec<Header> = history.to_vec();
-        for (offset, header) in headers.iter().enumerate() {
-            let height = ancestor_height + offset as u32 + 1;
-            if header.prev_blockhash != prev.block_hash() {
-                return Err(SyncError::ForkChainBreak(format!(
-                    "expected prev {}, got {}",
-                    prev.block_hash(),
-                    header.prev_blockhash
-                )));
-            }
-
-            // PoW target met.
-            let hashed_header = HashedBlockHeader::from(*header);
-            if !header.target().is_met_by(*hashed_header.hash()) {
-                return Err(SyncError::Validation(format!(
-                    "Fork header at height {} failed PoW target",
-                    height
-                )));
-            }
-
-            // Median time past: candidate time must strictly exceed MTP of
-            // last 11 ancestor headers.
-            let mtp = median_time_past(&rolling_history);
-            if (header.time as u64) <= mtp {
-                return Err(SyncError::Validation(format!(
-                    "Fork header at height {} fails MTP rule ({} <= {})",
-                    height, header.time, mtp
-                )));
-            }
-
-            // DGW v3 retarget anchored at the ancestor's window.
-            let expected_bits =
-                next_work_required_dgw_v3(&rolling_history, height - 1, &self.params);
-            let min_diff = min_difficulty_bits(&self.params, prev.time, prev.bits, header.time);
-            let bits_ok = header.bits == expected_bits || min_diff == Some(header.bits);
-            if !bits_ok {
-                return Err(SyncError::Validation(format!(
-                    "Fork header at height {} bad bits: got {:?}, expected {:?}",
-                    height, header.bits, expected_bits
-                )));
-            }
-
-            hashed.push(hashed_header);
-            rolling_history.push(*header);
-            prev = *header;
-        }
+        let hashed =
+            self.validate_chain(headers, ancestor_header, ancestor_height, &mut rolling_history)?;
 
         let branch_work = ChainWork::accumulate(ChainWork::zero(), headers);
 
@@ -153,6 +115,152 @@ impl ForkBuffer {
         );
 
         Ok(())
+    }
+
+    /// Validate `headers` as a continuous extension after `prev`.
+    ///
+    /// `rolling_history` must contain the active-chain headers preceding the
+    /// branch ancestor (oldest first) plus any already-buffered branch
+    /// headers. It is extended in place with each validated header so MTP
+    /// and DGW v3 see the full window.
+    ///
+    /// `prev_height` is the height of `prev`; the first validated header
+    /// lands at `prev_height + 1`. Pass `ancestor_height` for a fresh ingest
+    /// and the branch's current tip height when extending an existing branch.
+    fn validate_chain(
+        &self,
+        headers: &[Header],
+        mut prev: Header,
+        prev_height: u32,
+        rolling_history: &mut Vec<Header>,
+    ) -> SyncResult<Vec<HashedBlockHeader>> {
+        let mut hashed: Vec<HashedBlockHeader> = Vec::with_capacity(headers.len());
+        for (offset, header) in headers.iter().enumerate() {
+            let height = prev_height + offset as u32 + 1;
+            if header.prev_blockhash != prev.block_hash() {
+                return Err(SyncError::ForkChainBreak(format!(
+                    "expected prev {}, got {}",
+                    prev.block_hash(),
+                    header.prev_blockhash
+                )));
+            }
+
+            let hashed_header = HashedBlockHeader::from(*header);
+            if !header.target().is_met_by(*hashed_header.hash()) {
+                return Err(SyncError::Validation(format!(
+                    "Fork header at height {} failed PoW target",
+                    height
+                )));
+            }
+
+            let mtp = median_time_past(rolling_history);
+            if (header.time as u64) <= mtp {
+                return Err(SyncError::Validation(format!(
+                    "Fork header at height {} fails MTP rule ({} <= {})",
+                    height, header.time, mtp
+                )));
+            }
+
+            let expected_bits =
+                next_work_required_dgw_v3(rolling_history, height - 1, &self.params);
+            let min_diff = min_difficulty_bits(&self.params, prev.time, prev.bits, header.time);
+            let bits_ok = header.bits == expected_bits || min_diff == Some(header.bits);
+            if !bits_ok {
+                return Err(SyncError::Validation(format!(
+                    "Fork header at height {} bad bits: got {:?}, expected {:?}",
+                    height, header.bits, expected_bits
+                )));
+            }
+
+            hashed.push(hashed_header);
+            rolling_history.push(*header);
+            prev = *header;
+        }
+        Ok(hashed)
+    }
+
+    /// Extend an existing buffered branch with continuation headers.
+    ///
+    /// The branch is keyed by `(peer, prev_tip_hash)`. Each new header is
+    /// validated (continuity off the branch's current tip, PoW, MTP, DGW v3)
+    /// against a rolling window built from `history` plus the branch's
+    /// already-buffered headers. On success the branch is re-keyed under the
+    /// new tip hash and the caller receives a `BranchUpdate` to update its
+    /// own tip-to-ancestor index.
+    ///
+    /// `history` is the same shape as for `ingest`: active-chain headers
+    /// preceding the branch ancestor, oldest first, with the ancestor itself
+    /// at `history.last()`.
+    pub(super) fn extend_branch(
+        &mut self,
+        peer: SocketAddr,
+        prev_tip_hash: BlockHash,
+        headers: &[Header],
+        history: &[Header],
+    ) -> SyncResult<BranchUpdate> {
+        if headers.is_empty() {
+            return Err(SyncError::Validation(
+                "extend_branch called with empty headers".to_string(),
+            ));
+        }
+        let key = (peer, prev_tip_hash);
+        let branch = self.branches.remove(&key).ok_or_else(|| {
+            SyncError::ForkChainBreak(format!(
+                "no buffered branch for peer {} tip {}",
+                peer, prev_tip_hash
+            ))
+        })?;
+
+        if branch.headers.len() + headers.len() > MAX_FORK_HEADERS_PER_PEER {
+            let total = branch.headers.len() + headers.len();
+            self.branches.insert(key, branch);
+            return Err(SyncError::Validation(format!(
+                "Fork branch extension exceeds cap: {} headers (max {})",
+                total, MAX_FORK_HEADERS_PER_PEER
+            )));
+        }
+
+        let branch_tip_height = branch.ancestor_height + branch.headers.len() as u32;
+        let branch_tip_header = *branch.headers.last().expect("non-empty buffered branch").header();
+
+        let mut rolling_history: Vec<Header> = history.to_vec();
+        rolling_history.extend(branch.headers.iter().map(|h| *h.header()));
+
+        let validated = match self.validate_chain(
+            headers,
+            branch_tip_header,
+            branch_tip_height,
+            &mut rolling_history,
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                self.branches.insert(key, branch);
+                return Err(e);
+            }
+        };
+
+        let mut combined_headers = branch.headers;
+        combined_headers.extend(validated);
+        let added_work = ChainWork::accumulate(ChainWork::zero(), headers);
+        let new_work = branch.total_work + added_work;
+        let new_tip = combined_headers.last().expect("non-empty branch").hash().to_owned();
+        let new_height = branch.ancestor_height + combined_headers.len() as u32;
+
+        self.branches.insert(
+            (peer, new_tip),
+            BufferedBranch {
+                headers: combined_headers,
+                ancestor_height: branch.ancestor_height,
+                total_work: new_work,
+                arrived_at: Instant::now(),
+            },
+        );
+
+        Ok(BranchUpdate {
+            new_tip,
+            new_height,
+            new_work,
+        })
     }
 
     /// Drop branches older than `ttl`. Returns how many were evicted.
@@ -587,5 +695,134 @@ mod tests {
         buf.ingest(peer, &[fork_header], ancestor_height, ancestor, &active)
             .expect("min-difficulty fork header must be accepted");
         assert_eq!(buf.len(), 1);
+    }
+
+    /// Ingest a 1-header branch, then `extend_branch` with a second 1-header
+    /// continuation. The branch is re-keyed under the new tip with both
+    /// headers buffered and the cumulative work doubled.
+    #[test]
+    fn extend_branch_appends_single_header_continuation() {
+        let peer: SocketAddr = "1.2.3.4:9999".parse().unwrap();
+        let mut buf = ForkBuffer::new(regtest_params());
+
+        let active = build_chain(1_700_000_000, 11, BlockHash::all_zeros());
+        let ancestor_height = (active.len() as u32) - 1;
+        let ancestor = *active.last().unwrap();
+
+        let fork = build_chain(1_700_000_000 + 12 * 600, 1, ancestor.block_hash());
+        let first_tip = fork[0].block_hash();
+        buf.ingest(peer, &fork, ancestor_height, ancestor, &active).expect("ingest");
+        assert_eq!(buf.len(), 1);
+
+        let cont = build_chain(1_700_000_000 + 13 * 600, 1, first_tip);
+        let update =
+            buf.extend_branch(peer, first_tip, &cont, &active).expect("extend continuation");
+        assert_eq!(update.new_tip, cont[0].block_hash());
+        assert_eq!(update.new_height, ancestor_height + 2);
+        assert_eq!(buf.len(), 1, "branch is re-keyed in place, count unchanged");
+        assert!(!buf.branches.contains_key(&(peer, first_tip)), "old branch key must be removed");
+        assert!(buf.branches.contains_key(&(peer, update.new_tip)), "new branch key inserted");
+
+        // Branch now holds both headers.
+        let candidate = buf
+            .take_winning_candidate(ChainWork::zero())
+            .expect("extended branch must win against zero active work");
+        assert_eq!(candidate.headers.len(), 2);
+        assert_eq!(*candidate.headers[0].hash(), first_tip);
+        assert_eq!(*candidate.headers[1].hash(), update.new_tip);
+    }
+
+    /// Stream a 4-header reorg as four 1-header continuations, matching the
+    /// dashd `generatetoaddress` pattern. Final branch must hold all 4 headers
+    /// and beat the active chain on work.
+    #[test]
+    fn extend_branch_handles_multi_message_reorg_announcement() {
+        let peer: SocketAddr = "1.2.3.4:9999".parse().unwrap();
+        let mut buf = ForkBuffer::new(regtest_params());
+
+        let active = build_chain(1_700_000_000, 11, BlockHash::all_zeros());
+        let ancestor_height = (active.len() as u32) - 1;
+        let ancestor = *active.last().unwrap();
+
+        // Build a 4-header fork chain as a single sequence, then feed it
+        // header-by-header through ingest + 3 extend_branch calls.
+        let fork = build_chain(1_700_000_000 + 12 * 600, 4, ancestor.block_hash());
+        buf.ingest(peer, &fork[..1], ancestor_height, ancestor, &active).expect("first batch");
+
+        let mut current_tip = fork[0].block_hash();
+        for next in &fork[1..] {
+            let update = buf
+                .extend_branch(peer, current_tip, std::slice::from_ref(next), &active)
+                .expect("continuation must validate");
+            assert_eq!(update.new_tip, next.block_hash());
+            current_tip = update.new_tip;
+        }
+        assert_eq!(buf.len(), 1);
+
+        let candidate = buf
+            .take_winning_candidate(ChainWork::zero())
+            .expect("4-header branch must win against zero work");
+        assert_eq!(candidate.headers.len(), 4);
+        assert_eq!(candidate.ancestor_height, ancestor_height);
+    }
+
+    /// A continuation whose `prev_blockhash` does not chain off the buffered
+    /// branch tip returns `ForkChainBreak` and leaves the branch untouched.
+    #[test]
+    fn extend_branch_rejects_continuity_break() {
+        let peer: SocketAddr = "1.2.3.4:9999".parse().unwrap();
+        let mut buf = ForkBuffer::new(regtest_params());
+
+        let active = build_chain(1_700_000_000, 11, BlockHash::all_zeros());
+        let ancestor_height = (active.len() as u32) - 1;
+        let ancestor = *active.last().unwrap();
+
+        let fork = build_chain(1_700_000_000 + 12 * 600, 1, ancestor.block_hash());
+        let first_tip = fork[0].block_hash();
+        buf.ingest(peer, &fork, ancestor_height, ancestor, &active).expect("ingest");
+
+        // Build a header whose prev_blockhash points at the ancestor (the
+        // active-chain tip) instead of the branch tip — that is exactly the
+        // shape of a dashd headers2 message arriving for the next reorg block
+        // before the branch re-key happens. With `extend_branch`, this is a
+        // ForkChainBreak because the buffered tip is `first_tip`, not ancestor.
+        let bad = build_chain(1_700_000_000 + 13 * 600, 1, ancestor.block_hash());
+        let err = buf
+            .extend_branch(peer, first_tip, &bad, &active)
+            .expect_err("continuation off the wrong predecessor must fail");
+        assert!(
+            matches!(&err, SyncError::ForkChainBreak(_)),
+            "expected ForkChainBreak, got: {:?}",
+            err
+        );
+        assert_eq!(buf.len(), 1, "branch must be restored on failure");
+        assert!(buf.branches.contains_key(&(peer, first_tip)), "original key must be intact");
+    }
+
+    /// Continuation from a peer that did not own the branch must be rejected.
+    #[test]
+    fn extend_branch_rejects_wrong_peer() {
+        let peer_a: SocketAddr = "1.2.3.4:9999".parse().unwrap();
+        let peer_b: SocketAddr = "5.6.7.8:9999".parse().unwrap();
+        let mut buf = ForkBuffer::new(regtest_params());
+
+        let active = build_chain(1_700_000_000, 11, BlockHash::all_zeros());
+        let ancestor_height = (active.len() as u32) - 1;
+        let ancestor = *active.last().unwrap();
+
+        let fork = build_chain(1_700_000_000 + 12 * 600, 1, ancestor.block_hash());
+        let first_tip = fork[0].block_hash();
+        buf.ingest(peer_a, &fork, ancestor_height, ancestor, &active).expect("ingest from a");
+
+        let cont = build_chain(1_700_000_000 + 13 * 600, 1, first_tip);
+        let err = buf
+            .extend_branch(peer_b, first_tip, &cont, &active)
+            .expect_err("wrong-peer continuation must fail");
+        assert!(
+            matches!(&err, SyncError::ForkChainBreak(_)),
+            "expected ForkChainBreak for missing branch, got: {:?}",
+            err
+        );
+        assert!(buf.branches.contains_key(&(peer_a, first_tip)), "peer_a branch must be untouched");
     }
 }

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -308,6 +308,81 @@ impl<
         Ok(())
     }
 
+    /// Extend a buffered fork branch with continuation headers from a
+    /// follow-up `headers2` batch. Used when a peer streams a reorg as one
+    /// header per message instead of a single multi-header batch.
+    async fn extend_fork(
+        &mut self,
+        peer: SocketAddr,
+        prev_tip_hash: BlockHash,
+        ancestor_height: u32,
+        headers: &[Header],
+    ) -> SyncResult<()> {
+        if headers.is_empty() {
+            return Ok(());
+        }
+        // Chainlock floor check still applies: a continuation that started below
+        // the floor is already side-listed, but re-check defensively in case the
+        // chainlock advanced between batches.
+        if let Some(cl_height) = self.best_chainlock_height() {
+            if is_below_chainlock_floor(ancestor_height, cl_height) {
+                tracing::warn!(
+                    "discarding chainlock-conflicting fork continuation from {} at ancestor {} (chainlock {})",
+                    peer,
+                    ancestor_height,
+                    cl_height
+                );
+                return Ok(());
+            }
+        }
+
+        let storage = self.header_storage.read().await;
+        let history_start = ancestor_height.saturating_sub(Self::DGW_HISTORY);
+        let history = storage.load_headers(history_start..ancestor_height + 1).await?;
+        let expected_len = (ancestor_height + 1 - history_start) as usize;
+        if history.len() != expected_len {
+            return Err(SyncError::Validation(format!(
+                "storage gap before ancestor at height {}: expected {} headers, got {}",
+                ancestor_height,
+                expected_len,
+                history.len()
+            )));
+        }
+        let tip_height = storage
+            .get_tip_height()
+            .await
+            .ok_or_else(|| SyncError::MissingDependency("no tip height".to_string()))?;
+        let active_extension = storage.load_headers(ancestor_height + 1..tip_height + 1).await?;
+        drop(storage);
+
+        let update = self.fork_buffer.extend_branch(peer, prev_tip_hash, headers, &history)?;
+
+        tracing::debug!(
+            "extended fork branch from peer {}: new_tip={} height={} added={} work_bytes={:?}",
+            peer,
+            update.new_tip,
+            update.new_height,
+            headers.len(),
+            update.new_work.as_bytes()
+        );
+
+        self.fork_tip_index.remove(&prev_tip_hash);
+        self.fork_tip_index.insert(update.new_tip, ancestor_height);
+
+        let active_extension_work = ChainWork::accumulate(ChainWork::zero(), &active_extension);
+        if let Some(candidate) = self.fork_buffer.take_winning_candidate(active_extension_work) {
+            tracing::info!(
+                "Fork candidate ready for promotion after continuation: ancestor={} headers={} (peer {})",
+                candidate.ancestor_height,
+                candidate.headers.len(),
+                peer
+            );
+            self.pending_fork_candidate = Some(candidate);
+            self.prune_fork_tip_index();
+        }
+        Ok(())
+    }
+
     /// Remove `fork_tip_index` entries whose branch no longer exists in the buffer.
     pub(super) fn prune_fork_tip_index(&mut self) {
         let live_tips: HashSet<BlockHash> = self.fork_buffer.branch_tip_hashes().copied().collect();
@@ -406,21 +481,11 @@ impl<
                 }
             } else if let Some(&ancestor_height) = self.fork_tip_index.get(&first.prev_blockhash) {
                 // prev_blockhash is a fork tip, not on the active chain.
-                // Route continuation batches to the fork buffer using the
-                // same ancestor_height as the first batch. Chain-break errors
-                // are swallowed because the second batch anchors at the
-                // active-chain ancestor rather than the buffered fork tip;
-                // proper re-anchoring is deferred to Phase 3.
-                match self.ingest_fork(peer, headers, ancestor_height).await {
-                    Ok(()) => {}
-                    Err(SyncError::ForkChainBreak(msg)) => {
-                        tracing::debug!(
-                            "fork continuation chain break (deferred to Phase 3): {}",
-                            msg
-                        );
-                    }
-                    Err(e) => return Err(e),
-                }
+                // Route continuation headers into the buffered branch via
+                // `extend_branch` so multi-message reorgs (one header per
+                // `headers2`) accumulate into a single candidate.
+                let prev_tip = first.prev_blockhash;
+                self.extend_fork(peer, prev_tip, ancestor_height, headers).await?;
                 return Ok(Vec::new());
             }
         }
@@ -562,7 +627,6 @@ mod tests {
         PersistentFilterHeaderStorage, PersistentFilterStorage, PersistentMetadataStorage,
         StorageManager,
     };
-    use crate::sync::block_headers::fork_buffer::MAX_FORK_HEADERS_PER_PEER;
     use crate::sync::{ManagerIdentifier, SyncManager, SyncManagerProgress};
     use dashcore::block::Version;
     use dashcore::network::message::NetworkMessage;
@@ -1071,22 +1135,26 @@ mod tests {
         }
         let second_fork_header = second_fork_header.expect("nonce space exhausted");
 
-        // The continuation batch is routed through fork_tip_index to ingest_fork.
-        // The ingest fails the chain-continuity check (second batch anchors at the
-        // active-chain ancestor, not the buffered fork tip), but the ForkChainBreak
-        // error is swallowed so the peer is not penalized. The fork buffer stays
-        // at one branch; proper multi-batch continuation is deferred to Phase 3.
+        // The continuation batch is routed through fork_tip_index into
+        // `extend_branch`, which appends it to the existing branch in place.
+        // The branch count stays at 1 but the branch now spans 2 headers, and
+        // `fork_tip_index` is re-keyed under the new tip.
+        let new_fork_tip = second_fork_header.block_hash();
         let result2 = manager.handle_headers_pipeline(&[second_fork_header], peer, &sender).await;
         assert!(result2.is_ok(), "continuation must not propagate error to caller: {:?}", result2);
-        assert_eq!(
-            manager.fork_buffer.len(),
-            1,
-            "fork buffer must not grow (second ingest fails chain-continuity)"
+        assert_eq!(manager.fork_buffer.len(), 1, "branch is extended in place, not duplicated");
+        assert!(
+            manager.fork_tip_index.contains_key(&new_fork_tip),
+            "fork_tip_index must now key under the new branch tip"
+        );
+        assert!(
+            !manager.fork_tip_index.contains_key(&fork_tip),
+            "old fork tip must be removed from fork_tip_index"
         );
     }
 
     #[tokio::test]
-    async fn fork_continuation_non_fork_chain_break_error_propagates() {
+    async fn fork_continuation_missing_branch_returns_chain_break() {
         use dashcore::{block::Version, CompactTarget, TxMerkleNode};
 
         let (mut manager, _chain) = create_regtest_manager_with_chain(5).await;
@@ -1096,14 +1164,14 @@ mod tests {
         manager.pipeline.mark_tip_complete();
         manager.progress.set_state(SyncState::Synced);
 
+        // `fork_tip_index` claims a branch tip the buffer does not actually
+        // hold (e.g., after the branch was evicted by TTL but the index was
+        // not yet pruned). `extend_branch` must surface this as a
+        // ForkChainBreak rather than silently dropping the headers.
         let fake_fork_tip = BlockHash::from_slice(&[0xAB; 32]).unwrap();
         manager.fork_tip_index.insert(fake_fork_tip, 1);
 
-        // Craft a batch that exceeds MAX_FORK_HEADERS_PER_PEER (4096) so
-        // fork_buffer.ingest returns SyncError::Validation("Fork branch too
-        // large") before the chain-break check. This is not a ForkChainBreak
-        // error and must reach the Err(e) => return Err(e) arm.
-        let oversized_header = Header {
+        let header = Header {
             version: Version::ONE,
             prev_blockhash: fake_fork_tip,
             merkle_root: TxMerkleNode::all_zeros(),
@@ -1111,15 +1179,14 @@ mod tests {
             bits: CompactTarget::from_consensus(0x207fffff),
             nonce: 0,
         };
-        let oversized_batch = vec![oversized_header; MAX_FORK_HEADERS_PER_PEER + 1];
 
         let peer: SocketAddr = "1.2.3.4:9999".parse().unwrap();
         let (sender, _rx) = create_test_request_sender();
 
-        let result = manager.handle_headers_pipeline(&oversized_batch, peer, &sender).await;
+        let result = manager.handle_headers_pipeline(&[header], peer, &sender).await;
         assert!(
-            matches!(&result, Err(SyncError::Validation(_))),
-            "non-ForkChainBreak error must propagate from fork continuation: {:?}",
+            matches!(&result, Err(SyncError::ForkChainBreak(_))),
+            "missing-branch continuation must surface as ForkChainBreak: {:?}",
             result
         );
     }
@@ -1443,5 +1510,75 @@ mod tests {
             initial_gen + 1,
             "generation must be bumped on successful reorg"
         );
+    }
+
+    /// Reorg announced as 4 separate `headers2` messages (one header each,
+    /// the dashd `generatetoaddress` pattern). The first batch enters the
+    /// buffer via `ingest_fork`, the remaining three extend it via
+    /// `extend_branch`. After the final batch the fork outweighs the
+    /// 3-header active extension and is staged as `pending_fork_candidate`.
+    #[tokio::test]
+    async fn multi_message_fork_announcement_extends_branch_and_promotes_candidate() {
+        let easy_bits = CompactTarget::from_consensus(0x207fffff);
+        let (mut manager, chain) = create_regtest_manager_with_chain(8).await;
+
+        let tip = manager.tip().await.unwrap();
+        let tip_hash = *tip.hash();
+        manager.pipeline.init(0, tip_hash, tip.height());
+        manager.pipeline.mark_tip_complete();
+        manager.progress.set_state(SyncState::Synced);
+
+        // Ancestor at height 4: active extension is heights 5,6,7 (3 headers).
+        // Fork extension is 4 headers, so total work strictly exceeds active.
+        let ancestor = chain[4];
+        let mut prev = ancestor.block_hash();
+        let mut fork_headers: Vec<Header> = Vec::new();
+        for i in 0..4u32 {
+            let time = ancestor.time + 11 * 600 + 1 + i * 600;
+            let mut header = None;
+            for nonce in 0u32..64 {
+                let h = Header {
+                    version: Version::ONE,
+                    prev_blockhash: prev,
+                    merkle_root: TxMerkleNode::all_zeros(),
+                    time,
+                    bits: easy_bits,
+                    nonce,
+                };
+                if h.target().is_met_by(h.block_hash()) {
+                    header = Some(h);
+                    break;
+                }
+            }
+            let h = header.expect("nonce space exhausted");
+            prev = h.block_hash();
+            fork_headers.push(h);
+        }
+        let final_fork_tip = fork_headers.last().unwrap().block_hash();
+
+        let peer: SocketAddr = "1.2.3.4:9999".parse().unwrap();
+        let (sender, _rx) = create_test_request_sender();
+
+        // Feed the 4 headers as 4 separate batches, like dashd's headers2 stream.
+        for h in &fork_headers {
+            let events =
+                manager.handle_headers_pipeline(&[*h], peer, &sender).await.expect("ingest batch");
+            assert!(events.is_empty(), "fork path emits no events before promotion");
+        }
+
+        // After the 4th header the buffer compared 4-fork-work against
+        // 3-active-extension-work, promoted the candidate, and pruned the
+        // fork_tip_index entry that referenced the now-consumed branch.
+        assert_eq!(manager.fork_buffer.len(), 0, "winning candidate was removed from the buffer");
+        assert!(
+            !manager.fork_tip_index.contains_key(&final_fork_tip),
+            "prune_fork_tip_index must drop the promoted branch's entry"
+        );
+
+        let candidate =
+            manager.take_pending_fork_candidate().expect("4>3 must promote a candidate");
+        assert_eq!(candidate.ancestor_height, 4);
+        assert_eq!(candidate.headers.len(), 4);
+        assert_eq!(*candidate.headers.last().unwrap().hash(), final_fork_tip);
     }
 }

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -132,6 +132,14 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> ChainLockManager<H, M> {
         self.pending_validation = None;
     }
 
+    /// Reset state for a peer disconnect. `pending_validation` is intentionally
+    /// kept: a chainlock that arrived before `masternode_ready` remains valid on
+    /// the same chain and must be re-evaluated when `on_masternode_ready` fires
+    /// on the next reconnect.
+    pub(super) fn reset_for_disconnect(&mut self) {
+        self.masternode_ready = false;
+    }
+
     /// Process an incoming ChainLock message.
     pub(super) async fn process_chainlock(
         &mut self,

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -48,7 +48,7 @@ pub struct ChainLockManager<H: BlockHeaderStorage, M: MetadataStorage> {
     /// not-ready → ready transition (see [`Self::on_masternode_ready`])
     /// so we don't lose a chainlock that landed during the gap between
     /// the chainlock manager starting and masternode sync completing.
-    pending_validation: Option<ChainLock>,
+    pub(super) pending_validation: Option<ChainLock>,
     /// Shared snapshot of the best validated chainlock height. `0` means
     /// "no chainlock observed yet". Read by `BlockHeadersManager` as the
     /// floor for the reorg cascade.
@@ -639,6 +639,43 @@ mod tests {
             let restored = manager.best_chainlock().expect("chainlock should be restored");
             assert_eq!(restored.block_height, 200);
         }
+    }
+
+    /// `ChainReorg` hard-blocks CL validation by flipping `masternode_ready`
+    /// back to `false` and dropping any `pending_validation`. After the
+    /// cascade, an incoming chainlock must take the pre-ready path again
+    /// (cached in `pending_validation`, not validated), waiting for the next
+    /// `MasternodeStateUpdated` to retry.
+    #[tokio::test]
+    async fn test_chain_reorg_hard_blocks_chainlock_validation() {
+        use crate::network::RequestSender;
+        use crate::sync::SyncEvent;
+        use tokio::sync::mpsc::unbounded_channel;
+
+        let mut manager = create_test_manager().await;
+        let _ = manager.on_masternode_ready().await;
+        manager.pending_validation = Some(create_test_chainlock(123));
+        assert!(manager.masternode_ready);
+
+        let (tx, _rx) = unbounded_channel();
+        let requests = RequestSender::new(tx);
+        let event = SyncEvent::ChainReorg {
+            fork_height: 80,
+            old_tip: BlockHash::all_zeros(),
+            new_tip: BlockHash::all_zeros(),
+            generation: 1,
+        };
+        manager.handle_sync_event(&event, &requests).await.expect("handle_sync_event succeeds");
+
+        assert!(!manager.masternode_ready, "ChainReorg must flip masternode_ready back to false");
+        assert!(manager.pending_validation.is_none(), "ChainReorg must drop pending_validation");
+
+        // A new chainlock arriving while the cascade is active must be cached
+        // for validation once masternode sync catches up, not validated.
+        let _ = manager.process_chainlock(&create_test_chainlock(150)).await.unwrap();
+        assert!(manager.pending_validation.is_some());
+        assert_eq!(manager.progress.valid(), 0);
+        assert_eq!(manager.progress.invalid(), 0);
     }
 
     #[tokio::test]

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -136,6 +136,11 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> ChainLockManager<H, M> {
     /// kept: a chainlock that arrived before `masternode_ready` remains valid on
     /// the same chain and must be re-evaluated when `on_masternode_ready` fires
     /// on the next reconnect.
+    ///
+    /// Safety invariant: correctness here relies on header sync always completing
+    /// (and emitting any `ChainReorg` → `reset_for_reorg`) before masternode sync
+    /// emits `MasternodeStateUpdated`. If those phases are ever parallelized, a
+    /// `ChainReorg` check must be added in this path.
     pub(super) fn reset_for_disconnect(&mut self) {
         self.masternode_ready = false;
     }
@@ -686,6 +691,34 @@ mod tests {
         assert!(manager.pending_validation.is_some());
         assert_eq!(manager.progress.valid(), 0);
         assert_eq!(manager.progress.invalid(), 0);
+    }
+
+    /// `pending_validation` must survive a disconnect so the cached chainlock
+    /// can be re-evaluated after reconnect. `on_masternode_ready` must consume
+    /// it on the next ready transition rather than silently discarding it.
+    #[tokio::test]
+    async fn test_pending_validation_survives_disconnect_and_consumed_on_reconnect() {
+        let mut manager = create_test_manager().await;
+
+        let _ = manager.process_chainlock(&create_test_chainlock(100)).await.unwrap();
+        assert!(manager.pending_validation.is_some());
+        assert!(!manager.masternode_ready);
+
+        manager.reset_for_disconnect();
+
+        assert!(
+            manager.pending_validation.is_some(),
+            "pending_validation must not be dropped on disconnect"
+        );
+        assert!(!manager.masternode_ready, "masternode_ready must be cleared on disconnect");
+
+        let _ = manager.on_masternode_ready().await;
+
+        assert!(
+            manager.pending_validation.is_none(),
+            "on_masternode_ready must consume pending_validation"
+        );
+        assert!(manager.masternode_ready);
     }
 
     #[tokio::test]

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -42,13 +42,13 @@ pub struct ChainLockManager<H: BlockHeaderStorage, M: MetadataStorage> {
     /// ChainLock hashes that have been requested (to avoid duplicate requests).
     pub(super) requested_chainlocks: HashSet<ChainLockHash>,
     /// Whether masternode sync is complete and we can validate signatures.
-    pub(super) masternode_ready: bool,
+    masternode_ready: bool,
     /// Highest chainlock that arrived before `masternode_ready` and
     /// therefore could not be validated yet. Re-validated on the
     /// not-ready → ready transition (see [`Self::on_masternode_ready`])
     /// so we don't lose a chainlock that landed during the gap between
     /// the chainlock manager starting and masternode sync completing.
-    pub(super) pending_validation: Option<ChainLock>,
+    pending_validation: Option<ChainLock>,
     /// Shared snapshot of the best validated chainlock height. `0` means
     /// "no chainlock observed yet". Read by `BlockHeadersManager` as the
     /// floor for the reorg cascade.
@@ -119,6 +119,17 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> ChainLockManager<H, M> {
         }
 
         self.best_chainlock.clone()
+    }
+
+    pub(super) fn is_masternode_ready(&self) -> bool {
+        self.masternode_ready
+    }
+
+    /// Reset state for a chain reorg, blocking validation until masternode data
+    /// is re-established on the new chain.
+    pub(super) fn reset_for_reorg(&mut self) {
+        self.masternode_ready = false;
+        self.pending_validation = None;
     }
 
     /// Process an incoming ChainLock message.

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -718,6 +718,10 @@ mod tests {
             returned.is_none(),
             "on_masternode_ready must not re-validate a stale chainlock cleared by reorg"
         );
+        assert!(
+            manager.masternode_ready,
+            "on_masternode_ready must set masternode_ready=true even when pending_validation is None"
+        );
         assert_eq!(
             manager.progress.valid(),
             0,

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -305,7 +305,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> std::fmt::Debug for ChainLockMan
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::network::MessageType;
+    use crate::network::{MessageType, RequestSender};
     use crate::storage::{
         DiskStorageManager, PersistentBlockHeaderStorage, PersistentMetadataStorage, StorageManager,
     };
@@ -314,6 +314,7 @@ mod tests {
     use dashcore::bls_sig_utils::BLSSignature;
     use dashcore::hashes::Hash;
     use dashcore::BlockHash;
+    use tokio::sync::mpsc::unbounded_channel;
 
     type TestChainLockManager =
         ChainLockManager<PersistentBlockHeaderStorage, PersistentMetadataStorage>;
@@ -367,10 +368,6 @@ mod tests {
     /// sync cycle after reconnect, so dropping it here is safe.
     #[tokio::test]
     async fn test_handle_sync_event_drops_masternode_state_updated_in_waiting_for_connections() {
-        use crate::network::RequestSender;
-        use crate::sync::SyncEvent;
-        use tokio::sync::mpsc::unbounded_channel;
-
         let mut manager = create_test_manager().await;
         manager.set_state(SyncState::WaitingForConnections);
 
@@ -648,10 +645,6 @@ mod tests {
     /// `MasternodeStateUpdated` to retry.
     #[tokio::test]
     async fn test_chain_reorg_hard_blocks_chainlock_validation() {
-        use crate::network::RequestSender;
-        use crate::sync::SyncEvent;
-        use tokio::sync::mpsc::unbounded_channel;
-
         let mut manager = create_test_manager().await;
         let _ = manager.on_masternode_ready().await;
         manager.pending_validation = Some(create_test_chainlock(123));
@@ -670,8 +663,6 @@ mod tests {
         assert!(!manager.masternode_ready, "ChainReorg must flip masternode_ready back to false");
         assert!(manager.pending_validation.is_none(), "ChainReorg must drop pending_validation");
 
-        // A new chainlock arriving while the cascade is active must be cached
-        // for validation once masternode sync catches up, not validated.
         let _ = manager.process_chainlock(&create_test_chainlock(150)).await.unwrap();
         assert!(manager.pending_validation.is_some());
         assert_eq!(manager.progress.valid(), 0);

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -693,6 +693,43 @@ mod tests {
         assert_eq!(manager.progress.invalid(), 0);
     }
 
+    /// `reset_for_reorg` clears `pending_validation`, so a subsequent
+    /// `on_masternode_ready` cannot re-validate a chainlock that arrived on the
+    /// orphaned branch. This is the phase-ordering invariant documented on
+    /// `reset_for_disconnect`: `ChainReorg → reset_for_reorg` must fire before
+    /// `MasternodeStateUpdated → on_masternode_ready`.
+    #[tokio::test]
+    async fn test_reorg_prevents_stale_pending_validation_from_being_revalidated() {
+        let mut manager = create_test_manager().await;
+
+        let _ = manager.process_chainlock(&create_test_chainlock(100)).await.unwrap();
+        assert!(manager.pending_validation.is_some());
+
+        manager.reset_for_reorg();
+
+        assert!(
+            manager.pending_validation.is_none(),
+            "reset_for_reorg must drop pending_validation from the orphaned branch"
+        );
+        assert!(!manager.masternode_ready);
+
+        let returned = manager.on_masternode_ready().await;
+        assert!(
+            returned.is_none(),
+            "on_masternode_ready must not re-validate a stale chainlock cleared by reorg"
+        );
+        assert_eq!(
+            manager.progress.valid(),
+            0,
+            "no chainlock from the orphaned branch was validated"
+        );
+        assert_eq!(
+            manager.progress.invalid(),
+            0,
+            "dropped chainlock must not be counted as invalid"
+        );
+    }
+
     /// `pending_validation` must survive a disconnect so the cached chainlock
     /// can be re-evaluated after reconnect. `on_masternode_ready` must consume
     /// it on the next ready transition rather than silently discarding it.
@@ -712,13 +749,19 @@ mod tests {
         );
         assert!(!manager.masternode_ready, "masternode_ready must be cleared on disconnect");
 
-        let _ = manager.on_masternode_ready().await;
+        let returned = manager.on_masternode_ready().await;
 
         assert!(
             manager.pending_validation.is_none(),
             "on_masternode_ready must consume pending_validation"
         );
         assert!(manager.masternode_ready);
+        // The empty engine cannot validate the signature, so the chainlock is
+        // counted as invalid and best_chainlock stays None — returned is None.
+        // The invariant is that pending_validation was consumed (not silently
+        // dropped), which is covered by the is_none() assertion above.
+        assert!(returned.is_none());
+        assert_eq!(manager.progress.invalid(), 1);
     }
 
     #[tokio::test]

--- a/dash-spv/src/sync/chainlock/sync_manager.rs
+++ b/dash-spv/src/sync/chainlock/sync_manager.rs
@@ -28,7 +28,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for ChainLockManager
 
     fn on_disconnect(&mut self) {
         self.requested_chainlocks.clear();
-        self.reset_for_reorg();
+        self.reset_for_disconnect();
     }
 
     async fn handle_message(

--- a/dash-spv/src/sync/chainlock/sync_manager.rs
+++ b/dash-spv/src/sync/chainlock/sync_manager.rs
@@ -78,6 +78,20 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for ChainLockManager
         event: &SyncEvent,
         _requests: &RequestSender,
     ) -> SyncResult<Vec<SyncEvent>> {
+        if let SyncEvent::ChainReorg {
+            fork_height,
+            ..
+        } = event
+        {
+            tracing::info!(
+                fork_height,
+                "ChainLockManager: cascading ChainReorg, hard-blocking validation"
+            );
+            self.masternode_ready = false;
+            self.pending_validation = None;
+            return Ok(vec![]);
+        }
+
         // `MasternodeStateUpdated` fires on every MnListDiff / QRInfo
         // update; the work below is strictly one-shot startup work, so
         // gate the entire branch on the not-ready transition. Also drop

--- a/dash-spv/src/sync/chainlock/sync_manager.rs
+++ b/dash-spv/src/sync/chainlock/sync_manager.rs
@@ -28,7 +28,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for ChainLockManager
 
     fn on_disconnect(&mut self) {
         self.requested_chainlocks.clear();
-        self.masternode_ready = false;
+        self.reset_for_reorg();
     }
 
     async fn handle_message(
@@ -87,8 +87,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for ChainLockManager
                 fork_height,
                 "ChainLockManager: cascading ChainReorg, hard-blocking validation"
             );
-            self.masternode_ready = false;
-            self.pending_validation = None;
+            self.reset_for_reorg();
             return Ok(vec![]);
         }
 
@@ -100,7 +99,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for ChainLockManager
         // peerless. `MasternodeStateUpdated` re-fires once `MasternodesManager`
         // completes a sync cycle after reconnect.
         if !matches!(event, SyncEvent::MasternodeStateUpdated { .. })
-            || self.masternode_ready
+            || self.is_masternode_ready()
             || self.state() == SyncState::WaitingForConnections
         {
             return Ok(vec![]);

--- a/dash-spv/src/sync/instantsend/manager.rs
+++ b/dash-spv/src/sync/instantsend/manager.rs
@@ -289,6 +289,7 @@ mod tests {
     use dashcore::bls_sig_utils::BLSSignature;
     use dashcore::hash_types::CycleHash;
     use dashcore::hashes::Hash;
+    use dashcore::BlockHash;
     use dashcore::OutPoint;
 
     fn create_test_instantlock(txid: Txid) -> InstantLock {
@@ -438,6 +439,39 @@ mod tests {
         // Unknown txid
         let unknown = Txid::from_byte_array([2u8; 32]);
         assert!(manager.get_instantlock(&unknown).is_none());
+    }
+
+    /// `ChainReorg` drops any pending instantlocks. They were validated
+    /// against the pre-reorg quorum view, so retrying them would either
+    /// succeed under the wrong cycle or fail spuriously. The network re-emits
+    /// IS locks after the reorg settles, and the existing retry path on
+    /// `MasternodeStateUpdated` picks those up.
+    #[tokio::test]
+    async fn test_chain_reorg_drops_pending_instantlocks() {
+        use crate::network::RequestSender;
+        use crate::sync::SyncEvent;
+        use tokio::sync::mpsc::unbounded_channel;
+
+        let mut manager = create_test_manager();
+
+        // Queue a pending instantlock by feeding one through the normal path
+        // while no engine state is available to validate it.
+        let txid = Txid::from_byte_array([1u8; 32]);
+        let _ = manager.process_instantlock(&create_test_instantlock(txid)).await.unwrap();
+        assert_eq!(manager.pending_count(), 1);
+
+        let event = SyncEvent::ChainReorg {
+            fork_height: 80,
+            old_tip: BlockHash::all_zeros(),
+            new_tip: BlockHash::all_zeros(),
+            generation: 1,
+        };
+        let (tx, _rx) = unbounded_channel();
+        let events =
+            manager.handle_sync_event(&event, &RequestSender::new(tx)).await.expect("handle");
+
+        assert!(events.is_empty());
+        assert_eq!(manager.pending_count(), 0, "ChainReorg must clear pending_instantlocks");
     }
 
     #[tokio::test]

--- a/dash-spv/src/sync/instantsend/manager.rs
+++ b/dash-spv/src/sync/instantsend/manager.rs
@@ -284,13 +284,14 @@ impl std::fmt::Debug for InstantSendManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::network::MessageType;
+    use crate::network::{MessageType, RequestSender};
     use crate::sync::{ManagerIdentifier, SyncManager, SyncManagerProgress, SyncState};
     use dashcore::bls_sig_utils::BLSSignature;
     use dashcore::hash_types::CycleHash;
     use dashcore::hashes::Hash;
     use dashcore::BlockHash;
     use dashcore::OutPoint;
+    use tokio::sync::mpsc::unbounded_channel;
 
     fn create_test_instantlock(txid: Txid) -> InstantLock {
         InstantLock {
@@ -323,10 +324,6 @@ mod tests {
     /// `MasternodesManager` re-emits the event after reconnect.
     #[tokio::test]
     async fn test_handle_sync_event_drops_masternode_state_updated_in_waiting_for_connections() {
-        use crate::network::RequestSender;
-        use crate::sync::SyncEvent;
-        use tokio::sync::mpsc::unbounded_channel;
-
         let mut manager = create_test_manager();
         manager.set_state(SyncState::WaitingForConnections);
 
@@ -448,14 +445,8 @@ mod tests {
     /// `MasternodeStateUpdated` picks those up.
     #[tokio::test]
     async fn test_chain_reorg_drops_pending_instantlocks() {
-        use crate::network::RequestSender;
-        use crate::sync::SyncEvent;
-        use tokio::sync::mpsc::unbounded_channel;
-
         let mut manager = create_test_manager();
 
-        // Queue a pending instantlock by feeding one through the normal path
-        // while no engine state is available to validate it.
         let txid = Txid::from_byte_array([1u8; 32]);
         let _ = manager.process_instantlock(&create_test_instantlock(txid)).await.unwrap();
         assert_eq!(manager.pending_count(), 1);

--- a/dash-spv/src/sync/instantsend/sync_manager.rs
+++ b/dash-spv/src/sync/instantsend/sync_manager.rs
@@ -62,6 +62,20 @@ impl SyncManager for InstantSendManager {
         event: &SyncEvent,
         _requests: &RequestSender,
     ) -> SyncResult<Vec<SyncEvent>> {
+        if let SyncEvent::ChainReorg {
+            fork_height,
+            ..
+        } = event
+        {
+            tracing::info!(
+                fork_height,
+                "InstantSendManager: cascading ChainReorg, dropping pending instantlocks"
+            );
+            self.pending_instantlocks.clear();
+            self.progress.update_pending(0);
+            return Ok(vec![]);
+        }
+
         // Drop buffered events that arrive between `stop_sync` and the next
         // `start_sync`. `pending_instantlocks` is cleared on disconnect, and
         // `MasternodesManager` re-emits `MasternodeStateUpdated` once it

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -1179,9 +1179,8 @@ mod tests {
         }
         drop(rx);
 
-        let result = manager
-            .rewind_to_height(50, BlockHash::from_byte_array([0xBB; 32]), &requests)
-            .await;
+        let result =
+            manager.rewind_to_height(50, BlockHash::from_byte_array([0xBB; 32]), &requests).await;
         assert!(result.is_err(), "expected error when the channel is closed");
         assert_eq!(manager.state(), SyncState::WaitForEvents);
         assert!(manager.sync_state.qrinfo_in_flight.is_none());

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -1175,6 +1175,7 @@ mod tests {
         let (mut manager, requests, rx) = make_synced_incremental_manager(120).await;
         {
             let mut engine = manager.engine.write().await;
+            engine.masternode_lists.insert(30, MasternodeList::empty(anchor_hash(30), 30));
             engine.masternode_lists.insert(120, MasternodeList::empty(anchor_hash(120), 120));
         }
         drop(rx);
@@ -1187,12 +1188,12 @@ mod tests {
         {
             let engine = manager.engine.read().await;
             assert!(
-                !engine.masternode_lists.contains_key(&120),
-                "engine must be truncated above fork_height=50 even when send fails"
+                engine.masternode_lists.contains_key(&30),
+                "entry below fork_height=50 must survive truncation even when send fails"
             );
             assert!(
-                engine.masternode_lists.is_empty(),
-                "no entries survive when all seeded heights are above fork_height=50"
+                !engine.masternode_lists.contains_key(&120),
+                "entry above fork_height=50 must be dropped even when send fails"
             );
         }
     }

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -1165,4 +1165,25 @@ mod tests {
         let queued = rx.try_recv().expect("ChainReorg must queue a GetQRInfo");
         assert!(matches!(queued, NetworkRequest::SendMessage(NetworkMessage::GetQRInfo(_))));
     }
+
+    /// When `send_qrinfo_for_tip` fails inside `rewind_to_height` (e.g. the
+    /// channel receiver is dropped), the manager must transition to
+    /// `WaitForEvents` rather than staying in `Syncing`, and must leave no
+    /// in-flight marker so the next `BlockHeaderSyncComplete` can retry.
+    #[tokio::test]
+    async fn test_rewind_to_height_sets_wait_for_events_on_send_failure() {
+        let (mut manager, requests, rx) = make_synced_incremental_manager(120).await;
+        {
+            let mut engine = manager.engine.write().await;
+            engine.masternode_lists.insert(120, MasternodeList::empty(anchor_hash(120), 120));
+        }
+        drop(rx);
+
+        let result = manager
+            .rewind_to_height(50, BlockHash::from_byte_array([0xBB; 32]), &requests)
+            .await;
+        assert!(result.is_err(), "expected error when the channel is closed");
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
+        assert!(manager.sync_state.qrinfo_in_flight.is_none());
+    }
 }

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -1131,7 +1131,10 @@ mod tests {
         let (mut manager, requests, _rx) = make_synced_incremental_manager(120).await;
         manager.sync_state.known_mn_list_heights.insert(120);
 
-        manager.rewind_to_height(80, BlockHash::from_byte_array([0xCC; 32]), &requests).await.unwrap();
+        manager
+            .rewind_to_height(80, BlockHash::from_byte_array([0xCC; 32]), &requests)
+            .await
+            .unwrap();
         assert!(!manager.is_synced_for_height(80));
 
         // Simulate the post-rewind QRInfo response settling: the manager's
@@ -1140,5 +1143,35 @@ mod tests {
         manager.sync_state.known_mn_list_heights.insert(80);
         assert!(manager.is_synced_for_height(80));
         assert!(!manager.is_synced_for_height(81));
+    }
+
+    /// A `SyncEvent::ChainReorg` delivered to `handle_sync_event` must invoke
+    /// the rewind path. Engine state above the fork is gone, the manager
+    /// transitions to `Syncing`, and a fresh QRInfo is queued for the new tip.
+    #[tokio::test]
+    async fn test_handle_sync_event_chain_reorg_invokes_rewind() {
+        let (mut manager, requests, mut rx) = make_synced_incremental_manager(120).await;
+        manager.sync_state.known_mn_list_heights.insert(120);
+        {
+            let mut engine = manager.engine.write().await;
+            engine.masternode_lists.insert(120, MasternodeList::empty(anchor_hash(120), 120));
+        }
+
+        let event = SyncEvent::ChainReorg {
+            fork_height: 80,
+            old_tip: BlockHash::from_byte_array([0xAA; 32]),
+            new_tip: BlockHash::from_byte_array([0xBB; 32]),
+            generation: 1,
+        };
+        manager.handle_sync_event(&event, &requests).await.expect("handle_sync_event succeeds");
+
+        {
+            let engine = manager.engine.read().await;
+            assert!(!engine.masternode_lists.contains_key(&120));
+        }
+        assert_eq!(manager.state(), SyncState::Syncing);
+        assert!(manager.sync_state.qrinfo_in_flight.is_some());
+        let queued = rx.try_recv().expect("ChainReorg must queue a GetQRInfo");
+        assert!(matches!(queued, NetworkRequest::SendMessage(NetworkMessage::GetQRInfo(_))));
     }
 }

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -1061,8 +1061,6 @@ mod tests {
     #[tokio::test]
     async fn test_rewind_to_height_truncates_engine_and_dispatches_qrinfo() {
         let (mut manager, requests, mut rx) = make_synced_incremental_manager(120).await;
-        // Pre-populate sync-state height sets and engine state to mimic a fully
-        // synced run.
         manager.sync_state.known_mn_list_heights.insert(60);
         manager.sync_state.known_mn_list_heights.insert(96);
         manager.sync_state.known_mn_list_heights.insert(120);
@@ -1082,8 +1080,6 @@ mod tests {
             .await
             .expect("rewind_to_height must succeed");
 
-        // Engine state at heights > fork_height is gone; entries at or below
-        // are retained.
         {
             let engine = manager.engine.read().await;
             assert!(engine.masternode_lists.contains_key(&60));
@@ -1091,7 +1087,6 @@ mod tests {
             assert!(!engine.masternode_lists.contains_key(&120));
         }
 
-        // Sync-state height sets are pruned in lockstep with the engine.
         assert_eq!(
             manager.sync_state.known_mn_list_heights.iter().copied().collect::<Vec<_>>(),
             vec![60]
@@ -1100,13 +1095,8 @@ mod tests {
             manager.sync_state.validated_cycle_heights.iter().copied().collect::<Vec<_>>(),
             vec![48]
         );
-
-        // `last_synced_block_hash` is rebuilt from the engine's surviving tip.
         assert_eq!(manager.sync_state.last_synced_block_hash, Some(anchor_hash(60)));
-        // Late-straggler dedup state is wiped so a fresh QRInfo round can begin.
         assert!(manager.sync_state.last_processed_qrinfo_tip.is_none());
-
-        // The manager dispatched a QRInfo for the new tip and is now Syncing.
         assert!(manager.sync_state.qrinfo_in_flight.is_some());
         assert_eq!(manager.progress.qr_infos_requested(), 1);
         assert_eq!(manager.state(), SyncState::Syncing);

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -558,6 +558,60 @@ impl<H: BlockHeaderStorage> MasternodesManager<H> {
         Ok(vec![])
     }
 
+    /// Rewind masternode state to `fork_height` after a chain reorg, then fire
+    /// a fresh `QRInfo` for the new tip so the engine catches up. The truncation
+    /// is the engine-side cleanup that complements the storage cascade run by
+    /// `BlockHeadersManager`. After this returns, the manager is in `Syncing`
+    /// with an in-flight QRInfo, and `MasternodeStateUpdated` will fire later
+    /// through the normal QRInfo response path.
+    pub(super) async fn rewind_to_height(
+        &mut self,
+        fork_height: u32,
+        new_tip: BlockHash,
+        requests: &RequestSender,
+    ) -> SyncResult<Vec<SyncEvent>> {
+        {
+            let mut engine = self.engine.write().await;
+            engine.truncate_above(fork_height);
+            self.sync_state.last_synced_block_hash =
+                engine.masternode_lists.iter().next_back().map(|(_, list)| list.block_hash);
+        }
+
+        self.sync_state.known_mn_list_heights.retain(|h| *h <= fork_height);
+        self.sync_state.validated_cycle_heights.retain(|h| *h <= fork_height);
+        self.sync_state.current_cycle_height = None;
+        self.sync_state.current_cycle_attempts = 0;
+        self.sync_state.last_window_qrinfo_tip = None;
+        self.sync_state.last_processed_qrinfo_tip = None;
+        self.sync_state.clear_pending();
+        self.sync_state.qrinfo_retry_count = 0;
+
+        let engine_tip_height = {
+            let engine = self.engine.read().await;
+            engine.masternode_lists.iter().next_back().map(|(h, _)| *h).unwrap_or(0)
+        };
+        self.progress.update_current_height(engine_tip_height);
+
+        self.set_state(SyncState::Syncing);
+
+        tracing::info!(
+            fork_height,
+            new_tip = %new_tip,
+            engine_tip_height,
+            "MasternodesManager: rewinding for reorg, dispatching QRInfo for new tip"
+        );
+
+        self.send_qrinfo_for_tip(requests).await?;
+        Ok(vec![])
+    }
+
+    /// Returns `true` when the engine holds a masternode list at a height at
+    /// or above `h`. Used by the rewind path to detect whether the masternode
+    /// state has caught up to a target height after a reorg.
+    pub(super) fn is_synced_for_height(&self, h: u32) -> bool {
+        self.sync_state.known_mn_list_heights.iter().next_back().is_some_and(|tip| *tip >= h)
+    }
+
     /// Verify quorums and mark complete.
     ///
     /// For initial sync (state == Syncing), emits MasternodeStateUpdated and logs completion.
@@ -1003,5 +1057,88 @@ mod tests {
             0,
             "no QRInfo must be requested when the gate picks Incremental"
         );
+    }
+
+    /// `rewind_to_height` must truncate engine state above the fork height,
+    /// prune the sync-state height sets, refresh `last_synced_block_hash` from
+    /// the engine's new tip, and fire a fresh `QRInfo` request via
+    /// `send_qrinfo_for_tip`. The catch-up dispatch is the entire reason the
+    /// rewind exists, so a successful call must surface as a queued
+    /// `GetQRInfo` and an in-flight marker.
+    #[tokio::test]
+    async fn test_rewind_to_height_truncates_engine_and_dispatches_qrinfo() {
+        let (mut manager, requests, mut rx) = make_synced_incremental_manager(120).await;
+        // Pre-populate sync-state height sets and engine state to mimic a fully
+        // synced run.
+        manager.sync_state.known_mn_list_heights.insert(60);
+        manager.sync_state.known_mn_list_heights.insert(96);
+        manager.sync_state.known_mn_list_heights.insert(120);
+        manager.sync_state.validated_cycle_heights.insert(48);
+        manager.sync_state.validated_cycle_heights.insert(96);
+        manager.sync_state.last_processed_qrinfo_tip = Some(BlockHash::from_byte_array([0xAA; 32]));
+        {
+            let mut engine = manager.engine.write().await;
+            engine.masternode_lists.insert(60, MasternodeList::empty(anchor_hash(60), 60));
+            engine.masternode_lists.insert(96, MasternodeList::empty(anchor_hash(96), 96));
+        }
+
+        let fork_height = 80;
+        let new_tip = BlockHash::from_byte_array([0xBB; 32]);
+        manager
+            .rewind_to_height(fork_height, new_tip, &requests)
+            .await
+            .expect("rewind_to_height must succeed");
+
+        // Engine state at heights > fork_height is gone; entries at or below
+        // are retained.
+        {
+            let engine = manager.engine.read().await;
+            assert!(engine.masternode_lists.contains_key(&60));
+            assert!(!engine.masternode_lists.contains_key(&96));
+            assert!(!engine.masternode_lists.contains_key(&120));
+        }
+
+        // Sync-state height sets are pruned in lockstep with the engine.
+        assert_eq!(
+            manager.sync_state.known_mn_list_heights.iter().copied().collect::<Vec<_>>(),
+            vec![60]
+        );
+        assert_eq!(
+            manager.sync_state.validated_cycle_heights.iter().copied().collect::<Vec<_>>(),
+            vec![48]
+        );
+
+        // `last_synced_block_hash` is rebuilt from the engine's surviving tip.
+        assert_eq!(manager.sync_state.last_synced_block_hash, Some(anchor_hash(60)));
+        // Late-straggler dedup state is wiped so a fresh QRInfo round can begin.
+        assert!(manager.sync_state.last_processed_qrinfo_tip.is_none());
+
+        // The manager dispatched a QRInfo for the new tip and is now Syncing.
+        assert!(manager.sync_state.qrinfo_in_flight.is_some());
+        assert_eq!(manager.progress.qr_infos_requested(), 1);
+        assert_eq!(manager.state(), SyncState::Syncing);
+        let queued = rx.try_recv().expect("rewind_to_height must queue a GetQRInfo");
+        assert!(matches!(queued, NetworkRequest::SendMessage(NetworkMessage::GetQRInfo(_))));
+    }
+
+    /// `is_synced_for_height` mirrors the engine's notion of "the masternode
+    /// list has caught up to height h". Immediately after a rewind the engine
+    /// tip is below the requested fork height, so the predicate is false;
+    /// after simulating the response by re-inserting a list at the fork height
+    /// (the same effect `MasternodeStateUpdated` carries) it must flip to true.
+    #[tokio::test]
+    async fn test_is_synced_for_height_tracks_engine_state() {
+        let (mut manager, requests, _rx) = make_synced_incremental_manager(120).await;
+        manager.sync_state.known_mn_list_heights.insert(120);
+
+        manager.rewind_to_height(80, BlockHash::from_byte_array([0xCC; 32]), &requests).await.unwrap();
+        assert!(!manager.is_synced_for_height(80));
+
+        // Simulate the post-rewind QRInfo response settling: the manager's
+        // QRInfo handler is what normally records `known_mn_list_heights`,
+        // mirroring engine state. Re-populate to match.
+        manager.sync_state.known_mn_list_heights.insert(80);
+        assert!(manager.is_synced_for_height(80));
+        assert!(!manager.is_synced_for_height(81));
     }
 }

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -605,13 +605,6 @@ impl<H: BlockHeaderStorage> MasternodesManager<H> {
         Ok(vec![])
     }
 
-    /// Returns `true` when the engine holds a masternode list at a height at
-    /// or above `h`. Used by the rewind path to detect whether the masternode
-    /// state has caught up to a target height after a reorg.
-    pub(super) fn is_synced_for_height(&self, h: u32) -> bool {
-        self.sync_state.known_mn_list_heights.iter().next_back().is_some_and(|tip| *tip >= h)
-    }
-
     /// Verify quorums and mark complete.
     ///
     /// For initial sync (state == Syncing), emits MasternodeStateUpdated and logs completion.
@@ -1119,30 +1112,6 @@ mod tests {
         assert_eq!(manager.state(), SyncState::Syncing);
         let queued = rx.try_recv().expect("rewind_to_height must queue a GetQRInfo");
         assert!(matches!(queued, NetworkRequest::SendMessage(NetworkMessage::GetQRInfo(_))));
-    }
-
-    /// `is_synced_for_height` mirrors the engine's notion of "the masternode
-    /// list has caught up to height h". Immediately after a rewind the engine
-    /// tip is below the requested fork height, so the predicate is false;
-    /// after simulating the response by re-inserting a list at the fork height
-    /// (the same effect `MasternodeStateUpdated` carries) it must flip to true.
-    #[tokio::test]
-    async fn test_is_synced_for_height_tracks_engine_state() {
-        let (mut manager, requests, _rx) = make_synced_incremental_manager(120).await;
-        manager.sync_state.known_mn_list_heights.insert(120);
-
-        manager
-            .rewind_to_height(80, BlockHash::from_byte_array([0xCC; 32]), &requests)
-            .await
-            .unwrap();
-        assert!(!manager.is_synced_for_height(80));
-
-        // Simulate the post-rewind QRInfo response settling: the manager's
-        // QRInfo handler is what normally records `known_mn_list_heights`,
-        // mirroring engine state. Re-populate to match.
-        manager.sync_state.known_mn_list_heights.insert(80);
-        assert!(manager.is_synced_for_height(80));
-        assert!(!manager.is_synced_for_height(81));
     }
 
     /// A `SyncEvent::ChainReorg` delivered to `handle_sync_event` must invoke

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -1184,5 +1184,12 @@ mod tests {
         assert!(result.is_err(), "expected error when the channel is closed");
         assert_eq!(manager.state(), SyncState::WaitForEvents);
         assert!(manager.sync_state.qrinfo_in_flight.is_none());
+        {
+            let engine = manager.engine.read().await;
+            assert!(
+                !engine.masternode_lists.contains_key(&120),
+                "engine must be truncated above fork_height=50 even when send fails"
+            );
+        }
     }
 }

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -570,12 +570,13 @@ impl<H: BlockHeaderStorage> MasternodesManager<H> {
         new_tip: BlockHash,
         requests: &RequestSender,
     ) -> SyncResult<Vec<SyncEvent>> {
-        {
+        let engine_tip_height = {
             let mut engine = self.engine.write().await;
             engine.truncate_above(fork_height);
-            self.sync_state.last_synced_block_hash =
-                engine.masternode_lists.iter().next_back().map(|(_, list)| list.block_hash);
-        }
+            let tip_entry = engine.masternode_lists.iter().next_back();
+            self.sync_state.last_synced_block_hash = tip_entry.map(|(_, list)| list.block_hash);
+            tip_entry.map(|(h, _)| *h).unwrap_or(0)
+        };
 
         self.sync_state.known_mn_list_heights.retain(|h| *h <= fork_height);
         self.sync_state.validated_cycle_heights.retain(|h| *h <= fork_height);
@@ -586,10 +587,6 @@ impl<H: BlockHeaderStorage> MasternodesManager<H> {
         self.sync_state.clear_pending();
         self.sync_state.qrinfo_retry_count = 0;
 
-        let engine_tip_height = {
-            let engine = self.engine.read().await;
-            engine.masternode_lists.iter().next_back().map(|(h, _)| *h).unwrap_or(0)
-        };
         self.progress.update_current_height(engine_tip_height);
 
         self.set_state(SyncState::Syncing);
@@ -601,8 +598,11 @@ impl<H: BlockHeaderStorage> MasternodesManager<H> {
             "MasternodesManager: rewinding for reorg, dispatching QRInfo for new tip"
         );
 
-        self.send_qrinfo_for_tip(requests).await?;
-        Ok(vec![])
+        let result = self.send_qrinfo_for_tip(requests).await;
+        if result.is_err() {
+            self.set_state(SyncState::WaitForEvents);
+        }
+        result
     }
 
     /// Verify quorums and mark complete.
@@ -1101,6 +1101,38 @@ mod tests {
         assert_eq!(manager.progress.qr_infos_requested(), 1);
         assert_eq!(manager.state(), SyncState::Syncing);
         let queued = rx.try_recv().expect("rewind_to_height must queue a GetQRInfo");
+        assert!(matches!(queued, NetworkRequest::SendMessage(NetworkMessage::GetQRInfo(_))));
+    }
+
+    /// When every masternode list is above the fork height, truncation empties
+    /// the engine. `last_synced_block_hash` must become `None` and progress
+    /// must report height 0.
+    #[tokio::test]
+    async fn test_rewind_to_height_empty_engine_after_truncation() {
+        let (mut manager, requests, mut rx) = make_synced_incremental_manager(120).await;
+        manager.sync_state.known_mn_list_heights.extend([100, 120]);
+        {
+            let mut engine = manager.engine.write().await;
+            engine.masternode_lists.insert(100, MasternodeList::empty(anchor_hash(100), 100));
+            engine.masternode_lists.insert(120, MasternodeList::empty(anchor_hash(120), 120));
+        }
+
+        manager
+            .rewind_to_height(50, BlockHash::from_byte_array([0xBB; 32]), &requests)
+            .await
+            .expect("rewind_to_height must succeed");
+
+        {
+            let engine = manager.engine.read().await;
+            assert!(engine.masternode_lists.is_empty());
+        }
+        assert_eq!(manager.sync_state.last_synced_block_hash, None);
+        assert_eq!(manager.progress.current_height(), 0);
+        assert!(manager.sync_state.known_mn_list_heights.is_empty());
+        assert!(manager.sync_state.qrinfo_in_flight.is_some());
+        let queued = rx
+            .try_recv()
+            .expect("rewind_to_height must queue a GetQRInfo even when engine is empty");
         assert!(matches!(queued, NetworkRequest::SendMessage(NetworkMessage::GetQRInfo(_))));
     }
 

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -1190,6 +1190,10 @@ mod tests {
                 !engine.masternode_lists.contains_key(&120),
                 "engine must be truncated above fork_height=50 even when send fails"
             );
+            assert!(
+                engine.masternode_lists.is_empty(),
+                "no entries survive when all seeded heights are above fork_height=50"
+            );
         }
     }
 }

--- a/dash-spv/src/sync/masternodes/sync_manager.rs
+++ b/dash-spv/src/sync/masternodes/sync_manager.rs
@@ -414,6 +414,20 @@ impl<H: BlockHeaderStorage> SyncManager for MasternodesManager<H> {
         event: &SyncEvent,
         requests: &RequestSender,
     ) -> SyncResult<Vec<SyncEvent>> {
+        if let SyncEvent::ChainReorg {
+            fork_height,
+            new_tip,
+            ..
+        } = event
+        {
+            tracing::info!(
+                fork_height,
+                new_tip = %new_tip,
+                "MasternodesManager: cascading ChainReorg, rewinding engine"
+            );
+            return self.rewind_to_height(*fork_height, *new_tip, requests).await;
+        }
+
         // Track block header tip height as headers come in
         if let SyncEvent::BlockHeadersStored {
             tip_height,

--- a/dash-spv/src/test_utils/masternode_network.rs
+++ b/dash-spv/src/test_utils/masternode_network.rs
@@ -304,7 +304,12 @@ impl MasternodeTestContext {
             .try_rpc_call("getblockcount", &[])
             .and_then(|v| v.as_u64())
             .expect("getblockcount on controller") as u32;
-        assert!(tip_height >= depth, "controller tip {} is below reorg depth {}", tip_height, depth);
+        assert!(
+            tip_height >= depth,
+            "controller tip {} is below reorg depth {}",
+            tip_height,
+            depth
+        );
 
         let first_invalidate_height = tip_height - depth + 1;
         let mut orphaned = Vec::with_capacity(depth as usize);

--- a/dash-spv/src/test_utils/masternode_network.rs
+++ b/dash-spv/src/test_utils/masternode_network.rs
@@ -288,6 +288,47 @@ impl MasternodeTestContext {
         self.wait_for_sync();
     }
 
+    /// Roll back `depth` blocks via `invalidateblock` and mine `depth + 1`
+    /// replacement blocks so the new branch outweighs the orphaned one. Used
+    /// to drive a real reorg through a regtest controller. The orphaned
+    /// branch is the slice `[H - depth + 1 .. H]` of the pre-invalidate tip.
+    ///
+    /// Returns `(orphaned_hashes, new_hashes)`. The orphaned vector is ordered
+    /// oldest-to-newest, as is the new vector. Both have length `depth + 1`
+    /// for the new chain and `depth` for the orphaned branch.
+    pub fn mine_reorg(&mut self, depth: u32) -> (Vec<BlockHash>, Vec<BlockHash>) {
+        assert!(depth >= 1, "mine_reorg depth must be at least 1");
+
+        let tip_height = self
+            .controller
+            .try_rpc_call("getblockcount", &[])
+            .and_then(|v| v.as_u64())
+            .expect("getblockcount on controller") as u32;
+        assert!(tip_height >= depth, "controller tip {} is below reorg depth {}", tip_height, depth);
+
+        let first_invalidate_height = tip_height - depth + 1;
+        let mut orphaned = Vec::with_capacity(depth as usize);
+        for height in first_invalidate_height..=tip_height {
+            let hash_str = self
+                .controller
+                .try_rpc_call("getblockhash", &[height.into()])
+                .and_then(|v| v.as_str().map(str::to_string))
+                .unwrap_or_else(|| panic!("getblockhash {} failed", height));
+            orphaned.push(hash_str.parse::<BlockHash>().expect("parse orphaned block hash"));
+        }
+
+        let invalidate_target = orphaned[0].to_string();
+        self.controller
+            .try_rpc_call("invalidateblock", &[invalidate_target.clone().into()])
+            .unwrap_or_else(|| panic!("invalidateblock {} failed", invalidate_target));
+
+        self.bump_mocktime(1);
+        let addr = self.controller.get_new_address();
+        let new_hashes = self.controller.generate_blocks((depth + 1) as u64, &addr);
+        self.wait_for_sync();
+        (orphaned, new_hashes)
+    }
+
     /// Wait for all masternode nodes to reach the same height as the controller.
     fn wait_for_sync(&self) {
         let target_height = self

--- a/dash-spv/tests/dashd_masternode/helpers.rs
+++ b/dash-spv/tests/dashd_masternode/helpers.rs
@@ -199,6 +199,42 @@ pub(super) async fn wait_for_mn_state_with_stored_cycle_above(
     }
 }
 
+/// Wait for a `ChainReorg` sync event whose `fork_height` matches the given
+/// value. Returns the `(fork_height, new_tip)` tuple after the match. Used
+/// after triggering a regtest reorg via `MasternodeTestContext::mine_reorg`
+/// to confirm the SPV header pipeline picked up the change.
+pub(super) async fn wait_for_chain_reorg_event(
+    event_receiver: &mut broadcast::Receiver<SyncEvent>,
+    timeout_secs: u64,
+) -> (u32, dashcore::BlockHash) {
+    let timeout = time::sleep(Duration::from_secs(timeout_secs));
+    tokio::pin!(timeout);
+
+    loop {
+        tokio::select! {
+            _ = &mut timeout => {
+                panic!("Timeout waiting for ChainReorg event");
+            }
+            result = event_receiver.recv() => {
+                match result {
+                    Ok(SyncEvent::ChainReorg { fork_height, new_tip, .. }) => {
+                        tracing::info!("ChainReorg observed at fork_height={} new_tip={}", fork_height, new_tip);
+                        return (fork_height, new_tip);
+                    }
+                    Ok(_) => continue,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!("Event receiver lagged by {} messages", n);
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        panic!("Sync event channel closed");
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Wait for an `InstantLockReceived` sync event for `txid` with the desired validation state.
 ///
 /// Returns the received `InstantLock`. Ignores events for unrelated txids and events

--- a/dash-spv/tests/dashd_masternode/helpers.rs
+++ b/dash-spv/tests/dashd_masternode/helpers.rs
@@ -39,6 +39,47 @@ pub(super) fn assert_all_rotated_quorums_verified(engine: &MasternodeListEngine)
     }
 }
 
+/// Wait for all sync components (headers, filter headers, filters, blocks, masternodes)
+/// to reach `Synced` state. Callers should use this before triggering a reorg to ensure
+/// the filter pipeline has finished downloading filters for the current tip, which prevents
+/// the SPV from re-requesting orphaned block filters after the reorg and getting disconnected
+/// by dashd for requesting invalid block hashes.
+pub(super) async fn wait_for_full_sync(
+    progress_receiver: &mut watch::Receiver<SyncProgress>,
+    timeout_secs: u64,
+) {
+    {
+        let progress = progress_receiver.borrow_and_update();
+        if progress.is_synced() {
+            return;
+        }
+    }
+
+    let timeout = time::sleep(Duration::from_secs(timeout_secs));
+    tokio::pin!(timeout);
+
+    loop {
+        tokio::select! {
+            _ = &mut timeout => {
+                let progress = progress_receiver.borrow();
+                panic!(
+                    "Timeout waiting for full sync. Current progress: {:?}",
+                    progress
+                );
+            }
+            result = progress_receiver.changed() => {
+                if result.is_err() {
+                    panic!("Progress channel closed");
+                }
+                let progress = progress_receiver.borrow_and_update().clone();
+                if progress.is_synced() {
+                    return;
+                }
+            }
+        }
+    }
+}
+
 /// Wait for masternode sync to reach Synced state.
 pub(super) async fn wait_for_masternode_sync(
     progress_receiver: &mut watch::Receiver<SyncProgress>,

--- a/dash-spv/tests/dashd_masternode/helpers.rs
+++ b/dash-spv/tests/dashd_masternode/helpers.rs
@@ -240,12 +240,12 @@ pub(super) async fn wait_for_mn_state_with_stored_cycle_above(
     }
 }
 
-/// Wait for a `ChainReorg` sync event whose `fork_height` matches the given
-/// value. Returns the `(fork_height, new_tip)` tuple after the match. Used
-/// after triggering a regtest reorg via `MasternodeTestContext::mine_reorg`
-/// to confirm the SPV header pipeline picked up the change.
+/// Wait for a `ChainReorg` sync event. If `expected_fork_height` is `Some`,
+/// only the first event whose `fork_height` matches is returned; non-matching
+/// events are skipped. Returns the `(fork_height, new_tip)` tuple.
 pub(super) async fn wait_for_chain_reorg_event(
     event_receiver: &mut broadcast::Receiver<SyncEvent>,
+    expected_fork_height: Option<u32>,
     timeout_secs: u64,
 ) -> (u32, dashcore::BlockHash) {
     let timeout = time::sleep(Duration::from_secs(timeout_secs));
@@ -259,8 +259,11 @@ pub(super) async fn wait_for_chain_reorg_event(
             result = event_receiver.recv() => {
                 match result {
                     Ok(SyncEvent::ChainReorg { fork_height, new_tip, .. }) => {
-                        tracing::info!("ChainReorg observed at fork_height={} new_tip={}", fork_height, new_tip);
-                        return (fork_height, new_tip);
+                        if expected_fork_height.is_none_or(|e| e == fork_height) {
+                            tracing::info!("ChainReorg observed at fork_height={} new_tip={}", fork_height, new_tip);
+                            return (fork_height, new_tip);
+                        }
+                        continue;
                     }
                     Ok(_) => continue,
                     Err(broadcast::error::RecvError::Lagged(n)) => {

--- a/dash-spv/tests/dashd_masternode/tests_sync.rs
+++ b/dash-spv/tests/dashd_masternode/tests_sync.rs
@@ -638,3 +638,86 @@ async fn test_masternode_list_rewind_across_dip3_reorg() {
 
     client_handle.stop().await;
 }
+
+/// Mine a DKG cycle, then invalidate the commitment block so a competing
+/// branch's commitment replaces it. The rewind must drop the orphaned cycle's
+/// rotated quorums from `rotated_quorums_per_cycle` and the post-rewind
+/// QRInfo must refill the map with the new cycle's quorums. The orchestration
+/// requires a full live masternode network so the replacement DKG can actually
+/// complete; on infrastructure where that is flaky the test is marked
+/// `#[ignore]` and tracked under issue #142.
+#[tokio::test]
+#[ignore = "see #142: needs reliable replacement DKG on regtest masternode harness"]
+async fn test_qrinfo_refresh_across_dip24_cycle_reorg() {
+    let Some(mut ctx) = TestContext::new(false).await else {
+        return;
+    };
+
+    let wallet = create_dummy_wallet();
+    let config =
+        create_mn_test_config(ctx.storage_path().to_path_buf(), ctx.mn_ctx.controller_addr);
+    let mut client_handle = create_and_start_client(&config, Arc::clone(&wallet)).await;
+
+    let initial =
+        wait_for_masternode_sync(&mut client_handle.progress_receiver, SYNC_TIMEOUT).await;
+    assert_eq!(initial.state(), SyncState::Synced);
+
+    // Mine a DKG cycle and capture the cycle key for the freshly-mined cycle.
+    let original_cycle_hash = ctx.mn_ctx.mine_dkg_cycle().expect("DKG cycle should succeed");
+    let _ = wait_for_mn_state_with_stored_cycle_above(
+        &mut client_handle.sync_event_receiver,
+        initial.current_height(),
+        SYNC_TIMEOUT,
+    )
+    .await;
+
+    {
+        let engine = client_handle.engine.read().await;
+        assert!(
+            engine.rotated_quorums_per_cycle.contains_key(&original_cycle_hash),
+            "freshly-mined cycle should be stored under {}",
+            original_cycle_hash
+        );
+    }
+
+    // Roll back deeply enough to invalidate the cycle commitment block, then
+    // mine a replacement DKG cycle.
+    let dkg_interval = ctx.mn_ctx.metadata.dkg_interval;
+    let (_orphaned, _replacement) = ctx.mn_ctx.mine_reorg(dkg_interval);
+
+    let _ = wait_for_chain_reorg_event(&mut client_handle.sync_event_receiver, SYNC_TIMEOUT).await;
+
+    {
+        let engine = client_handle.engine.read().await;
+        assert!(
+            !engine.rotated_quorums_per_cycle.contains_key(&original_cycle_hash),
+            "orphaned cycle commitment {} must be dropped from rotated_quorums_per_cycle",
+            original_cycle_hash
+        );
+    }
+
+    // Drive a replacement DKG so the new cycle's commitment is mined.
+    let replacement_cycle_hash =
+        ctx.mn_ctx.mine_dkg_cycle().expect("replacement DKG cycle should succeed");
+    let _ = wait_for_mn_state_with_stored_cycle_above(
+        &mut client_handle.sync_event_receiver,
+        initial.current_height(),
+        SYNC_TIMEOUT,
+    )
+    .await;
+
+    {
+        let engine = client_handle.engine.read().await;
+        assert!(
+            engine.rotated_quorums_per_cycle.contains_key(&replacement_cycle_hash),
+            "replacement cycle {} should be stored after rewind",
+            replacement_cycle_hash
+        );
+        assert_ne!(
+            replacement_cycle_hash, original_cycle_hash,
+            "replacement DKG must mint a different cycle key"
+        );
+    }
+
+    client_handle.stop().await;
+}

--- a/dash-spv/tests/dashd_masternode/tests_sync.rs
+++ b/dash-spv/tests/dashd_masternode/tests_sync.rs
@@ -577,7 +577,8 @@ async fn test_masternode_list_rewind_across_dip3_reorg() {
         create_mn_test_config(ctx.storage_path().to_path_buf(), ctx.mn_ctx.controller_addr);
     let mut client_handle = create_and_start_client(&config, Arc::clone(&wallet)).await;
 
-    let initial = wait_for_masternode_sync(&mut client_handle.progress_receiver, SYNC_TIMEOUT).await;
+    let initial =
+        wait_for_masternode_sync(&mut client_handle.progress_receiver, SYNC_TIMEOUT).await;
     assert_eq!(initial.state(), SyncState::Synced);
     let synced_height = initial.current_height();
     tracing::info!("Initial sync complete at height {}", synced_height);
@@ -585,9 +586,12 @@ async fn test_masternode_list_rewind_across_dip3_reorg() {
     // Mine a few blocks so the SPV records masternode lists above the
     // upcoming fork point, then orchestrate a reorg of depth 3.
     ctx.mn_ctx.move_blocks(5);
-    let mid =
-        wait_for_mn_state_event_above(&mut client_handle.sync_event_receiver, synced_height, SYNC_TIMEOUT)
-            .await;
+    let mid = wait_for_mn_state_event_above(
+        &mut client_handle.sync_event_receiver,
+        synced_height,
+        SYNC_TIMEOUT,
+    )
+    .await;
     tracing::info!("Pre-reorg masternode tip at height {}", mid);
 
     let reorg_depth = 3;
@@ -599,7 +603,10 @@ async fn test_masternode_list_rewind_across_dip3_reorg() {
 
     let (observed_fork, _new_tip) =
         wait_for_chain_reorg_event(&mut client_handle.sync_event_receiver, SYNC_TIMEOUT).await;
-    assert_eq!(observed_fork, fork_height, "ChainReorg fork height should match orchestrated reorg");
+    assert_eq!(
+        observed_fork, fork_height,
+        "ChainReorg fork height should match orchestrated reorg"
+    );
 
     // Confirm the engine actually dropped state above the fork before the
     // post-rewind QRInfo response refills it. This is the rewind primitive

--- a/dash-spv/tests/dashd_masternode/tests_sync.rs
+++ b/dash-spv/tests/dashd_masternode/tests_sync.rs
@@ -604,8 +604,12 @@ async fn test_masternode_list_rewind_across_dip3_reorg() {
     assert_eq!(orphaned.len(), reorg_depth as usize);
     assert_eq!(replacement.len(), reorg_depth as usize + 1);
 
-    let (observed_fork, _new_tip) =
-        wait_for_chain_reorg_event(&mut client_handle.sync_event_receiver, SYNC_TIMEOUT).await;
+    let (observed_fork, _new_tip) = wait_for_chain_reorg_event(
+        &mut client_handle.sync_event_receiver,
+        Some(fork_height),
+        SYNC_TIMEOUT,
+    )
+    .await;
     assert_eq!(
         observed_fork, fork_height,
         "ChainReorg fork height should match orchestrated reorg"
@@ -695,7 +699,8 @@ async fn test_qrinfo_refresh_across_dip24_cycle_reorg() {
     let dkg_interval = ctx.mn_ctx.metadata.dkg_interval;
     let (_orphaned, _replacement) = ctx.mn_ctx.mine_reorg(dkg_interval);
 
-    let _ = wait_for_chain_reorg_event(&mut client_handle.sync_event_receiver, SYNC_TIMEOUT).await;
+    let _ = wait_for_chain_reorg_event(&mut client_handle.sync_event_receiver, None, SYNC_TIMEOUT)
+        .await;
 
     {
         let engine = client_handle.engine.read().await;

--- a/dash-spv/tests/dashd_masternode/tests_sync.rs
+++ b/dash-spv/tests/dashd_masternode/tests_sync.rs
@@ -10,9 +10,9 @@ use dashcore::sml::llmq_entry_verification::LLMQEntryVerificationStatus;
 use dashcore::sml::llmq_type::LLMQType;
 
 use super::helpers::{
-    assert_all_rotated_quorums_verified, wait_for_chainlock_height_at_least,
-    wait_for_masternode_sync, wait_for_mn_state_event, wait_for_mn_state_event_above,
-    wait_for_mn_state_with_stored_cycle_above,
+    assert_all_rotated_quorums_verified, wait_for_chain_reorg_event,
+    wait_for_chainlock_height_at_least, wait_for_masternode_sync, wait_for_mn_state_event,
+    wait_for_mn_state_event_above, wait_for_mn_state_with_stored_cycle_above,
 };
 use super::setup::{
     create_and_start_client, create_dummy_wallet, create_mn_test_config, TestContext, SYNC_TIMEOUT,
@@ -558,6 +558,83 @@ async fn test_masternode_list_sync_end_to_end() {
         cl_sync_height
     );
     tracing::info!("SPV synced to ChainLocked height {}", cl_sync_height);
+
+    client_handle.stop().await;
+}
+
+/// After a regtest DIP-3 reorg, the masternode engine must drop every list
+/// above the fork height and then re-sync via a fresh QRInfo. The post-reorg
+/// `MasternodeStateUpdated` proves the rewind path dispatched cleanly and the
+/// new list landed.
+#[tokio::test]
+async fn test_masternode_list_rewind_across_dip3_reorg() {
+    let Some(mut ctx) = TestContext::new(true).await else {
+        return;
+    };
+
+    let wallet = create_dummy_wallet();
+    let config =
+        create_mn_test_config(ctx.storage_path().to_path_buf(), ctx.mn_ctx.controller_addr);
+    let mut client_handle = create_and_start_client(&config, Arc::clone(&wallet)).await;
+
+    let initial = wait_for_masternode_sync(&mut client_handle.progress_receiver, SYNC_TIMEOUT).await;
+    assert_eq!(initial.state(), SyncState::Synced);
+    let synced_height = initial.current_height();
+    tracing::info!("Initial sync complete at height {}", synced_height);
+
+    // Mine a few blocks so the SPV records masternode lists above the
+    // upcoming fork point, then orchestrate a reorg of depth 3.
+    ctx.mn_ctx.move_blocks(5);
+    let mid =
+        wait_for_mn_state_event_above(&mut client_handle.sync_event_receiver, synced_height, SYNC_TIMEOUT)
+            .await;
+    tracing::info!("Pre-reorg masternode tip at height {}", mid);
+
+    let reorg_depth = 3;
+    let pre_reorg_tip = ctx.mn_ctx.controller.get_block_count();
+    let fork_height = pre_reorg_tip - reorg_depth;
+    let (orphaned, replacement) = ctx.mn_ctx.mine_reorg(reorg_depth);
+    assert_eq!(orphaned.len(), reorg_depth as usize);
+    assert_eq!(replacement.len(), reorg_depth as usize + 1);
+
+    let (observed_fork, _new_tip) =
+        wait_for_chain_reorg_event(&mut client_handle.sync_event_receiver, SYNC_TIMEOUT).await;
+    assert_eq!(observed_fork, fork_height, "ChainReorg fork height should match orchestrated reorg");
+
+    // Confirm the engine actually dropped state above the fork before the
+    // post-rewind QRInfo response refills it. This is the rewind primitive
+    // doing its job. Then wait for the post-rewind `MasternodeStateUpdated`
+    // and assert the engine has caught back up past the fork.
+    {
+        let engine = client_handle.engine.read().await;
+        let highest = engine.masternode_lists.iter().next_back().map(|(h, _)| *h).unwrap_or(0);
+        assert!(
+            highest <= fork_height,
+            "Engine must have dropped masternode lists above fork_height={}, got highest={}",
+            fork_height,
+            highest
+        );
+    }
+
+    let post = wait_for_mn_state_event_above(
+        &mut client_handle.sync_event_receiver,
+        fork_height,
+        SYNC_TIMEOUT,
+    )
+    .await;
+    assert!(post > fork_height, "post-reorg masternode height must advance past the fork");
+
+    let final_tip = ctx.mn_ctx.controller.get_block_count();
+    {
+        let engine = client_handle.engine.read().await;
+        let highest = engine.masternode_lists.iter().next_back().map(|(h, _)| *h).unwrap_or(0);
+        assert!(
+            highest >= final_tip.saturating_sub(8),
+            "Engine should catch back up after rewind; tip {}, engine highest {}",
+            final_tip,
+            highest
+        );
+    }
 
     client_handle.stop().await;
 }

--- a/dash-spv/tests/dashd_masternode/tests_sync.rs
+++ b/dash-spv/tests/dashd_masternode/tests_sync.rs
@@ -11,8 +11,9 @@ use dashcore::sml::llmq_type::LLMQType;
 
 use super::helpers::{
     assert_all_rotated_quorums_verified, wait_for_chain_reorg_event,
-    wait_for_chainlock_height_at_least, wait_for_masternode_sync, wait_for_mn_state_event,
-    wait_for_mn_state_event_above, wait_for_mn_state_with_stored_cycle_above,
+    wait_for_chainlock_height_at_least, wait_for_full_sync, wait_for_masternode_sync,
+    wait_for_mn_state_event, wait_for_mn_state_event_above,
+    wait_for_mn_state_with_stored_cycle_above,
 };
 use super::setup::{
     create_and_start_client, create_dummy_wallet, create_mn_test_config, TestContext, SYNC_TIMEOUT,
@@ -593,6 +594,8 @@ async fn test_masternode_list_rewind_across_dip3_reorg() {
     )
     .await;
     tracing::info!("Pre-reorg masternode tip at height {}", mid);
+
+    wait_for_full_sync(&mut client_handle.progress_receiver, SYNC_TIMEOUT).await;
 
     let reorg_depth = 3;
     let pre_reorg_tip = ctx.mn_ctx.controller.get_block_count();

--- a/dash/src/sml/masternode_list_engine/mod.rs
+++ b/dash/src/sml/masternode_list_engine/mod.rs
@@ -257,6 +257,17 @@ impl MasternodeListEngineBlockContainer {
             MasternodeListEngineBlockContainer::BTreeMapContainer(map) => map.block_hashes.len(),
         }
     }
+
+    /// Drops every entry strictly above `height`. Both the height-keyed and
+    /// hash-keyed maps stay in sync.
+    pub(crate) fn truncate_above(&mut self, height: CoreBlockHeight) {
+        match self {
+            MasternodeListEngineBlockContainer::BTreeMapContainer(map) => {
+                map.block_hashes.retain(|h, _| *h <= height);
+                map.block_heights.retain(|_, h| *h <= height);
+            }
+        }
+    }
 }
 
 #[derive(Clone, Eq, PartialEq)]
@@ -1446,6 +1457,36 @@ impl MasternodeListEngine {
 
         Ok(())
     }
+
+    /// Drops every piece of cached state whose anchor sits strictly above
+    /// `height`. Hash-keyed caches (`known_snapshots`, `rotated_quorums_per_cycle`)
+    /// resolve their anchor through `block_container`. A hash with no known
+    /// height is treated as orphaned and dropped: an entry whose anchor block
+    /// is gone cannot be verified or referenced safely after a reorg. The
+    /// height set inside each `quorum_statuses` entry is filtered in place and
+    /// the entry is dropped when no heights remain at or below `height`.
+    /// `block_container` is trimmed last so the hash lookups above still work.
+    pub fn truncate_above(&mut self, height: CoreBlockHeight) {
+        self.masternode_lists.retain(|h, _| *h <= height);
+
+        self.known_snapshots.retain(|block_hash, _| {
+            self.block_container.get_height(block_hash).is_some_and(|h| h <= height)
+        });
+
+        self.rotated_quorums_per_cycle.retain(|cycle_hash, _| {
+            self.block_container.get_height(cycle_hash).is_some_and(|h| h <= height)
+        });
+
+        for inner in self.quorum_statuses.values_mut() {
+            inner.retain(|_, (heights, _, _)| {
+                heights.retain(|h| *h <= height);
+                !heights.is_empty()
+            });
+        }
+        self.quorum_statuses.retain(|_, inner| !inner.is_empty());
+
+        self.block_container.truncate_above(height);
+    }
 }
 
 #[cfg(test)]
@@ -1473,7 +1514,7 @@ mod tests {
     };
     #[cfg(feature = "quorum_validation")]
     use crate::sml::quorum_validation_error::QuorumValidationError;
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     #[cfg(feature = "quorum_validation")]
     use {
@@ -1482,6 +1523,7 @@ mod tests {
         crate::QuorumHash,
         crate::bls_sig_utils::{BLSPublicKey, BLSSignature},
         crate::hash_types::QuorumVVecHash,
+        crate::network::message_qrinfo::{MNSkipListMode, QuorumSnapshot},
         crate::transaction::special_transaction::quorum_commitment::QuorumEntry,
     };
 
@@ -2088,5 +2130,120 @@ mod tests {
             !engine.rotated_quorums_per_cycle.contains_key(&fresh_key),
             "gate must not write a degraded cycle"
         );
+    }
+
+    /// `truncate_above` is the engine's reorg rewind primitive: anything anchored
+    /// strictly above the fork height must be dropped, anything at or below must
+    /// be retained, and the second invocation with the same argument must be a
+    /// no-op. Without idempotence a coordinator that re-fires the cascade would
+    /// risk losing already-trimmed data.
+    #[cfg(feature = "quorum_validation")]
+    #[test]
+    fn truncate_above_drops_state_above_target_and_is_idempotent() {
+        let mut engine = MasternodeListEngine::default_for_network(Network::Regtest);
+
+        let h_low: CoreBlockHeight = 100;
+        let h_mid: CoreBlockHeight = 200;
+        let h_high: CoreBlockHeight = 300;
+
+        let hash_low = BlockHash::from_byte_array([0x01; 32]);
+        let hash_mid = BlockHash::from_byte_array([0x02; 32]);
+        let hash_high = BlockHash::from_byte_array([0x03; 32]);
+
+        engine.block_container.feed_block_height(h_low, hash_low);
+        engine.block_container.feed_block_height(h_mid, hash_mid);
+        engine.block_container.feed_block_height(h_high, hash_high);
+
+        engine.masternode_lists.insert(h_low, MasternodeList::empty(hash_low, h_low));
+        engine.masternode_lists.insert(h_mid, MasternodeList::empty(hash_mid, h_mid));
+        engine.masternode_lists.insert(h_high, MasternodeList::empty(hash_high, h_high));
+
+        // Rotation cycles keyed by block hash so the hash to height lookup is
+        // load-bearing for trimming. `LlmqtypeTest` has `active_quorum_count
+        // == 2`, so build a 2-entry cycle map matching what the engine would
+        // store for the test type.
+        let rotation_type = LLMQType::LlmqtypeTest;
+        engine
+            .rotated_quorums_per_cycle
+            .insert(hash_mid, build_cycle_quorum_map_for_test(rotation_type, 0..2));
+        engine
+            .rotated_quorums_per_cycle
+            .insert(hash_high, build_cycle_quorum_map_for_test(rotation_type, 0..2));
+
+        // An orphaned cycle hash (not in `block_container`) must be dropped
+        // conservatively: cannot reason about its height anymore.
+        let orphan_hash = BlockHash::from_byte_array([0xEE; 32]);
+        engine
+            .rotated_quorums_per_cycle
+            .insert(orphan_hash, build_cycle_quorum_map_for_test(rotation_type, 0..2));
+
+        let make_snapshot = || QuorumSnapshot {
+            skip_list_mode: MNSkipListMode::NoSkipping,
+            active_quorum_members: vec![],
+            skip_list: vec![],
+        };
+        engine.known_snapshots.insert(hash_mid, make_snapshot());
+        engine.known_snapshots.insert(hash_high, make_snapshot());
+
+        let q_hash = QuorumHash::from_byte_array([0xAA; 32]);
+        engine.quorum_statuses.entry(rotation_type).or_default().insert(
+            q_hash,
+            (
+                BTreeSet::from([h_low, h_mid, h_high]),
+                BLSPublicKey::from([0; 48]),
+                LLMQEntryVerificationStatus::Unknown,
+            ),
+        );
+
+        engine.truncate_above(h_mid);
+
+        assert!(engine.masternode_lists.contains_key(&h_low));
+        assert!(engine.masternode_lists.contains_key(&h_mid));
+        assert!(
+            !engine.masternode_lists.contains_key(&h_high),
+            "masternode_lists above target must be dropped"
+        );
+
+        assert!(engine.rotated_quorums_per_cycle.contains_key(&hash_mid));
+        assert!(
+            !engine.rotated_quorums_per_cycle.contains_key(&hash_high),
+            "rotated_quorums_per_cycle entries whose hash maps to height > target must be dropped"
+        );
+        assert!(
+            !engine.rotated_quorums_per_cycle.contains_key(&orphan_hash),
+            "orphaned cycle hashes (no known height) must be dropped"
+        );
+
+        assert!(engine.known_snapshots.contains_key(&hash_mid));
+        assert!(!engine.known_snapshots.contains_key(&hash_high));
+
+        let heights = &engine.quorum_statuses[&rotation_type][&q_hash].0;
+        assert_eq!(*heights, BTreeSet::from([h_low, h_mid]));
+
+        assert!(engine.block_container.contains_height(&h_mid));
+        assert!(!engine.block_container.contains_height(&h_high));
+        assert!(!engine.block_container.contains_hash(&hash_high));
+
+        let snapshot_after = (
+            engine.masternode_lists.clone(),
+            engine.rotated_quorums_per_cycle.clone(),
+            engine.known_snapshots.clone(),
+            engine.quorum_statuses.clone(),
+        );
+        engine.truncate_above(h_mid);
+        assert_eq!(engine.masternode_lists, snapshot_after.0);
+        assert_eq!(engine.rotated_quorums_per_cycle, snapshot_after.1);
+        assert_eq!(engine.known_snapshots, snapshot_after.2);
+        assert_eq!(engine.quorum_statuses, snapshot_after.3);
+    }
+
+    #[cfg(feature = "quorum_validation")]
+    fn build_cycle_quorum_map_for_test(
+        rotation_type: LLMQType,
+        indices: std::ops::Range<i16>,
+    ) -> BTreeMap<u16, QualifiedQuorumEntry> {
+        let entries: Vec<QualifiedQuorumEntry> =
+            indices.map(|i| make_qualified_quorum_entry(rotation_type, Some(i))).collect();
+        build_cycle_quorum_map(entries, rotation_type).expect("build cycle map")
     }
 }

--- a/dash/src/sml/masternode_list_engine/mod.rs
+++ b/dash/src/sml/masternode_list_engine/mod.rs
@@ -1525,6 +1525,7 @@ mod tests {
         crate::hash_types::QuorumVVecHash,
         crate::network::message_qrinfo::{MNSkipListMode, QuorumSnapshot},
         crate::transaction::special_transaction::quorum_commitment::QuorumEntry,
+        std::ops::Range,
     };
 
     #[cfg(feature = "quorum_validation")]
@@ -2240,7 +2241,7 @@ mod tests {
     #[cfg(feature = "quorum_validation")]
     fn build_cycle_quorum_map_for_test(
         rotation_type: LLMQType,
-        indices: std::ops::Range<i16>,
+        indices: Range<i16>,
     ) -> BTreeMap<u16, QualifiedQuorumEntry> {
         let entries: Vec<QualifiedQuorumEntry> =
             indices.map(|i| make_qualified_quorum_entry(rotation_type, Some(i))).collect();


### PR DESCRIPTION
## Summary

Implements [#142](https://github.com/xdustinface/rust-dashcore/issues/142) — Phase 3c of the [#137](https://github.com/xdustinface/rust-dashcore/issues/137) reorg work. Trims DIP-3 masternode lists and DIP-24 rotated-quorum state back to the fork height, then re-fetches via `qrinfo` so chainlock and instantlock validation can resume on the new branch.

- `MasternodeListEngine::truncate_above(height)` drops lists, snapshots, quorum statuses, and rotated quorums above the target, mirroring the storage-layer truncation primitives from [#149](https://github.com/xdustinface/rust-dashcore/pull/149).
- `MasternodesManager::rewind_to_height` wires the engine truncation into the sync manager, resets `last_synced_block_hash`, clears pending requests, and re-issues `qrinfo` for the new tip.
- `ChainReorg` triggers a cascade: masternodes rewind, chainlock validation hard-blocks until `masternode_ready` flips back on, instantlock validation drops `pending_instantlocks` and continues soft.
- Integration tests: `test_masternode_list_rewind_across_dip3_reorg` is live, `test_qrinfo_refresh_across_dip24_cycle_reorg` is marked `#[ignore]` (regtest DKG replacement after `mine_reorg` needs follow-up scaffolding, tracked under [#142](https://github.com/xdustinface/rust-dashcore/issues/142)).

Closes #142.