### PR TITLE
feat(dash-spv): startup consistency check and reorg-in-progress sentinel

### DIFF
--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -13,8 +13,9 @@ use crate::chain::checkpoints::{mainnet_checkpoints, testnet_checkpoints, Checkp
 use crate::error::{Result, SpvError};
 use crate::network::NetworkManager;
 use crate::storage::{
-    PersistentBlockHeaderStorage, PersistentBlockStorage, PersistentFilterHeaderStorage,
-    PersistentFilterStorage, PersistentMetadataStorage, StorageManager,
+    BlockHeaderStorage, PersistentBlockHeaderStorage, PersistentBlockStorage,
+    PersistentFilterHeaderStorage, PersistentFilterStorage, PersistentMetadataStorage,
+    StorageManager,
 };
 use crate::sync::{
     BlockHeadersManager, BlocksManager, ChainLockManager, FilterHeadersManager, FiltersManager,
@@ -45,6 +46,13 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         // Initialize genesis block or checkpoint before creating managers,
         // so they can read the tip from storage during construction.
         Self::initialize_genesis_block(&config, &mut storage).await?;
+
+        // Clamp wallet heights to the (possibly repaired) block-header tip so
+        // a mid-cascade crash recovery cannot leave wallet metadata pointing
+        // above a height the local header chain no longer contains.
+        if let Some(tip) = storage.block_headers().read().await.get_tip_height().await {
+            wallet.write().await.clamp_heights_to(tip).await;
+        }
 
         let masternode_engine = {
             if config.enable_masternodes {

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -50,7 +50,10 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         // Clamp wallet heights to the (possibly repaired) block-header tip so
         // a mid-cascade crash recovery cannot leave wallet metadata pointing
         // above a height the local header chain no longer contains.
-        if let Some(tip) = storage.block_headers().read().await.get_tip_height().await {
+        // Bind the tip into a local so the block-header read guard is dropped
+        // before the wallet write lock is acquired.
+        let tip_after_repair = storage.block_headers().read().await.get_tip_height().await;
+        if let Some(tip) = tip_after_repair {
             wallet.write().await.clamp_heights_to(tip).await;
         }
 

--- a/dash-spv/src/storage/block_headers.rs
+++ b/dash-spv/src/storage/block_headers.rs
@@ -264,14 +264,15 @@ impl BlockHeaderStorage for PersistentBlockHeaderStorage {
 }
 
 impl PersistentBlockHeaderStorage {
-    /// Highest height `h` such that every header in `[start, h]` chains
-    /// correctly via `prev_blockhash` to its parent in `header_hash_index`.
-    ///
-    /// Walks backward from the current tip, returning the first height whose
-    /// parent hash maps to the immediately preceding height. Returns `None`
-    /// when the storage is empty. Used by the startup consistency check to
-    /// recover a safe tip after a crash mid-cascade.
-    pub(crate) async fn highest_valid_tip(&self) -> Option<u32> {
+    /// Highest height `h` for which the immediate parent link
+    /// (`header_hash_index[prev_blockhash_of(h)] == h - 1`) is found in the
+    /// index and the header at `h` is present in storage. Walks backward from
+    /// the current tip, returning the first height that satisfies these two
+    /// conditions. Returns `None` when the storage is empty. Mid-chain gaps
+    /// are not detected; callers must not assume that `[start, result]` is
+    /// fully contiguous. Used by the startup consistency check to recover a
+    /// safe tip after a crash mid-cascade.
+    pub(crate) async fn highest_valid_tip(&mut self) -> Option<u32> {
         let mut headers = self.block_headers.write().await;
         let tip = headers.tip_height()?;
         let start = headers.start_height()?;

--- a/dash-spv/src/storage/block_headers.rs
+++ b/dash-spv/src/storage/block_headers.rs
@@ -263,6 +263,48 @@ impl BlockHeaderStorage for PersistentBlockHeaderStorage {
     }
 }
 
+impl PersistentBlockHeaderStorage {
+    /// Highest height `h` such that every header in `[start, h]` chains
+    /// correctly via `prev_blockhash` to its parent in `header_hash_index`.
+    ///
+    /// Walks backward from the current tip, returning the first height whose
+    /// parent hash maps to the immediately preceding height. Returns `None`
+    /// when the storage is empty. Used by the startup consistency check to
+    /// recover a safe tip after a crash mid-cascade.
+    pub(crate) async fn highest_valid_tip(&self) -> Option<u32> {
+        let mut headers = self.block_headers.write().await;
+        let tip = headers.tip_height()?;
+        let start = headers.start_height()?;
+
+        let mut height = tip;
+        loop {
+            if height == start {
+                return Some(start);
+            }
+
+            let parent_height = height - 1;
+            let current = headers.get_item(height).await.ok().flatten();
+            let Some(current) = current else {
+                if height == 0 {
+                    return None;
+                }
+                height -= 1;
+                continue;
+            };
+
+            match self.header_hash_index.get(&current.header().prev_blockhash) {
+                Some(&indexed) if indexed == parent_height => return Some(height),
+                _ => {
+                    if height == 0 {
+                        return None;
+                    }
+                    height -= 1;
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/dash-spv/src/storage/consistency.rs
+++ b/dash-spv/src/storage/consistency.rs
@@ -515,4 +515,25 @@ mod tests {
             "stale block above safe tip must be removed during sentinel recovery"
         );
     }
+
+    #[tokio::test]
+    async fn sentinel_cleared_when_no_block_headers_exist() {
+        let tmp = TempDir::new().unwrap();
+        let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
+
+        // Sentinel set but block-header storage is empty: the function must
+        // still clear the sentinel so a subsequent startup does not re-enter
+        // recovery indefinitely.
+        m.write().await.write_reorg_sentinel().await.unwrap();
+        assert!(m.read().await.is_reorg_sentinel_set().await);
+        assert_eq!(bh.read().await.get_tip_height().await, None);
+
+        check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
+
+        assert!(
+            !m.read().await.is_reorg_sentinel_set().await,
+            "sentinel must be cleared even when block-header storage is empty"
+        );
+        assert_eq!(bh.read().await.get_tip_height().await, None);
+    }
 }

--- a/dash-spv/src/storage/consistency.rs
+++ b/dash-spv/src/storage/consistency.rs
@@ -1,0 +1,148 @@
+//! Cross-storage startup consistency check.
+//!
+//! Runs unconditionally during `DiskStorageManager::new`, after every
+//! sub-storage has been opened. Verifies that downstream storages
+//! (filter headers, filters, blocks) cannot point above the block-header
+//! tip, and repairs any violation by truncating the offending storage
+//! and persisting it. Idempotent: a second invocation on already-repaired
+//! storages is a no-op.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::error::StorageResult;
+use crate::storage::{
+    BlockHeaderStorage, BlockStorage, FilterHeaderStorage, FilterStorage,
+    PersistentBlockHeaderStorage, PersistentBlockStorage, PersistentFilterHeaderStorage,
+    PersistentFilterStorage, PersistentMetadataStorage, PersistentStorage,
+};
+
+/// Run the cross-storage consistency repair sweep.
+///
+/// `storage_path` is forwarded to each sub-storage's `persist` so a repair
+/// is durable before the function returns. Designed to run during storage
+/// open, before any sync task observes the storages.
+pub(crate) async fn check_and_repair_consistency(
+    storage_path: &PathBuf,
+    block_headers: &Arc<RwLock<PersistentBlockHeaderStorage>>,
+    filter_headers: &Arc<RwLock<PersistentFilterHeaderStorage>>,
+    filters: &Arc<RwLock<PersistentFilterStorage>>,
+    blocks: &Arc<RwLock<PersistentBlockStorage>>,
+    metadata: &Arc<RwLock<PersistentMetadataStorage>>,
+) -> StorageResult<()> {
+    let block_tip = block_headers.read().await.get_tip_height().await;
+    let block_tip = match block_tip {
+        Some(h) => h,
+        None => {
+            tracing::debug!("consistency: no block header tip, skipping repair");
+            return Ok(());
+        }
+    };
+
+    // Filter header invariant: `filter_header_tip <= block_header_tip`.
+    let fh_tip = filter_headers.read().await.get_filter_tip_height().await?;
+    if let Some(fh_tip) = fh_tip {
+        if fh_tip > block_tip {
+            tracing::warn!(
+                "consistency: filter header tip {} > block header tip {}, truncating",
+                fh_tip,
+                block_tip
+            );
+            let mut guard = filter_headers.write().await;
+            guard.truncate_above(block_tip).await?;
+            guard.persist(storage_path).await?;
+        }
+    }
+
+    // Filter invariant: `filter_tip <= filter_header_tip`.
+    let fh_tip_after = filter_headers.read().await.get_filter_tip_height().await?;
+    let f_tip = filters.read().await.filter_tip_height().await?;
+    let fh_bound = fh_tip_after.unwrap_or(0);
+    if f_tip > fh_bound {
+        tracing::warn!(
+            "consistency: filter tip {} > filter header tip {}, truncating",
+            f_tip,
+            fh_bound
+        );
+        let mut guard = filters.write().await;
+        guard.truncate_above(fh_bound).await?;
+        guard.persist(storage_path).await?;
+    }
+
+    // Block storage invariant: `block_storage_tip <= block_header_tip`. We
+    // walk down from `block_tip + 1` checking for the highest stored block;
+    // if any exist strictly above the tip, truncate.
+    repair_blocks_above_tip(storage_path, blocks, block_tip).await?;
+
+    // BIP157 chain integrity: any filter header within [start, tip] must be
+    // loadable without error. A read failure here indicates a corrupted or
+    // partially-truncated filter-header range, so we truncate filter headers
+    // and filters back to the block header tip.
+    if let Some(start) = filter_headers.read().await.get_filter_start_height().await {
+        let tip = filter_headers
+            .read()
+            .await
+            .get_filter_tip_height()
+            .await?
+            .unwrap_or(start);
+        if tip >= start {
+            let read = filter_headers.read().await.load_filter_headers(start..tip + 1).await;
+            if let Err(err) = read {
+                tracing::warn!(
+                    "consistency: filter header chain unreadable ({:?}), truncating to block tip {}",
+                    err,
+                    block_tip
+                );
+                {
+                    let mut guard = filter_headers.write().await;
+                    guard.truncate_above(block_tip).await?;
+                    guard.persist(storage_path).await?;
+                }
+                let mut guard = filters.write().await;
+                guard.truncate_above(block_tip).await?;
+                guard.persist(storage_path).await?;
+            }
+        }
+    }
+
+    // Drop unused parameter warnings (metadata used by callers in a later commit).
+    let _ = metadata;
+
+    Ok(())
+}
+
+/// Probe block storage above `block_tip` and truncate when stale blocks are
+/// found. `PersistentBlockStorage` does not expose its own tip, so we sweep
+/// a bounded window above the header tip and truncate when any hit is found.
+async fn repair_blocks_above_tip(
+    storage_path: &PathBuf,
+    blocks: &Arc<RwLock<PersistentBlockStorage>>,
+    block_tip: u32,
+) -> StorageResult<()> {
+    const PROBE_WINDOW: u32 = 1_024;
+    let upper = block_tip.saturating_add(PROBE_WINDOW);
+    let guard = blocks.read().await;
+    let mut found_stale = false;
+    let mut probe = block_tip.saturating_add(1);
+    while probe <= upper {
+        if guard.load_block(probe).await?.is_some() {
+            found_stale = true;
+            break;
+        }
+        probe += 1;
+    }
+    drop(guard);
+
+    if found_stale {
+        tracing::warn!(
+            "consistency: block storage holds blocks above header tip {}, truncating",
+            block_tip
+        );
+        let mut guard = blocks.write().await;
+        guard.truncate_above(block_tip).await?;
+        guard.persist(storage_path).await?;
+    }
+    Ok(())
+}

--- a/dash-spv/src/storage/consistency.rs
+++ b/dash-spv/src/storage/consistency.rs
@@ -212,11 +212,13 @@ async fn repair_blocks_above_tip(
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
+    use dashcore::bls_sig_utils::BLSSignature;
     use dashcore::ephemerealdata::chain_lock::ChainLock;
     use dashcore::hash_types::FilterHeader;
-    use dashcore::Header as BlockHeader;
+    use dashcore::{BlockHash, Header as BlockHeader};
     use dashcore_hashes::Hash;
     use tempfile::TempDir;
     use tokio::sync::RwLock;
@@ -232,9 +234,9 @@ mod tests {
     use super::check_and_repair_consistency;
 
     async fn open_all(
-        path: &std::path::Path,
+        path: &Path,
     ) -> (
-        std::path::PathBuf,
+        PathBuf,
         Arc<RwLock<PersistentBlockHeaderStorage>>,
         Arc<RwLock<PersistentFilterHeaderStorage>>,
         Arc<RwLock<PersistentFilterStorage>>,
@@ -257,7 +259,7 @@ mod tests {
     #[tokio::test]
     async fn highest_valid_tip_returns_full_chain_when_intact() {
         let tmp = TempDir::new().unwrap();
-        let chain = BlockHeader::dummy_chain(5, dashcore::BlockHash::all_zeros());
+        let chain = BlockHeader::dummy_chain(5, BlockHash::all_zeros());
         let storage = PersistentBlockHeaderStorage::open(tmp.path()).await.unwrap();
         let mut storage = storage;
         storage.store_headers(&chain).await.unwrap();
@@ -287,7 +289,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
 
-        let chain = BlockHeader::dummy_chain(5, dashcore::BlockHash::all_zeros());
+        let chain = BlockHeader::dummy_chain(5, BlockHash::all_zeros());
         bh.write().await.store_headers(&chain).await.unwrap();
         fh.write().await.store_filter_headers(&FilterHeader::dummy_batch(0..10)).await.unwrap();
         assert_eq!(fh.read().await.get_filter_tip_height().await.unwrap(), Some(9));
@@ -302,7 +304,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
 
-        let chain = BlockHeader::dummy_chain(10, dashcore::BlockHash::all_zeros());
+        let chain = BlockHeader::dummy_chain(10, BlockHash::all_zeros());
         bh.write().await.store_headers(&chain).await.unwrap();
         fh.write().await.store_filter_headers(&FilterHeader::dummy_batch(0..5)).await.unwrap();
         for h in 0..8 {
@@ -322,7 +324,7 @@ mod tests {
 
         // Header tip at 4, block storage holds a block at heights 3 and 10.
         // Block 3 is within bounds, block 10 is stale and must be dropped.
-        let chain = BlockHeader::dummy_chain(5, dashcore::BlockHash::all_zeros());
+        let chain = BlockHeader::dummy_chain(5, BlockHash::all_zeros());
         bh.write().await.store_headers(&chain).await.unwrap();
         b.write().await.store_block(3, HashedBlock::dummy(3, vec![])).await.unwrap();
         b.write().await.store_block(10, HashedBlock::dummy(10, vec![])).await.unwrap();
@@ -338,13 +340,13 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
 
-        let chain = BlockHeader::dummy_chain(5, dashcore::BlockHash::all_zeros());
+        let chain = BlockHeader::dummy_chain(5, BlockHash::all_zeros());
         bh.write().await.store_headers(&chain).await.unwrap();
 
         let chainlock = ChainLock {
             block_height: 100,
-            block_hash: dashcore::BlockHash::all_zeros(),
-            signature: dashcore::bls_sig_utils::BLSSignature::from([0u8; 96]),
+            block_hash: BlockHash::all_zeros(),
+            signature: BLSSignature::from([0u8; 96]),
         };
         let bytes = serde_json::to_vec(&chainlock).unwrap();
         m.write().await.store_metadata(BEST_CHAINLOCK_KEY, &bytes).await.unwrap();
@@ -360,7 +362,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
 
-        let chain = BlockHeader::dummy_chain(10, dashcore::BlockHash::all_zeros());
+        let chain = BlockHeader::dummy_chain(10, BlockHash::all_zeros());
         bh.write().await.store_headers(&chain).await.unwrap();
         m.write().await.write_reorg_sentinel().await.unwrap();
         assert!(m.read().await.is_reorg_sentinel_set());

--- a/dash-spv/src/storage/consistency.rs
+++ b/dash-spv/src/storage/consistency.rs
@@ -90,7 +90,8 @@ pub(crate) async fn check_and_repair_consistency(
     // valid because we have no header to match it against. Clear it so the
     // chainlock manager starts from scratch instead of trusting a value the
     // header tip can no longer corroborate.
-    if let Some(bytes) = metadata.read().await.load_metadata(BEST_CHAINLOCK_KEY).await? {
+    let stored_chainlock = metadata.read().await.load_metadata(BEST_CHAINLOCK_KEY).await?;
+    if let Some(bytes) = stored_chainlock {
         match serde_json::from_slice::<ChainLock>(&bytes) {
             Ok(chainlock) if chainlock.block_height > block_tip => {
                 tracing::warn!(
@@ -212,4 +213,192 @@ async fn repair_blocks_above_tip(
         guard.persist(storage_path).await?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use dashcore::ephemerealdata::chain_lock::ChainLock;
+    use dashcore::hash_types::FilterHeader;
+    use dashcore::Header as BlockHeader;
+    use dashcore_hashes::Hash;
+    use tempfile::TempDir;
+    use tokio::sync::RwLock;
+
+    use crate::storage::{
+        BlockHeaderStorage, BlockStorage, FilterHeaderStorage, FilterStorage, MetadataStorage,
+        PersistentBlockHeaderStorage, PersistentBlockStorage, PersistentFilterHeaderStorage,
+        PersistentFilterStorage, PersistentMetadataStorage, PersistentStorage,
+    };
+    use crate::sync::BEST_CHAINLOCK_KEY;
+    use crate::types::HashedBlock;
+
+    use super::check_and_repair_consistency;
+
+    async fn open_all(
+        path: &std::path::Path,
+    ) -> (
+        std::path::PathBuf,
+        Arc<RwLock<PersistentBlockHeaderStorage>>,
+        Arc<RwLock<PersistentFilterHeaderStorage>>,
+        Arc<RwLock<PersistentFilterStorage>>,
+        Arc<RwLock<PersistentBlockStorage>>,
+        Arc<RwLock<PersistentMetadataStorage>>,
+    ) {
+        let storage_path = path.to_path_buf();
+        let bh = Arc::new(RwLock::new(
+            PersistentBlockHeaderStorage::open(&storage_path).await.unwrap(),
+        ));
+        let fh = Arc::new(RwLock::new(
+            PersistentFilterHeaderStorage::open(&storage_path).await.unwrap(),
+        ));
+        let f = Arc::new(RwLock::new(
+            PersistentFilterStorage::open(&storage_path).await.unwrap(),
+        ));
+        let b = Arc::new(RwLock::new(
+            PersistentBlockStorage::open(&storage_path).await.unwrap(),
+        ));
+        let m = Arc::new(RwLock::new(
+            PersistentMetadataStorage::open(&storage_path).await.unwrap(),
+        ));
+        (storage_path, bh, fh, f, b, m)
+    }
+
+    #[tokio::test]
+    async fn highest_valid_tip_returns_full_chain_when_intact() {
+        let tmp = TempDir::new().unwrap();
+        let chain = BlockHeader::dummy_chain(5, dashcore::BlockHash::all_zeros());
+        let storage = PersistentBlockHeaderStorage::open(tmp.path()).await.unwrap();
+        let mut storage = storage;
+        storage.store_headers(&chain).await.unwrap();
+        let tip = storage.highest_valid_tip().await;
+        assert_eq!(tip, Some(4));
+    }
+
+    #[tokio::test]
+    async fn highest_valid_tip_returns_lower_height_when_chain_broken() {
+        let tmp = TempDir::new().unwrap();
+        // `BlockHeader::dummy_batch(0..5)` produces headers whose
+        // `prev_blockhash` is `BlockHash::dummy(h-1)`, which does not equal
+        // the previous header's actual block_hash. So the index chain is
+        // broken everywhere except height 0, where `prev_blockhash` =
+        // `BlockHash::dummy(0)` which is stored in the index only when
+        // `block_hash() == dummy(0)`. Since that's also unlikely, the function
+        // bails to the start sentinel `Some(0)`.
+        let chain = BlockHeader::dummy_batch(0..5);
+        let mut storage = PersistentBlockHeaderStorage::open(tmp.path()).await.unwrap();
+        storage.store_headers(&chain).await.unwrap();
+        let tip = storage.highest_valid_tip().await;
+        assert_eq!(
+            tip,
+            Some(0),
+            "broken chain must fall back to the start height"
+        );
+    }
+
+    #[tokio::test]
+    async fn filter_header_above_block_tip_is_truncated() {
+        let tmp = TempDir::new().unwrap();
+        let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
+
+        let chain = BlockHeader::dummy_chain(5, dashcore::BlockHash::all_zeros());
+        bh.write().await.store_headers(&chain).await.unwrap();
+        fh.write()
+            .await
+            .store_filter_headers(&FilterHeader::dummy_batch(0..10))
+            .await
+            .unwrap();
+        assert_eq!(fh.read().await.get_filter_tip_height().await.unwrap(), Some(9));
+
+        check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
+
+        assert_eq!(fh.read().await.get_filter_tip_height().await.unwrap(), Some(4));
+    }
+
+    #[tokio::test]
+    async fn filter_above_filter_header_tip_is_truncated() {
+        let tmp = TempDir::new().unwrap();
+        let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
+
+        let chain = BlockHeader::dummy_chain(10, dashcore::BlockHash::all_zeros());
+        bh.write().await.store_headers(&chain).await.unwrap();
+        fh.write()
+            .await
+            .store_filter_headers(&FilterHeader::dummy_batch(0..5))
+            .await
+            .unwrap();
+        for h in 0..8 {
+            f.write().await.store_filter(h, &[0xAA; 4]).await.unwrap();
+        }
+        assert_eq!(f.read().await.filter_tip_height().await.unwrap(), 7);
+
+        check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
+
+        assert_eq!(f.read().await.filter_tip_height().await.unwrap(), 4);
+    }
+
+    #[tokio::test]
+    async fn block_above_block_tip_is_truncated() {
+        let tmp = TempDir::new().unwrap();
+        let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
+
+        // Header tip at 4, block storage holds a block at heights 3 and 10.
+        // Block 3 is within bounds, block 10 is stale and must be dropped.
+        let chain = BlockHeader::dummy_chain(5, dashcore::BlockHash::all_zeros());
+        bh.write().await.store_headers(&chain).await.unwrap();
+        b.write().await.store_block(3, HashedBlock::dummy(3, vec![])).await.unwrap();
+        b.write().await.store_block(10, HashedBlock::dummy(10, vec![])).await.unwrap();
+
+        check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
+
+        assert_eq!(b.read().await.load_block(10).await.unwrap(), None);
+        assert!(b.read().await.load_block(3).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn stale_chainlock_is_cleared() {
+        let tmp = TempDir::new().unwrap();
+        let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
+
+        let chain = BlockHeader::dummy_chain(5, dashcore::BlockHash::all_zeros());
+        bh.write().await.store_headers(&chain).await.unwrap();
+
+        let chainlock = ChainLock {
+            block_height: 100,
+            block_hash: dashcore::BlockHash::all_zeros(),
+            signature: dashcore::bls_sig_utils::BLSSignature::from([0u8; 96]),
+        };
+        let bytes = serde_json::to_vec(&chainlock).unwrap();
+        m.write()
+            .await
+            .store_metadata(BEST_CHAINLOCK_KEY, &bytes)
+            .await
+            .unwrap();
+
+        check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
+
+        let after = m.read().await.load_metadata(BEST_CHAINLOCK_KEY).await.unwrap();
+        assert!(after.is_none(), "stale chainlock must be cleared");
+    }
+
+    #[tokio::test]
+    async fn sentinel_triggers_safe_tip_truncation() {
+        let tmp = TempDir::new().unwrap();
+        let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
+
+        let chain = BlockHeader::dummy_chain(10, dashcore::BlockHash::all_zeros());
+        bh.write().await.store_headers(&chain).await.unwrap();
+        m.write().await.write_reorg_sentinel().await.unwrap();
+        assert!(m.read().await.is_reorg_sentinel_set());
+
+        check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
+
+        assert!(
+            !m.read().await.is_reorg_sentinel_set(),
+            "sentinel must be cleared after safe-tip recovery"
+        );
+        // Intact chain reopens at the same tip.
+        assert_eq!(bh.read().await.get_tip_height().await, Some(9));
+    }
 }

--- a/dash-spv/src/storage/consistency.rs
+++ b/dash-spv/src/storage/consistency.rs
@@ -458,6 +458,14 @@ mod tests {
             0,
             "orphaned filter storage must be cleared when filter headers are absent"
         );
+
+        // Reopen from disk to verify the clear was persisted and survives a restart.
+        let f2 = Arc::new(RwLock::new(PersistentFilterStorage::open(&path).await.unwrap()));
+        assert_eq!(
+            f2.read().await.filter_tip_height().await.unwrap(),
+            0,
+            "cleared filter storage must remain empty after reopen"
+        );
     }
 
     #[tokio::test]

--- a/dash-spv/src/storage/consistency.rs
+++ b/dash-spv/src/storage/consistency.rs
@@ -152,12 +152,7 @@ pub(crate) async fn check_and_repair_consistency(
     // partially-truncated filter-header range, so we truncate filter headers
     // and filters back to the block header tip.
     if let Some(start) = filter_headers.read().await.get_filter_start_height().await {
-        let tip = filter_headers
-            .read()
-            .await
-            .get_filter_tip_height()
-            .await?
-            .unwrap_or(start);
+        let tip = filter_headers.read().await.get_filter_tip_height().await?.unwrap_or(start);
         if tip >= start {
             let read = filter_headers.read().await.load_filter_headers(start..tip + 1).await;
             if let Err(err) = read {
@@ -247,21 +242,15 @@ mod tests {
         Arc<RwLock<PersistentMetadataStorage>>,
     ) {
         let storage_path = path.to_path_buf();
-        let bh = Arc::new(RwLock::new(
-            PersistentBlockHeaderStorage::open(&storage_path).await.unwrap(),
-        ));
+        let bh =
+            Arc::new(RwLock::new(PersistentBlockHeaderStorage::open(&storage_path).await.unwrap()));
         let fh = Arc::new(RwLock::new(
             PersistentFilterHeaderStorage::open(&storage_path).await.unwrap(),
         ));
-        let f = Arc::new(RwLock::new(
-            PersistentFilterStorage::open(&storage_path).await.unwrap(),
-        ));
-        let b = Arc::new(RwLock::new(
-            PersistentBlockStorage::open(&storage_path).await.unwrap(),
-        ));
-        let m = Arc::new(RwLock::new(
-            PersistentMetadataStorage::open(&storage_path).await.unwrap(),
-        ));
+        let f = Arc::new(RwLock::new(PersistentFilterStorage::open(&storage_path).await.unwrap()));
+        let b = Arc::new(RwLock::new(PersistentBlockStorage::open(&storage_path).await.unwrap()));
+        let m =
+            Arc::new(RwLock::new(PersistentMetadataStorage::open(&storage_path).await.unwrap()));
         (storage_path, bh, fh, f, b, m)
     }
 
@@ -290,11 +279,7 @@ mod tests {
         let mut storage = PersistentBlockHeaderStorage::open(tmp.path()).await.unwrap();
         storage.store_headers(&chain).await.unwrap();
         let tip = storage.highest_valid_tip().await;
-        assert_eq!(
-            tip,
-            Some(0),
-            "broken chain must fall back to the start height"
-        );
+        assert_eq!(tip, Some(0), "broken chain must fall back to the start height");
     }
 
     #[tokio::test]
@@ -304,11 +289,7 @@ mod tests {
 
         let chain = BlockHeader::dummy_chain(5, dashcore::BlockHash::all_zeros());
         bh.write().await.store_headers(&chain).await.unwrap();
-        fh.write()
-            .await
-            .store_filter_headers(&FilterHeader::dummy_batch(0..10))
-            .await
-            .unwrap();
+        fh.write().await.store_filter_headers(&FilterHeader::dummy_batch(0..10)).await.unwrap();
         assert_eq!(fh.read().await.get_filter_tip_height().await.unwrap(), Some(9));
 
         check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
@@ -323,11 +304,7 @@ mod tests {
 
         let chain = BlockHeader::dummy_chain(10, dashcore::BlockHash::all_zeros());
         bh.write().await.store_headers(&chain).await.unwrap();
-        fh.write()
-            .await
-            .store_filter_headers(&FilterHeader::dummy_batch(0..5))
-            .await
-            .unwrap();
+        fh.write().await.store_filter_headers(&FilterHeader::dummy_batch(0..5)).await.unwrap();
         for h in 0..8 {
             f.write().await.store_filter(h, &[0xAA; 4]).await.unwrap();
         }
@@ -370,11 +347,7 @@ mod tests {
             signature: dashcore::bls_sig_utils::BLSSignature::from([0u8; 96]),
         };
         let bytes = serde_json::to_vec(&chainlock).unwrap();
-        m.write()
-            .await
-            .store_metadata(BEST_CHAINLOCK_KEY, &bytes)
-            .await
-            .unwrap();
+        m.write().await.store_metadata(BEST_CHAINLOCK_KEY, &bytes).await.unwrap();
 
         check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
 

--- a/dash-spv/src/storage/consistency.rs
+++ b/dash-spv/src/storage/consistency.rs
@@ -14,7 +14,7 @@ use tokio::sync::RwLock;
 
 use crate::error::StorageResult;
 use crate::storage::{
-    BlockHeaderStorage, BlockStorage, FilterHeaderStorage, FilterStorage,
+    BlockHeaderStorage, BlockStorage, FilterHeaderStorage, FilterStorage, MetadataStorage,
     PersistentBlockHeaderStorage, PersistentBlockStorage, PersistentFilterHeaderStorage,
     PersistentFilterStorage, PersistentMetadataStorage, PersistentStorage,
 };
@@ -32,6 +32,49 @@ pub(crate) async fn check_and_repair_consistency(
     blocks: &Arc<RwLock<PersistentBlockStorage>>,
     metadata: &Arc<RwLock<PersistentMetadataStorage>>,
 ) -> StorageResult<()> {
+    // Sentinel branch: a previous run crashed mid-cascade between the
+    // generation bump and the final clear. Recover by recomputing the
+    // highest header whose parent chains correctly back through the
+    // hash index, then truncate every storage to that safe tip.
+    if metadata.read().await.is_reorg_sentinel_set() {
+        let safe_tip = block_headers.read().await.highest_valid_tip().await;
+        match safe_tip {
+            Some(safe_tip) => {
+                tracing::warn!(
+                    "consistency: reorg sentinel set, truncating all storages to safe tip {}",
+                    safe_tip
+                );
+                {
+                    let mut guard = block_headers.write().await;
+                    guard.truncate_above(safe_tip).await?;
+                    guard.persist(storage_path).await?;
+                }
+                {
+                    let mut guard = filter_headers.write().await;
+                    guard.truncate_above(safe_tip).await?;
+                    guard.persist(storage_path).await?;
+                }
+                {
+                    let mut guard = filters.write().await;
+                    guard.truncate_above(safe_tip).await?;
+                    guard.persist(storage_path).await?;
+                }
+                {
+                    let mut guard = blocks.write().await;
+                    guard.truncate_above(safe_tip).await?;
+                    guard.persist(storage_path).await?;
+                }
+                metadata.write().await.clear_reorg_sentinel().await?;
+            }
+            None => {
+                tracing::warn!(
+                    "consistency: reorg sentinel set but no headers available, clearing sentinel"
+                );
+                metadata.write().await.clear_reorg_sentinel().await?;
+            }
+        }
+    }
+
     let block_tip = block_headers.read().await.get_tip_height().await;
     let block_tip = match block_tip {
         Some(h) => h,
@@ -106,9 +149,6 @@ pub(crate) async fn check_and_repair_consistency(
             }
         }
     }
-
-    // Drop unused parameter warnings (metadata used by callers in a later commit).
-    let _ = metadata;
 
     Ok(())
 }

--- a/dash-spv/src/storage/consistency.rs
+++ b/dash-spv/src/storage/consistency.rs
@@ -143,7 +143,16 @@ pub(crate) async fn check_and_repair_consistency(
             guard.persist(storage_path).await?;
         }
     } else if f_tip > 0 {
-        tracing::warn!("consistency: filters exist (tip {}) but no filter headers present", f_tip);
+        // No filter headers exist but filter segments do. Clear the filter
+        // storage entirely to prevent the filter sync from treating orphaned
+        // segments as already-downloaded data for a potentially discarded chain.
+        tracing::warn!(
+            "consistency: filters exist (tip {}) but no filter headers present, clearing",
+            f_tip
+        );
+        let mut guard = filters.write().await;
+        guard.clear_all().await?;
+        guard.persist(storage_path).await?;
     }
 
     // Block storage invariant: `block_storage_tip <= block_header_tip`. We
@@ -430,7 +439,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn filters_without_filter_headers_are_not_truncated() {
+    async fn filters_without_filter_headers_are_cleared() {
         let tmp = TempDir::new().unwrap();
         let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
 
@@ -446,8 +455,8 @@ mod tests {
 
         assert_eq!(
             f.read().await.filter_tip_height().await.unwrap(),
-            2,
-            "filter storage must be left untouched when filter headers are absent"
+            0,
+            "orphaned filter storage must be cleared when filter headers are absent"
         );
     }
 

--- a/dash-spv/src/storage/consistency.rs
+++ b/dash-spv/src/storage/consistency.rs
@@ -430,6 +430,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn filters_without_filter_headers_are_not_truncated() {
+        let tmp = TempDir::new().unwrap();
+        let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
+
+        let chain = BlockHeader::dummy_chain(5, BlockHash::all_zeros());
+        bh.write().await.store_headers(&chain).await.unwrap();
+        for h in 0..3u32 {
+            f.write().await.store_filter(h, &[0xAA; 4]).await.unwrap();
+        }
+        assert_eq!(f.read().await.filter_tip_height().await.unwrap(), 2);
+        assert!(fh.read().await.get_filter_tip_height().await.unwrap().is_none());
+
+        check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
+
+        assert_eq!(
+            f.read().await.filter_tip_height().await.unwrap(),
+            2,
+            "filter storage must be left untouched when filter headers are absent"
+        );
+    }
+
+    #[tokio::test]
     async fn sentinel_triggers_safe_tip_truncation() {
         let tmp = TempDir::new().unwrap();
         let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
@@ -443,6 +465,15 @@ mod tests {
         for h in 0..12u32 {
             f.write().await.store_filter(h, &[0xBB; 4]).await.unwrap();
         }
+        // Store blocks: one within the safe range (anchors start_height) and one
+        // above the safe tip to verify block-storage truncation by the sentinel path.
+        let stale_height = 11u32;
+        b.write().await.store_block(0, HashedBlock::dummy(0, vec![])).await.unwrap();
+        b.write()
+            .await
+            .store_block(stale_height, HashedBlock::dummy(stale_height, vec![]))
+            .await
+            .unwrap();
         assert_eq!(fh.read().await.get_filter_tip_height().await.unwrap(), Some(14));
         assert_eq!(f.read().await.filter_tip_height().await.unwrap(), 11);
 
@@ -461,5 +492,10 @@ mod tests {
         // Downstream storages must be truncated to the safe tip.
         assert_eq!(fh.read().await.get_filter_tip_height().await.unwrap(), Some(safe_tip));
         assert_eq!(f.read().await.filter_tip_height().await.unwrap(), safe_tip);
+        assert_eq!(
+            b.read().await.load_block(stale_height).await.unwrap(),
+            None,
+            "stale block above safe tip must be removed during sentinel recovery"
+        );
     }
 }

--- a/dash-spv/src/storage/consistency.rs
+++ b/dash-spv/src/storage/consistency.rs
@@ -10,6 +10,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use dashcore::ephemerealdata::chain_lock::ChainLock;
 use tokio::sync::RwLock;
 
 use crate::error::StorageResult;
@@ -18,6 +19,7 @@ use crate::storage::{
     PersistentBlockHeaderStorage, PersistentBlockStorage, PersistentFilterHeaderStorage,
     PersistentFilterStorage, PersistentMetadataStorage, PersistentStorage,
 };
+use crate::sync::BEST_CHAINLOCK_KEY;
 
 /// Run the cross-storage consistency repair sweep.
 ///
@@ -83,6 +85,31 @@ pub(crate) async fn check_and_repair_consistency(
             return Ok(());
         }
     };
+
+    // Stale chainlock: a persisted chainlock above the header tip cannot be
+    // valid because we have no header to match it against. Clear it so the
+    // chainlock manager starts from scratch instead of trusting a value the
+    // header tip can no longer corroborate.
+    if let Some(bytes) = metadata.read().await.load_metadata(BEST_CHAINLOCK_KEY).await? {
+        match serde_json::from_slice::<ChainLock>(&bytes) {
+            Ok(chainlock) if chainlock.block_height > block_tip => {
+                tracing::warn!(
+                    "consistency: persisted chainlock at height {} above block tip {}, clearing",
+                    chainlock.block_height,
+                    block_tip
+                );
+                metadata.write().await.delete_metadata(BEST_CHAINLOCK_KEY).await?;
+            }
+            Ok(_) => {}
+            Err(err) => {
+                tracing::warn!(
+                    "consistency: persisted chainlock failed to deserialize ({}), clearing",
+                    err
+                );
+                metadata.write().await.delete_metadata(BEST_CHAINLOCK_KEY).await?;
+            }
+        }
+    }
 
     // Filter header invariant: `filter_header_tip <= block_header_tip`.
     let fh_tip = filter_headers.read().await.get_filter_tip_height().await?;

--- a/dash-spv/src/storage/consistency.rs
+++ b/dash-spv/src/storage/consistency.rs
@@ -19,6 +19,7 @@ use crate::storage::{
     PersistentBlockHeaderStorage, PersistentBlockStorage, PersistentFilterHeaderStorage,
     PersistentFilterStorage, PersistentMetadataStorage, PersistentStorage,
 };
+use crate::sync::reorg::MAX_REORG_DEPTH;
 use crate::sync::BEST_CHAINLOCK_KEY;
 
 /// Run the cross-storage consistency repair sweep.
@@ -38,8 +39,8 @@ pub(crate) async fn check_and_repair_consistency(
     // generation bump and the final clear. Recover by recomputing the
     // highest header whose parent chains correctly back through the
     // hash index, then truncate every storage to that safe tip.
-    if metadata.read().await.is_reorg_sentinel_set() {
-        let safe_tip = block_headers.read().await.highest_valid_tip().await;
+    if metadata.read().await.is_reorg_sentinel_set().await {
+        let safe_tip = block_headers.write().await.highest_valid_tip().await;
         match safe_tip {
             Some(safe_tip) => {
                 tracing::warn!(
@@ -130,16 +131,19 @@ pub(crate) async fn check_and_repair_consistency(
     // Filter invariant: `filter_tip <= filter_header_tip`.
     let fh_tip_after = filter_headers.read().await.get_filter_tip_height().await?;
     let f_tip = filters.read().await.filter_tip_height().await?;
-    let fh_bound = fh_tip_after.unwrap_or(0);
-    if f_tip > fh_bound {
-        tracing::warn!(
-            "consistency: filter tip {} > filter header tip {}, truncating",
-            f_tip,
-            fh_bound
-        );
-        let mut guard = filters.write().await;
-        guard.truncate_above(fh_bound).await?;
-        guard.persist(storage_path).await?;
+    if let Some(fh_bound) = fh_tip_after {
+        if f_tip > fh_bound {
+            tracing::warn!(
+                "consistency: filter tip {} > filter header tip {}, truncating",
+                f_tip,
+                fh_bound
+            );
+            let mut guard = filters.write().await;
+            guard.truncate_above(fh_bound).await?;
+            guard.persist(storage_path).await?;
+        }
+    } else if f_tip > 0 {
+        tracing::warn!("consistency: filters exist (tip {}) but no filter headers present", f_tip);
     }
 
     // Block storage invariant: `block_storage_tip <= block_header_tip`. We
@@ -185,6 +189,10 @@ async fn repair_blocks_above_tip(
     block_tip: u32,
 ) -> StorageResult<()> {
     const PROBE_WINDOW: u32 = 1_024;
+    const _: () = assert!(
+        PROBE_WINDOW > MAX_REORG_DEPTH,
+        "PROBE_WINDOW must exceed MAX_REORG_DEPTH to guarantee stale-block detection"
+    );
     let upper = block_tip.saturating_add(PROBE_WINDOW);
     let guard = blocks.read().await;
     let mut found_stale = false;
@@ -285,6 +293,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn highest_valid_tip_returns_last_good_height_when_only_top_broken() {
+        let tmp = TempDir::new().unwrap();
+        // Build a valid chain of 8 headers (heights 0-7), then append one
+        // disconnected header at height 8 using dummy_batch, which produces a
+        // header whose `prev_blockhash` does not match height 7's block_hash.
+        // The function must walk back to height 7 and return Some(7).
+        let connected = BlockHeader::dummy_chain(8, BlockHash::all_zeros());
+        let disconnected = BlockHeader::dummy_batch(8..9);
+        let mut storage = PersistentBlockHeaderStorage::open(tmp.path()).await.unwrap();
+        storage.store_headers(&connected).await.unwrap();
+        storage.store_headers_at_height(&disconnected, 8).await.unwrap();
+        assert_eq!(storage.get_tip_height().await, Some(8));
+        let tip = storage.highest_valid_tip().await;
+        assert_eq!(tip, Some(7), "only the top link is broken; must return the last good height");
+    }
+
+    #[tokio::test]
     async fn filter_header_above_block_tip_is_truncated() {
         let tmp = TempDir::new().unwrap();
         let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
@@ -336,6 +361,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn block_at_probe_window_boundary_is_truncated() {
+        let tmp = TempDir::new().unwrap();
+        let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
+
+        let chain = BlockHeader::dummy_chain(5, BlockHash::all_zeros());
+        bh.write().await.store_headers(&chain).await.unwrap();
+        // Store a block within range to anchor start_height, then one at the
+        // exact PROBE_WINDOW boundary so it is found and truncated.
+        let at_boundary = 4 + 1_024u32;
+        b.write().await.store_block(0, HashedBlock::dummy(0, vec![])).await.unwrap();
+        b.write()
+            .await
+            .store_block(at_boundary, HashedBlock::dummy(at_boundary, vec![]))
+            .await
+            .unwrap();
+
+        check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
+
+        assert_eq!(b.read().await.load_block(at_boundary).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn block_beyond_probe_window_is_not_detected() {
+        let tmp = TempDir::new().unwrap();
+        let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
+
+        let chain = BlockHeader::dummy_chain(5, BlockHash::all_zeros());
+        bh.write().await.store_headers(&chain).await.unwrap();
+        // Store a block within range to anchor start_height, then one beyond
+        // PROBE_WINDOW. The beyond-window block is a known limitation.
+        let beyond_window = 4 + 1_024u32 + 1;
+        b.write().await.store_block(0, HashedBlock::dummy(0, vec![])).await.unwrap();
+        b.write()
+            .await
+            .store_block(beyond_window, HashedBlock::dummy(beyond_window, vec![]))
+            .await
+            .unwrap();
+
+        check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
+
+        // Known limitation: blocks beyond PROBE_WINDOW are not detected.
+        // MAX_REORG_DEPTH (100) << PROBE_WINDOW (1024) so this cannot occur
+        // via normal reorg paths.
+        assert!(b.read().await.load_block(beyond_window).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
     async fn stale_chainlock_is_cleared() {
         let tmp = TempDir::new().unwrap();
         let (path, bh, fh, f, b, m) = open_all(tmp.path()).await;
@@ -364,16 +436,30 @@ mod tests {
 
         let chain = BlockHeader::dummy_chain(10, BlockHash::all_zeros());
         bh.write().await.store_headers(&chain).await.unwrap();
+
+        // Populate filter headers and filters above the block-header tip to
+        // exercise cascade truncation through all downstream storages.
+        fh.write().await.store_filter_headers(&FilterHeader::dummy_batch(0..15)).await.unwrap();
+        for h in 0..12u32 {
+            f.write().await.store_filter(h, &[0xBB; 4]).await.unwrap();
+        }
+        assert_eq!(fh.read().await.get_filter_tip_height().await.unwrap(), Some(14));
+        assert_eq!(f.read().await.filter_tip_height().await.unwrap(), 11);
+
         m.write().await.write_reorg_sentinel().await.unwrap();
-        assert!(m.read().await.is_reorg_sentinel_set());
+        assert!(m.read().await.is_reorg_sentinel_set().await);
 
         check_and_repair_consistency(&path, &bh, &fh, &f, &b, &m).await.unwrap();
 
         assert!(
-            !m.read().await.is_reorg_sentinel_set(),
+            !m.read().await.is_reorg_sentinel_set().await,
             "sentinel must be cleared after safe-tip recovery"
         );
         // Intact chain reopens at the same tip.
-        assert_eq!(bh.read().await.get_tip_height().await, Some(9));
+        let safe_tip = bh.read().await.get_tip_height().await.unwrap();
+        assert_eq!(safe_tip, 9);
+        // Downstream storages must be truncated to the safe tip.
+        assert_eq!(fh.read().await.get_filter_tip_height().await.unwrap(), Some(safe_tip));
+        assert_eq!(f.read().await.filter_tip_height().await.unwrap(), safe_tip);
     }
 }

--- a/dash-spv/src/storage/filters.rs
+++ b/dash-spv/src/storage/filters.rs
@@ -21,6 +21,10 @@ pub trait FilterStorage: Send + Sync + 'static {
 
     async fn filter_tip_height(&self) -> StorageResult<u32>;
 
+    /// Remove all stored filters and reset the storage to the empty state.
+    /// Changes are applied in-memory and flushed on the next `persist`.
+    async fn clear_all(&mut self) -> StorageResult<()>;
+
     /// Drop all filters with `height > target_height`.
     ///
     /// Truncating above the current tip is a no-op, truncating below
@@ -77,6 +81,11 @@ impl FilterStorage for PersistentFilterStorage {
 
     async fn filter_tip_height(&self) -> StorageResult<u32> {
         Ok(self.filters.read().await.tip_height().unwrap_or(0))
+    }
+
+    async fn clear_all(&mut self) -> StorageResult<()> {
+        self.filters.write().await.clear_all();
+        Ok(())
     }
 
     async fn truncate_above(&mut self, target_height: u32) -> StorageResult<()> {

--- a/dash-spv/src/storage/metadata.rs
+++ b/dash-spv/src/storage/metadata.rs
@@ -11,15 +11,35 @@ use dashcore::prelude::CoreBlockHeight;
 /// Metadata key for persisting the best known peer height.
 const LAST_TARGET_HEIGHT_KEY: &str = "last_target_height";
 
+/// Filename of the reorg-in-progress sentinel inside the metadata folder.
+pub(crate) const REORG_SENTINEL_FILE: &str = "reorg_in_progress.dat";
+
 #[async_trait]
 pub trait MetadataStorage: Send + Sync + 'static {
     async fn store_metadata(&mut self, key: &str, value: &[u8]) -> StorageResult<()>;
 
     async fn load_metadata(&self, key: &str) -> StorageResult<Option<Vec<u8>>>;
+
+    /// Remove a stored metadata entry. A no-op when the key has not been
+    /// persisted.
+    async fn delete_metadata(&mut self, key: &str) -> StorageResult<()>;
+
     /// Persist the last target height to metadata storage.
     async fn store_last_target_height(&mut self, height: CoreBlockHeight) -> StorageResult<()>;
     /// Load the last target height from metadata storage.
     async fn load_last_target_height(&self) -> StorageResult<CoreBlockHeight>;
+
+    /// Create the reorg-in-progress sentinel marker on disk. Written
+    /// immediately before the truncation cascade so a crash mid-cascade is
+    /// detectable on the next startup.
+    async fn write_reorg_sentinel(&mut self) -> StorageResult<()>;
+
+    /// Remove the reorg-in-progress sentinel marker. Called after the
+    /// cascade's last truncation completes successfully.
+    async fn clear_reorg_sentinel(&mut self) -> StorageResult<()>;
+
+    /// `true` when the reorg-in-progress sentinel marker is present on disk.
+    fn is_reorg_sentinel_set(&self) -> bool;
 }
 
 pub struct PersistentMetadataStorage {
@@ -27,7 +47,15 @@ pub struct PersistentMetadataStorage {
 }
 
 impl PersistentMetadataStorage {
-    const FOLDER_NAME: &str = "metadata";
+    pub(crate) const FOLDER_NAME: &str = "metadata";
+
+    fn metadata_folder(&self) -> PathBuf {
+        self.storage_path.join(Self::FOLDER_NAME)
+    }
+
+    fn reorg_sentinel_path(&self) -> PathBuf {
+        self.metadata_folder().join(REORG_SENTINEL_FILE)
+    }
 }
 
 #[async_trait]
@@ -47,7 +75,7 @@ impl PersistentStorage for PersistentMetadataStorage {
 #[async_trait]
 impl MetadataStorage for PersistentMetadataStorage {
     async fn store_metadata(&mut self, key: &str, value: &[u8]) -> StorageResult<()> {
-        let metadata_folder = self.storage_path.join(Self::FOLDER_NAME);
+        let metadata_folder = self.metadata_folder();
         let path = metadata_folder.join(format!("{key}.dat"));
 
         tokio::fs::create_dir_all(metadata_folder).await?;
@@ -58,7 +86,7 @@ impl MetadataStorage for PersistentMetadataStorage {
     }
 
     async fn load_metadata(&self, key: &str) -> StorageResult<Option<Vec<u8>>> {
-        let path = self.storage_path.join(Self::FOLDER_NAME).join(format!("{key}.dat"));
+        let path = self.metadata_folder().join(format!("{key}.dat"));
 
         if !path.exists() {
             return Ok(None);
@@ -66,6 +94,15 @@ impl MetadataStorage for PersistentMetadataStorage {
 
         let data = tokio::fs::read(path).await?;
         Ok(Some(data))
+    }
+
+    async fn delete_metadata(&mut self, key: &str) -> StorageResult<()> {
+        let path = self.metadata_folder().join(format!("{key}.dat"));
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(StorageError::Io(e)),
+        }
     }
 
     /// Persist the last target height to metadata storage.
@@ -106,5 +143,23 @@ impl MetadataStorage for PersistentMetadataStorage {
                 Err(StorageError::Corruption(error))
             }
         }
+    }
+
+    async fn write_reorg_sentinel(&mut self) -> StorageResult<()> {
+        tokio::fs::create_dir_all(self.metadata_folder()).await?;
+        atomic_write(&self.reorg_sentinel_path(), &[]).await
+    }
+
+    async fn clear_reorg_sentinel(&mut self) -> StorageResult<()> {
+        let path = self.reorg_sentinel_path();
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(StorageError::Io(e)),
+        }
+    }
+
+    fn is_reorg_sentinel_set(&self) -> bool {
+        self.reorg_sentinel_path().exists()
     }
 }

--- a/dash-spv/src/storage/metadata.rs
+++ b/dash-spv/src/storage/metadata.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::{
     error::StorageResult,
@@ -39,7 +39,7 @@ pub trait MetadataStorage: Send + Sync + 'static {
     async fn clear_reorg_sentinel(&mut self) -> StorageResult<()>;
 
     /// `true` when the reorg-in-progress sentinel marker is present on disk.
-    fn is_reorg_sentinel_set(&self) -> bool;
+    async fn is_reorg_sentinel_set(&self) -> bool;
 }
 
 pub struct PersistentMetadataStorage {
@@ -49,12 +49,16 @@ pub struct PersistentMetadataStorage {
 impl PersistentMetadataStorage {
     pub(crate) const FOLDER_NAME: &str = "metadata";
 
+    pub(crate) fn sentinel_path_for(storage_path: &Path) -> PathBuf {
+        storage_path.join(Self::FOLDER_NAME).join(REORG_SENTINEL_FILE)
+    }
+
     fn metadata_folder(&self) -> PathBuf {
         self.storage_path.join(Self::FOLDER_NAME)
     }
 
     fn reorg_sentinel_path(&self) -> PathBuf {
-        self.metadata_folder().join(REORG_SENTINEL_FILE)
+        Self::sentinel_path_for(&self.storage_path)
     }
 }
 
@@ -159,7 +163,7 @@ impl MetadataStorage for PersistentMetadataStorage {
         }
     }
 
-    fn is_reorg_sentinel_set(&self) -> bool {
-        self.reorg_sentinel_path().exists()
+    async fn is_reorg_sentinel_set(&self) -> bool {
+        tokio::fs::try_exists(self.reorg_sentinel_path()).await.unwrap_or(false)
     }
 }

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -34,8 +34,8 @@ pub use crate::storage::blocks::{BlockStorage, PersistentBlockStorage};
 pub use crate::storage::filter_headers::{FilterHeaderStorage, PersistentFilterHeaderStorage};
 pub use crate::storage::filters::{FilterStorage, PersistentFilterStorage};
 pub use crate::storage::masternode::{MasternodeStateStorage, PersistentMasternodeStateStorage};
-pub use crate::storage::metadata::{MetadataStorage, PersistentMetadataStorage};
 use crate::storage::metadata::REORG_SENTINEL_FILE;
+pub use crate::storage::metadata::{MetadataStorage, PersistentMetadataStorage};
 pub use crate::storage::peers::{PeerStorage, PersistentPeerStorage};
 
 pub use types::*;

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -34,6 +34,7 @@ pub use crate::storage::filter_headers::{FilterHeaderStorage, PersistentFilterHe
 pub use crate::storage::filters::{FilterStorage, PersistentFilterStorage};
 pub use crate::storage::masternode::{MasternodeStateStorage, PersistentMasternodeStateStorage};
 pub use crate::storage::metadata::{MetadataStorage, PersistentMetadataStorage};
+use crate::storage::metadata::REORG_SENTINEL_FILE;
 pub use crate::storage::peers::{PeerStorage, PersistentPeerStorage};
 
 pub use types::*;
@@ -400,12 +401,31 @@ impl metadata::MetadataStorage for DiskStorageManager {
         self.metadata.read().await.load_metadata(key).await
     }
 
+    async fn delete_metadata(&mut self, key: &str) -> StorageResult<()> {
+        self.metadata.write().await.delete_metadata(key).await
+    }
+
     async fn store_last_target_height(&mut self, height: CoreBlockHeight) -> StorageResult<()> {
         self.metadata.write().await.store_last_target_height(height).await
     }
 
     async fn load_last_target_height(&self) -> StorageResult<CoreBlockHeight> {
         self.metadata.read().await.load_last_target_height().await
+    }
+
+    async fn write_reorg_sentinel(&mut self) -> StorageResult<()> {
+        self.metadata.write().await.write_reorg_sentinel().await
+    }
+
+    async fn clear_reorg_sentinel(&mut self) -> StorageResult<()> {
+        self.metadata.write().await.clear_reorg_sentinel().await
+    }
+
+    fn is_reorg_sentinel_set(&self) -> bool {
+        self.storage_path
+            .join(PersistentMetadataStorage::FOLDER_NAME)
+            .join(REORG_SENTINEL_FILE)
+            .exists()
     }
 }
 

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -383,6 +383,10 @@ impl filters::FilterStorage for DiskStorageManager {
         self.filters.read().await.filter_tip_height().await
     }
 
+    async fn clear_all(&mut self) -> StorageResult<()> {
+        self.filters.write().await.clear_all().await
+    }
+
     async fn truncate_above(&mut self, target_height: u32) -> StorageResult<()> {
         self.filters.write().await.truncate_above(target_height).await
     }

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -138,6 +138,8 @@ impl DiskStorageManager {
             _lock_file: lock_file,
         };
 
+        // Runs before `start_worker` so the first persist tick cannot
+        // race the sentinel-driven recovery and pin a stale tip to disk.
         consistency::check_and_repair_consistency(
             &storage.storage_path,
             &storage.block_headers,

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -34,7 +34,6 @@ pub use crate::storage::blocks::{BlockStorage, PersistentBlockStorage};
 pub use crate::storage::filter_headers::{FilterHeaderStorage, PersistentFilterHeaderStorage};
 pub use crate::storage::filters::{FilterStorage, PersistentFilterStorage};
 pub use crate::storage::masternode::{MasternodeStateStorage, PersistentMasternodeStateStorage};
-use crate::storage::metadata::REORG_SENTINEL_FILE;
 pub use crate::storage::metadata::{MetadataStorage, PersistentMetadataStorage};
 pub use crate::storage::peers::{PeerStorage, PersistentPeerStorage};
 
@@ -434,11 +433,10 @@ impl metadata::MetadataStorage for DiskStorageManager {
         self.metadata.write().await.clear_reorg_sentinel().await
     }
 
-    fn is_reorg_sentinel_set(&self) -> bool {
-        self.storage_path
-            .join(PersistentMetadataStorage::FOLDER_NAME)
-            .join(REORG_SENTINEL_FILE)
-            .exists()
+    async fn is_reorg_sentinel_set(&self) -> bool {
+        tokio::fs::try_exists(PersistentMetadataStorage::sentinel_path_for(&self.storage_path))
+            .await
+            .unwrap_or(false)
     }
 }
 

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -4,6 +4,7 @@ pub mod types;
 
 mod block_headers;
 mod blocks;
+mod consistency;
 mod filter_headers;
 mod filters;
 mod io;
@@ -136,6 +137,16 @@ impl DiskStorageManager {
 
             _lock_file: lock_file,
         };
+
+        consistency::check_and_repair_consistency(
+            &storage.storage_path,
+            &storage.block_headers,
+            &storage.filter_headers,
+            &storage.filters,
+            &storage.blocks,
+            &storage.metadata,
+        )
+        .await?;
 
         storage.start_worker().await;
 

--- a/dash-spv/src/storage/segments.rs
+++ b/dash-spv/src/storage/segments.rs
@@ -134,6 +134,7 @@ impl<I: Persistable> SegmentCache<I> {
                                 id,
                                 e
                             );
+                            cache.to_delete.insert(*id);
                         }
                     }
                 }
@@ -1134,7 +1135,7 @@ mod tests {
         // `StorageError::ReadFailed`.
         tokio::fs::write(&corrupt_path, [0xFDu8, 0x01, 0x00]).await.unwrap();
 
-        let reloaded = SegmentCache::<Vec<u8>>::load_or_new(tmp_dir.path()).await.unwrap();
+        let mut reloaded = SegmentCache::<Vec<u8>>::load_or_new(tmp_dir.path()).await.unwrap();
 
         assert_eq!(
             reloaded.tip_height(),
@@ -1142,6 +1143,14 @@ mod tests {
             "tip should fall back to the last readable segment"
         );
         assert_eq!(reloaded.start_height(), Some(0));
+
+        // The corrupt segment must be queued for deletion and removed on
+        // persist so subsequent startups do not emit the warning again.
+        reloaded.persist(tmp_dir.path()).await;
+        assert!(!corrupt_path.exists(), "corrupt segment file must be deleted on persist");
+
+        let reloaded2 = SegmentCache::<Vec<u8>>::load_or_new(tmp_dir.path()).await.unwrap();
+        assert_eq!(reloaded2.tip_height(), Some(9));
     }
 
     #[test]

--- a/dash-spv/src/storage/segments.rs
+++ b/dash-spv/src/storage/segments.rs
@@ -497,11 +497,22 @@ impl<I: Persistable> SegmentCache<I> {
 
     /// Queue all segments for deletion and reset the cache to the empty state.
     pub fn clear_all(&mut self) {
-        let all_ids: Vec<u32> = self.segments.keys().chain(self.evicted.keys()).copied().collect();
-        for id in all_ids {
-            self.segments.remove(&id);
-            self.evicted.remove(&id);
-            self.to_delete.insert(id);
+        if let (Some(start), Some(tip)) = (self.start_height, self.tip_height) {
+            let start_seg = Self::height_to_segment_id(start);
+            let end_seg = Self::height_to_segment_id(tip);
+            for id in start_seg..=end_seg {
+                self.segments.remove(&id);
+                self.evicted.remove(&id);
+                self.to_delete.insert(id);
+            }
+        } else {
+            let all_ids: Vec<u32> =
+                self.segments.keys().chain(self.evicted.keys()).copied().collect();
+            for id in all_ids {
+                self.segments.remove(&id);
+                self.evicted.remove(&id);
+                self.to_delete.insert(id);
+            }
         }
         self.tip_height = None;
         self.start_height = None;
@@ -1113,6 +1124,39 @@ mod tests {
             reloaded.get_items(ITEMS_PER_SEGMENT + 6..ITEMS_PER_SEGMENT + 16).await.unwrap(),
             replacement
         );
+    }
+
+    #[tokio::test]
+    async fn test_clear_all_deletes_all_segment_files_across_multiple_segments() {
+        let tmp_dir = TempDir::new().unwrap();
+
+        const ITEMS_PER_SEGMENT: u32 = Segment::<FilterHeader>::ITEMS_PER_SEGMENT;
+        let items = FilterHeader::dummy_batch(0..ITEMS_PER_SEGMENT * 2 + 5);
+
+        let mut cache = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
+        cache.store_items_at_height(&items, 0).await.unwrap();
+        cache.persist(tmp_dir.path()).await;
+
+        // Verify all three segment files exist on disk before clearing.
+        assert!(tmp_dir.path().join(FilterHeader::segment_file_name(0)).exists());
+        assert!(tmp_dir.path().join(FilterHeader::segment_file_name(1)).exists());
+        assert!(tmp_dir.path().join(FilterHeader::segment_file_name(2)).exists());
+
+        // Reload so segments 1 is evicted and only boundary segments (0 and 2)
+        // are in memory, leaving segment 1 as on-disk-only.
+        let mut cache = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
+        assert_eq!(cache.tip_height(), Some(ITEMS_PER_SEGMENT * 2 + 4));
+
+        cache.clear_all();
+        cache.persist(tmp_dir.path()).await;
+
+        assert!(!tmp_dir.path().join(FilterHeader::segment_file_name(0)).exists());
+        assert!(!tmp_dir.path().join(FilterHeader::segment_file_name(1)).exists());
+        assert!(!tmp_dir.path().join(FilterHeader::segment_file_name(2)).exists());
+
+        let reloaded = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
+        assert_eq!(reloaded.tip_height(), None, "cache must be empty after clear_all + persist + reload");
+        assert_eq!(reloaded.start_height(), None);
     }
 
     /// A corrupted highest segment is logged and dropped; the cache reopens

--- a/dash-spv/src/storage/segments.rs
+++ b/dash-spv/src/storage/segments.rs
@@ -495,6 +495,18 @@ impl<I: Persistable> SegmentCache<I> {
         self.start_height
     }
 
+    /// Queue all segments for deletion and reset the cache to the empty state.
+    pub fn clear_all(&mut self) {
+        let all_ids: Vec<u32> = self.segments.keys().chain(self.evicted.keys()).copied().collect();
+        for id in all_ids {
+            self.segments.remove(&id);
+            self.evicted.remove(&id);
+            self.to_delete.insert(id);
+        }
+        self.tip_height = None;
+        self.start_height = None;
+    }
+
     #[inline]
     pub fn next_height(&self) -> u32 {
         match self.tip_height() {

--- a/dash-spv/src/storage/segments.rs
+++ b/dash-spv/src/storage/segments.rs
@@ -1155,7 +1155,11 @@ mod tests {
         assert!(!tmp_dir.path().join(FilterHeader::segment_file_name(2)).exists());
 
         let reloaded = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
-        assert_eq!(reloaded.tip_height(), None, "cache must be empty after clear_all + persist + reload");
+        assert_eq!(
+            reloaded.tip_height(),
+            None,
+            "cache must be empty after clear_all + persist + reload"
+        );
         assert_eq!(reloaded.start_height(), None);
     }
 

--- a/dash-spv/src/storage/segments.rs
+++ b/dash-spv/src/storage/segments.rs
@@ -102,8 +102,7 @@ impl<I: Persistable> SegmentCache<I> {
 
         // Building the metadata
         if let Ok(entries) = fs::read_dir(&segments_dir) {
-            let mut max_seg_id = None;
-            let mut min_seg_id = None;
+            let mut segment_ids: Vec<u32> = Vec::new();
 
             for entry in entries.flatten() {
                 if let Some(name) = entry.file_name().to_str() {
@@ -114,24 +113,58 @@ impl<I: Persistable> SegmentCache<I> {
                         let segment_id_end = segment_id_start + 4;
 
                         if let Ok(id) = name[segment_id_start..segment_id_end].parse::<u32>() {
-                            max_seg_id = Some(max_seg_id.map_or(id, |max: u32| max.max(id)));
-                            min_seg_id = Some(min_seg_id.map_or(id, |min: u32| min.min(id)));
+                            segment_ids.push(id);
                         }
                     }
                 }
             }
+            segment_ids.sort_unstable();
 
-            if let Some(segment_id) = max_seg_id {
+            let max_readable_id = {
+                let mut result = None;
+                for id in segment_ids.iter().rev() {
+                    match cache.get_segment(id).await {
+                        Ok(_) => {
+                            result = Some(*id);
+                            break;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "SegmentCache: dropping unreadable segment {} ({}), truncating cache to last readable segment",
+                                id,
+                                e
+                            );
+                        }
+                    }
+                }
+                result
+            };
+
+            if let Some(segment_id) = max_readable_id {
                 let segment = cache.get_segment(&segment_id).await?;
-
                 cache.tip_height = segment
                     .last_valid_offset()
                     .map(|offset| Self::segment_id_to_start_height(segment_id) + offset);
             }
 
-            if let Some(segment_id) = min_seg_id {
-                let segment = cache.get_segment(&segment_id).await?;
+            // Walk forward from the lowest id to find the first readable
+            // segment for start_height. Unreadable lower segments are skipped
+            // to mirror the truncation behaviour above.
+            let mut min_readable_id = None;
+            for id in segment_ids.iter() {
+                if let Some(max) = max_readable_id {
+                    if *id > max {
+                        break;
+                    }
+                }
+                if cache.get_segment(id).await.is_ok() {
+                    min_readable_id = Some(*id);
+                    break;
+                }
+            }
 
+            if let Some(segment_id) = min_readable_id {
+                let segment = cache.get_segment(&segment_id).await?;
                 cache.start_height = segment
                     .first_valid_offset()
                     .map(|offset| Self::segment_id_to_start_height(segment_id) + offset);
@@ -1067,6 +1100,48 @@ mod tests {
             reloaded.get_items(ITEMS_PER_SEGMENT + 6..ITEMS_PER_SEGMENT + 16).await.unwrap(),
             replacement
         );
+    }
+
+    /// A corrupted highest segment is logged and dropped; the cache reopens
+    /// with the tip pointing at the last readable segment. The corruption
+    /// uses a non-minimal `VarInt` prefix (`0xFD 0x01 0x00`) which makes
+    /// `consensus_decode` return `Error::NonMinimalVarInt` instead of the
+    /// EOF break case `Segment::load` would tolerate.
+    #[tokio::test]
+    async fn test_load_or_new_truncates_on_corrupt_segment() {
+        let tmp_dir = TempDir::new().unwrap();
+
+        let mut cache = SegmentCache::<Vec<u8>>::load_or_new(tmp_dir.path()).await.unwrap();
+        for height in 0..10u32 {
+            cache.store_items_at_height(&[vec![height as u8; 4]], height).await.unwrap();
+        }
+        cache.persist(tmp_dir.path()).await;
+
+        // Force segment 1's existence by storing an item in it, then persist
+        // to materialise the file before corrupting.
+        cache
+            .store_items_at_height(&[vec![0xAA; 4]], Segment::<Vec<u8>>::ITEMS_PER_SEGMENT)
+            .await
+            .unwrap();
+        cache.persist(tmp_dir.path()).await;
+
+        let corrupt_path = tmp_dir.path().join(Vec::<u8>::segment_file_name(1));
+        assert!(corrupt_path.exists());
+
+        // Non-minimal VarInt: 0xFD prefix demands a u16 >= 0xFD; supplying
+        // 0x0001 violates that and `VarInt::consensus_decode` returns
+        // `Error::NonMinimalVarInt`, which `Segment::load` propagates as a
+        // `StorageError::ReadFailed`.
+        tokio::fs::write(&corrupt_path, [0xFDu8, 0x01, 0x00]).await.unwrap();
+
+        let reloaded = SegmentCache::<Vec<u8>>::load_or_new(tmp_dir.path()).await.unwrap();
+
+        assert_eq!(
+            reloaded.tip_height(),
+            Some(9),
+            "tip should fall back to the last readable segment"
+        );
+        assert_eq!(reloaded.start_height(), Some(0));
     }
 
     #[test]

--- a/dash-spv/src/sync/block_headers/fork_buffer.rs
+++ b/dash-spv/src/sync/block_headers/fork_buffer.rs
@@ -343,6 +343,8 @@ fn median_time_past(history: &[Header]) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::slice;
+
     use super::*;
     use dashcore::block::Version;
     use dashcore::{BlockHash, CompactTarget, Header, Network, TxMerkleNode};
@@ -768,7 +770,7 @@ mod tests {
         let mut current_tip = fork[0].block_hash();
         for next in &fork[1..] {
             let update = buf
-                .extend_branch(peer, current_tip, std::slice::from_ref(next), &active)
+                .extend_branch(peer, current_tip, slice::from_ref(next), &active)
                 .expect("continuation must validate");
             assert_eq!(update.new_tip, next.block_hash());
             current_tip = update.new_tip;

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -688,6 +688,7 @@ mod tests {
     use crate::sync::{ManagerIdentifier, SyncManager, SyncManagerProgress};
     use dashcore::block::Version;
     use dashcore::bls_sig_utils::BLSSignature;
+    use dashcore::ephemerealdata::chain_lock::ChainLock;
     use dashcore::network::message::NetworkMessage;
     use dashcore::{CompactTarget, TxMerkleNode};
     use dashcore_hashes::Hash;
@@ -1649,9 +1650,6 @@ mod tests {
     /// the generation, and storage reflects the chainlocked branch.
     #[tokio::test]
     async fn chainlock_forced_reorg_drives_cascade_for_lighter_branch() {
-        use dashcore::bls_sig_utils::BLSSignature;
-        use dashcore::ephemerealdata::chain_lock::ChainLock;
-
         let easy_bits = CompactTarget::from_consensus(0x207fffff);
         let (mut manager, chain) = create_regtest_manager_with_chain(8).await;
         let tip = manager.tip().await.unwrap();

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -203,11 +203,12 @@ impl<
         let current_tip = self.tip().await?;
         let current_tip_height = current_tip.height();
         let current_tip_hash = *current_tip.hash();
-        let storages: ReorgStorages<'_, H, FH, F, B> = ReorgStorages {
+        let storages: ReorgStorages<'_, H, FH, F, B, M> = ReorgStorages {
             block_header_storage: &self.header_storage,
             filter_header_storage: self.filter_header_storage.as_ref(),
             filter_storage: self.filter_storage.as_ref(),
             block_storage: self.block_storage.as_ref(),
+            metadata_storage: &self.metadata_storage,
         };
         handle_reorg(
             candidate,

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -23,7 +23,7 @@ use crate::storage::{BlockHeaderStorage, MetadataStorage};
 use crate::sync::{ChainLockProgress, SyncEvent};
 
 /// Metadata key for persisting the best validated ChainLock.
-const BEST_CHAINLOCK_KEY: &str = "best_chainlock";
+pub(crate) const BEST_CHAINLOCK_KEY: &str = "best_chainlock";
 
 /// How long a CLSig waiting on an unresolved header is kept before eviction.
 pub(super) const PENDING_UNKNOWN_HASH_TTL: Duration = Duration::from_secs(5 * 60);

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -516,7 +516,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> std::fmt::Debug for ChainLockMan
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::network::{MessageType, RequestSender};
+    use crate::network::{MessageType, NetworkRequest, RequestSender};
     use crate::storage::{
         DiskStorageManager, PersistentBlockHeaderStorage, PersistentMetadataStorage, StorageManager,
     };
@@ -1039,7 +1039,7 @@ mod tests {
         );
         assert!(manager.masternode_ready);
         // The empty engine cannot validate the signature, so the chainlock is
-        // counted as invalid and best_chainlock stays None — events is empty.
+        // counted as invalid and best_chainlock stays None. Events is empty.
         // The invariant is that pending_validation was consumed (not silently
         // dropped), which is covered by the is_none() assertion above.
         assert!(events.is_empty());
@@ -1367,7 +1367,7 @@ mod tests {
         );
         let req = rx.try_recv().expect("misbehavior report must be queued");
         match req {
-            crate::network::NetworkRequest::ReportMisbehavior(reported_peer, kind) => {
+            NetworkRequest::ReportMisbehavior(reported_peer, kind) => {
                 assert_eq!(reported_peer, peer);
                 assert_eq!(kind, MisbehaviorKind::InvalidChainLockSignature);
             }

--- a/dash-spv/src/sync/chainlock/mod.rs
+++ b/dash-spv/src/sync/chainlock/mod.rs
@@ -3,4 +3,5 @@ mod progress;
 mod sync_manager;
 
 pub use manager::ChainLockManager;
+pub(crate) use manager::BEST_CHAINLOCK_KEY;
 pub use progress::ChainLockProgress;

--- a/dash-spv/src/sync/mod.rs
+++ b/dash-spv/src/sync/mod.rs
@@ -18,6 +18,7 @@ mod sync_manager;
 
 pub use block_headers::{BlockHeadersManager, BlockHeadersProgress};
 pub use blocks::{BlocksManager, BlocksProgress};
+pub(crate) use chainlock::BEST_CHAINLOCK_KEY;
 pub use chainlock::{ChainLockManager, ChainLockProgress};
 pub use filter_headers::{FilterHeadersManager, FilterHeadersProgress};
 pub use filters::{FiltersManager, FiltersProgress};

--- a/dash-spv/src/sync/reorg.rs
+++ b/dash-spv/src/sync/reorg.rs
@@ -773,7 +773,7 @@ mod tests {
             state.lock().await.deny_list.contains_key(&candidate_tip),
             "rejected candidate must land on deny-list"
         );
-        assert_eq!(generation.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(generation.load(Ordering::SeqCst), 0);
 
         // force=true: chainlock floor is bypassed, cascade runs, ChainReorg is emitted.
         let state2 = Mutex::new(ReorgState::default());
@@ -817,11 +817,7 @@ mod tests {
             }
             other => panic!("expected ChainReorg, got {:?}", other),
         }
-        assert_eq!(
-            generation2.load(std::sync::atomic::Ordering::SeqCst),
-            1,
-            "forced cascade must bump generation"
-        );
+        assert_eq!(generation2.load(Ordering::SeqCst), 1, "forced cascade must bump generation");
         assert!(
             !state2.lock().await.deny_list.contains_key(&candidate_tip),
             "forced reorg must not land on the deny-list"

--- a/dash-spv/src/sync/reorg.rs
+++ b/dash-spv/src/sync/reorg.rs
@@ -261,7 +261,12 @@ where
         bs.write().await.truncate_above(candidate.ancestor_height).await?;
     }
 
-    metadata_storage.write().await.clear_reorg_sentinel().await?;
+    if let Err(e) = metadata_storage.write().await.clear_reorg_sentinel().await {
+        tracing::error!(
+            "reorg cascade succeeded but sentinel clear failed ({}); next startup will re-run recovery",
+            e
+        );
+    }
 
     tracing::info!(
         "reorg cascade complete: fork_height={} new_tip={} generation={}",
@@ -838,7 +843,7 @@ mod tests {
         let blocks = storage.blocks();
         let metadata = storage.metadata();
 
-        assert!(!metadata.read().await.is_reorg_sentinel_set());
+        assert!(!metadata.read().await.is_reorg_sentinel_set().await);
 
         let candidate = fork_candidate_from(5, chain[5].block_hash(), 3, 1_700_010_000);
         let state = Mutex::new(ReorgState::default());
@@ -874,7 +879,7 @@ mod tests {
         .expect("ChainReorg event");
 
         assert!(
-            !metadata.read().await.is_reorg_sentinel_set(),
+            !metadata.read().await.is_reorg_sentinel_set().await,
             "sentinel must be cleared after a successful cascade"
         );
     }

--- a/dash-spv/src/sync/reorg.rs
+++ b/dash-spv/src/sync/reorg.rs
@@ -16,7 +16,9 @@ use tokio::sync::{Mutex, RwLock};
 
 use crate::chain::{CheckpointManager, ForkCandidate};
 use crate::error::SyncResult;
-use crate::storage::{BlockHeaderStorage, BlockStorage, FilterHeaderStorage, FilterStorage};
+use crate::storage::{
+    BlockHeaderStorage, BlockStorage, FilterHeaderStorage, FilterStorage, MetadataStorage,
+};
 use crate::sync::SyncEvent;
 
 /// Maximum reorg depth (active_tip_height - fork_ancestor_height) the
@@ -60,20 +62,23 @@ impl ReorgState {
     }
 }
 
-/// Storage handles passed into [`handle_reorg`]. All four storages are
+/// Storage handles passed into [`handle_reorg`]. All four data storages are
 /// truncated in lockstep so downstream caches don't outlive the truncated
-/// header chain.
-pub(crate) struct ReorgStorages<'a, H, FH, F, B>
+/// header chain. `metadata_storage` carries the reorg-in-progress sentinel,
+/// written before the cascade commits and cleared once truncation succeeds.
+pub(crate) struct ReorgStorages<'a, H, FH, F, B, M>
 where
     H: BlockHeaderStorage,
     FH: FilterHeaderStorage,
     F: FilterStorage,
     B: BlockStorage,
+    M: MetadataStorage,
 {
     pub(crate) block_header_storage: &'a Arc<RwLock<H>>,
     pub(crate) filter_header_storage: Option<&'a Arc<RwLock<FH>>>,
     pub(crate) filter_storage: Option<&'a Arc<RwLock<F>>>,
     pub(crate) block_storage: Option<&'a Arc<RwLock<B>>>,
+    pub(crate) metadata_storage: &'a Arc<RwLock<M>>,
 }
 
 /// Drive the reorg cascade for a buffered fork candidate.
@@ -88,11 +93,11 @@ where
 /// valid `ChainLockForcedReorg` overrides both). Checkpoint floor,
 /// single-flight, and deny-list guards still apply.
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn handle_reorg<H, FH, F, B>(
+pub(crate) async fn handle_reorg<H, FH, F, B, M>(
     candidate: ForkCandidate,
     state: &Mutex<ReorgState>,
     generation: &AtomicU64,
-    storages: ReorgStorages<'_, H, FH, F, B>,
+    storages: ReorgStorages<'_, H, FH, F, B, M>,
     checkpoint_manager: &CheckpointManager,
     best_chainlock_height: Option<u32>,
     current_tip_height: u32,
@@ -104,6 +109,7 @@ where
     FH: FilterHeaderStorage,
     F: FilterStorage,
     B: BlockStorage,
+    M: MetadataStorage,
 {
     let candidate_tip_hash = candidate.tip_hash();
 
@@ -145,12 +151,12 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn run_guards_and_cascade<H, FH, F, B>(
+async fn run_guards_and_cascade<H, FH, F, B, M>(
     candidate: &ForkCandidate,
     candidate_tip_hash: BlockHash,
     state: &Mutex<ReorgState>,
     generation: &AtomicU64,
-    storages: ReorgStorages<'_, H, FH, F, B>,
+    storages: ReorgStorages<'_, H, FH, F, B, M>,
     checkpoint_manager: &CheckpointManager,
     best_chainlock_height: Option<u32>,
     current_tip_height: u32,
@@ -162,6 +168,7 @@ where
     FH: FilterHeaderStorage,
     F: FilterStorage,
     B: BlockStorage,
+    M: MetadataStorage,
 {
     // Checkpoint floor.
     if checkpoint_manager.should_reject_fork(candidate.ancestor_height) {
@@ -221,16 +228,22 @@ where
         }
     }
 
-    // Cascade. Bump the generation first so any response that races with the
-    // truncation is tagged stale and dropped at the downstream manager.
-    let new_generation = generation.fetch_add(1, Ordering::AcqRel) + 1;
-
     let ReorgStorages {
         block_header_storage,
         filter_header_storage,
         filter_storage,
         block_storage,
+        metadata_storage,
     } = storages;
+
+    // Mark the reorg in progress before any storage mutation. A crash between
+    // this write and the matching clear below leaves the sentinel on disk so
+    // the next startup can recompute a safe tip from `header_hash_index`.
+    metadata_storage.write().await.write_reorg_sentinel().await?;
+
+    // Cascade. Bump the generation first so any response that races with the
+    // truncation is tagged stale and dropped at the downstream manager.
+    let new_generation = generation.fetch_add(1, Ordering::AcqRel) + 1;
 
     {
         let mut headers = block_header_storage.write().await;
@@ -247,6 +260,8 @@ where
     if let Some(bs) = block_storage {
         bs.write().await.truncate_above(candidate.ancestor_height).await?;
     }
+
+    metadata_storage.write().await.clear_reorg_sentinel().await?;
 
     tracing::info!(
         "reorg cascade complete: fork_height={} new_tip={} generation={}",
@@ -269,8 +284,9 @@ mod tests {
     use crate::chain::checkpoints::Checkpoint;
     use crate::chain::ChainWork;
     use crate::storage::{
-        DiskStorageManager, PersistentBlockHeaderStorage, PersistentBlockStorage,
-        PersistentFilterHeaderStorage, PersistentFilterStorage, StorageManager,
+        DiskStorageManager, MetadataStorage, PersistentBlockHeaderStorage, PersistentBlockStorage,
+        PersistentFilterHeaderStorage, PersistentFilterStorage, PersistentMetadataStorage,
+        StorageManager,
     };
     use crate::types::HashedBlockHeader;
     use dashcore::block::{Header, Version};
@@ -341,6 +357,7 @@ mod tests {
         let filter_headers = storage.filter_headers();
         let filters = storage.filters();
         let blocks = storage.blocks();
+        let metadata = storage.metadata();
 
         let candidate = fork_candidate_from(5, chain[5].block_hash(), 3, 1_700_010_000);
 
@@ -353,11 +370,13 @@ mod tests {
             PersistentFilterHeaderStorage,
             PersistentFilterStorage,
             PersistentBlockStorage,
+            PersistentMetadataStorage,
         > = ReorgStorages {
             block_header_storage: &block_headers,
             filter_header_storage: Some(&filter_headers),
             filter_storage: Some(&filters),
             block_storage: Some(&blocks),
+            metadata_storage: &metadata,
         };
 
         let old_tip_hash = chain.last().unwrap().block_hash();
@@ -409,6 +428,7 @@ mod tests {
         let filter_headers = storage.filter_headers();
         let filters = storage.filters();
         let blocks = storage.blocks();
+        let metadata = storage.metadata();
 
         let candidate = fork_candidate_from(2, chain[2].block_hash(), 2, 1_700_010_000);
 
@@ -424,11 +444,13 @@ mod tests {
             PersistentFilterHeaderStorage,
             PersistentFilterStorage,
             PersistentBlockStorage,
+            PersistentMetadataStorage,
         > = ReorgStorages {
             block_header_storage: &block_headers,
             filter_header_storage: Some(&filter_headers),
             filter_storage: Some(&filters),
             block_storage: Some(&blocks),
+            metadata_storage: &metadata,
         };
 
         let result = handle_reorg(
@@ -459,6 +481,7 @@ mod tests {
         let filter_headers = storage.filter_headers();
         let filters = storage.filters();
         let blocks = storage.blocks();
+        let metadata = storage.metadata();
 
         let candidate = fork_candidate_from(3, chain[3].block_hash(), 2, 1_700_010_000);
         let candidate_tip = candidate.tip_hash();
@@ -472,11 +495,13 @@ mod tests {
             PersistentFilterHeaderStorage,
             PersistentFilterStorage,
             PersistentBlockStorage,
+            PersistentMetadataStorage,
         > = ReorgStorages {
             block_header_storage: &block_headers,
             filter_header_storage: Some(&filter_headers),
             filter_storage: Some(&filters),
             block_storage: Some(&blocks),
+            metadata_storage: &metadata,
         };
 
         let result = handle_reorg(
@@ -509,6 +534,7 @@ mod tests {
         let filter_headers = storage.filter_headers();
         let filters = storage.filters();
         let blocks = storage.blocks();
+        let metadata = storage.metadata();
 
         // ancestor at 10, tip at 119 → depth 109 > 100.
         let candidate = fork_candidate_from(10, chain[10].block_hash(), 3, 1_700_100_000);
@@ -523,11 +549,13 @@ mod tests {
             PersistentFilterHeaderStorage,
             PersistentFilterStorage,
             PersistentBlockStorage,
+            PersistentMetadataStorage,
         > = ReorgStorages {
             block_header_storage: &block_headers,
             filter_header_storage: Some(&filter_headers),
             filter_storage: Some(&filters),
             block_storage: Some(&blocks),
+            metadata_storage: &metadata,
         };
 
         let event = handle_reorg(
@@ -570,6 +598,7 @@ mod tests {
         let filter_headers = storage.filter_headers();
         let filters = storage.filters();
         let blocks = storage.blocks();
+        let metadata = storage.metadata();
 
         let candidate = fork_candidate_from(5, chain[5].block_hash(), 2, 1_700_010_000);
 
@@ -593,11 +622,13 @@ mod tests {
             PersistentFilterHeaderStorage,
             PersistentFilterStorage,
             PersistentBlockStorage,
+            PersistentMetadataStorage,
         > = ReorgStorages {
             block_header_storage: &block_headers,
             filter_header_storage: Some(&filter_headers),
             filter_storage: Some(&filters),
             block_storage: Some(&blocks),
+            metadata_storage: &metadata,
         };
 
         let result = handle_reorg(
@@ -630,6 +661,7 @@ mod tests {
         let filter_headers = storage.filter_headers();
         let filters = storage.filters();
         let blocks = storage.blocks();
+        let metadata = storage.metadata();
 
         // ancestor at 10, tip at 119 → depth 109 > MAX_REORG_DEPTH.
         let candidate = fork_candidate_from(10, chain[10].block_hash(), 3, 1_700_100_000);
@@ -644,11 +676,13 @@ mod tests {
             PersistentFilterHeaderStorage,
             PersistentFilterStorage,
             PersistentBlockStorage,
+            PersistentMetadataStorage,
         > = ReorgStorages {
             block_header_storage: &block_headers,
             filter_header_storage: Some(&filter_headers),
             filter_storage: Some(&filters),
             block_storage: Some(&blocks),
+            metadata_storage: &metadata,
         };
 
         let event = handle_reorg(
@@ -697,6 +731,7 @@ mod tests {
         let filter_headers = storage.filter_headers();
         let filters = storage.filters();
         let blocks = storage.blocks();
+        let metadata = storage.metadata();
 
         // ancestor at 40, best chainlock at 50 → is_below_chainlock_floor(40, 50) = true.
         let candidate = fork_candidate_from(40, chain[40].block_hash(), 3, 1_700_100_000);
@@ -712,11 +747,13 @@ mod tests {
             PersistentFilterHeaderStorage,
             PersistentFilterStorage,
             PersistentBlockStorage,
+            PersistentMetadataStorage,
         > = ReorgStorages {
             block_header_storage: &block_headers,
             filter_header_storage: Some(&filter_headers),
             filter_storage: Some(&filters),
             block_storage: Some(&blocks),
+            metadata_storage: &metadata,
         };
         let result = handle_reorg(
             candidate.clone(),
@@ -746,11 +783,13 @@ mod tests {
             PersistentFilterHeaderStorage,
             PersistentFilterStorage,
             PersistentBlockStorage,
+            PersistentMetadataStorage,
         > = ReorgStorages {
             block_header_storage: &block_headers,
             filter_header_storage: Some(&filter_headers),
             filter_storage: Some(&filters),
             block_storage: Some(&blocks),
+            metadata_storage: &metadata,
         };
         let event = handle_reorg(
             candidate,
@@ -786,6 +825,61 @@ mod tests {
         assert!(
             !state2.lock().await.deny_list.contains_key(&candidate_tip),
             "forced reorg must not land on the deny-list"
+        );
+    }
+
+    /// Successful cascade writes the sentinel before truncation and clears it
+    /// once the last `truncate_above` completes, so a clean restart sees no
+    /// in-progress marker.
+    #[tokio::test]
+    async fn cascade_writes_and_clears_reorg_sentinel() {
+        let mut storage = DiskStorageManager::with_temp_dir().await.unwrap();
+        let chain = mined_chain(10, 1_700_000_000);
+        storage.store_headers(&chain).await.unwrap();
+        let block_headers = storage.block_headers();
+        let filter_headers = storage.filter_headers();
+        let filters = storage.filters();
+        let blocks = storage.blocks();
+        let metadata = storage.metadata();
+
+        assert!(!metadata.read().await.is_reorg_sentinel_set());
+
+        let candidate = fork_candidate_from(5, chain[5].block_hash(), 3, 1_700_010_000);
+        let state = Mutex::new(ReorgState::default());
+        let generation = AtomicU64::new(0);
+        let checkpoint_manager = CheckpointManager::new(vec![]);
+        let storages: ReorgStorages<
+            PersistentBlockHeaderStorage,
+            PersistentFilterHeaderStorage,
+            PersistentFilterStorage,
+            PersistentBlockStorage,
+            PersistentMetadataStorage,
+        > = ReorgStorages {
+            block_header_storage: &block_headers,
+            filter_header_storage: Some(&filter_headers),
+            filter_storage: Some(&filters),
+            block_storage: Some(&blocks),
+            metadata_storage: &metadata,
+        };
+
+        let _ = handle_reorg(
+            candidate,
+            &state,
+            &generation,
+            storages,
+            &checkpoint_manager,
+            Some(0),
+            9,
+            chain[9].block_hash(),
+            false,
+        )
+        .await
+        .unwrap()
+        .expect("ChainReorg event");
+
+        assert!(
+            !metadata.read().await.is_reorg_sentinel_set(),
+            "sentinel must be cleared after a successful cascade"
         );
     }
 

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -287,6 +287,19 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         );
     }
 
+    async fn clamp_heights_to(&mut self, tip: CoreBlockHeight) {
+        for info in self.wallet_infos.values_mut() {
+            let current_last = info.last_processed_height();
+            if current_last > tip {
+                info.update_last_processed_height(tip);
+            }
+            let current_synced = info.synced_height();
+            if current_synced > tip {
+                info.update_synced_height(tip);
+            }
+        }
+    }
+
     fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent> {
         self.event_sender.subscribe()
     }

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -619,6 +619,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_clamp_heights_to_lowers_above_tip_metadata() {
+        let (mut manager, wallet_id, _) = setup_manager_with_wallet();
+
+        manager.update_wallet_synced_height(&wallet_id, 500);
+        manager.update_wallet_last_processed_height(&wallet_id, 600);
+        assert_eq!(manager.get_wallet_info(&wallet_id).unwrap().synced_height(), 500);
+        assert_eq!(manager.get_wallet_info(&wallet_id).unwrap().last_processed_height(), 600);
+
+        manager.clamp_heights_to(450).await;
+
+        assert_eq!(
+            manager.get_wallet_info(&wallet_id).unwrap().synced_height(),
+            450,
+            "synced_height above tip must be clamped down"
+        );
+        assert_eq!(
+            manager.get_wallet_info(&wallet_id).unwrap().last_processed_height(),
+            450,
+            "last_processed_height above tip must be clamped down"
+        );
+
+        // Clamping to a tip above both is a no-op.
+        manager.clamp_heights_to(10_000).await;
+        assert_eq!(manager.get_wallet_info(&wallet_id).unwrap().synced_height(), 450);
+        assert_eq!(manager.get_wallet_info(&wallet_id).unwrap().last_processed_height(), 450);
+    }
+
+    #[tokio::test]
     async fn test_update_wallet_synced_height_emits_sync_height_advanced() {
         let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
         let mut rx = manager.subscribe_events();

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -134,6 +134,14 @@ pub trait WalletInterface: Send + Sync + 'static {
         height: CoreBlockHeight,
     );
 
+    /// Clamp every managed wallet's `last_processed_height` and `synced_height`
+    /// so neither exceeds `tip`. Called from the SPV client's startup path
+    /// after the storage consistency check repairs a mid-cascade crash. The
+    /// default implementation is a no-op; implementations that track per-wallet
+    /// heights must iterate their internal wallets and bound both metadata
+    /// fields with `min(current, tip)`.
+    async fn clamp_heights_to(&mut self, _tip: CoreBlockHeight) {}
+
     /// Return a revision counter that increments whenever the set of monitored
     /// addresses or watched outpoints changes. The mempool manager uses this to
     /// detect when its bloom filter is stale without requiring an external signal.

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -140,6 +140,12 @@ pub trait WalletInterface: Send + Sync + 'static {
     /// default implementation is a no-op; implementations that track per-wallet
     /// heights must iterate their internal wallets and bound both metadata
     /// fields with `min(current, tip)`.
+    ///
+    /// The return type is intentionally `()`. This operation is a pure in-memory
+    /// clamp of wallet metadata, so it must not perform any fallible I/O or
+    /// validation. Implementors that need to persist the clamped state must do
+    /// so eagerly during ordinary operation, not from inside this call, so the
+    /// startup path remains infallible.
     async fn clamp_heights_to(&mut self, _tip: CoreBlockHeight) {}
 
     /// Return a revision counter that increments whenever the set of monitored


### PR DESCRIPTION
## Summary

Implements [#143](https://github.com/xdustinface/rust-dashcore/issues/143) — Phase 3.5 of the [#137](https://github.com/xdustinface/rust-dashcore/issues/137) reorg work. Detects and recovers from crashes during the reorg cascade, and validates cross-storage invariants on every startup.

- `MetadataStorage` gains `delete_metadata`, plus sentinel write/clear/probe primitives. Sentinel is a zero-byte file at `metadata/reorg_in_progress.dat` written via `atomic_write` immediately before the reorg cascade's `generation.fetch_add` and cleared after the last `truncate_above` completes.
- New `storage::consistency::check_and_repair_consistency` runs at the end of `DiskStorageManager::new` (before the background worker starts). It validates `filter_header_tip <= block_header_tip`, `filter_tip <= filter_header_tip`, and the block-storage tip (probed by 1024-height window). Any violation triggers `truncate_above(block_header_tip)` + `persist` on the offending storage.
- If the sentinel is set, walks `header_hash_index` backward from `tip_height` via `PersistentBlockHeaderStorage::highest_valid_tip` and truncates all storages to that height before invariant checks run.
- `SegmentCache::load_or_new` is now corruption-tolerant: an unreadable segment truncates the cache to the last readable segment and logs a warning (matches the sentinel cascade philosophy).
- Stale chainlock cleared on startup if `chainlock.block_height > block_header_tip` via `delete_metadata(BEST_CHAINLOCK_KEY)`.
- New `WalletInterface::clamp_heights_to(tip)` on the wallet trait, called from `lifecycle.rs` after `initialize_genesis_block`.
- New unit tests cover sentinel state transitions, valid-tip walk on intact and corrupted chains, each invariant violation triggering correct downstream truncation, stale-chainlock clearing, wallet height clamping, and corrupt-segment recovery.

Closes #143.