### PR TITLE
feat(key-wallet): `TransactionContext` `Conflicted` and `Abandoned` variants

### DIFF
--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -1168,6 +1168,48 @@ mod tests {
     }
 
     #[test]
+    fn transaction_context_from_ffi_conflicted_returns_none() {
+        let result = transaction_context_from_ffi(
+            FFITransactionContextType::Conflicted,
+            &FFIBlockInfo::empty(),
+            ptr::null(),
+            0,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn transaction_context_from_ffi_abandoned_returns_none() {
+        let result = transaction_context_from_ffi(
+            FFITransactionContextType::Abandoned,
+            &FFIBlockInfo::empty(),
+            ptr::null(),
+            0,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_ffi_transaction_context_type_from_conflicted() {
+        let ctx = TransactionContext::Conflicted {
+            previous: Box::new(TransactionContext::Mempool),
+        };
+        assert!(matches!(
+            FFITransactionContextType::from(ctx),
+            FFITransactionContextType::Conflicted
+        ));
+    }
+
+    #[test]
+    fn test_ffi_transaction_context_type_from_abandoned() {
+        let ctx = TransactionContext::Abandoned;
+        assert!(matches!(
+            FFITransactionContextType::from(ctx),
+            FFITransactionContextType::Abandoned
+        ));
+    }
+
+    #[test]
     fn test_ffi_transaction_context_from_in_block() {
         let hash = dashcore::BlockHash::from_byte_array([0xab; 32]);
         let block_info = BlockInfo::new(1000, hash, 1700000000);

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -86,6 +86,7 @@ pub(crate) fn transaction_context_from_ffi(
             }
             Some(TransactionContext::InChainLockedBlock(block_info.to_block_info()))
         }
+        FFITransactionContextType::Conflicted | FFITransactionContextType::Abandoned => None,
     }
 }
 
@@ -684,6 +685,12 @@ pub enum FFITransactionContextType {
     InBlock = 2,
     /// Transaction is in a chain-locked block at the given height
     InChainLockedBlock = 3,
+    /// Transaction was reorganized out and is superseded by a conflicting
+    /// transaction. The previous context is not surfaced across the FFI
+    /// boundary.
+    Conflicted = 4,
+    /// Transaction was reorganized out and is not expected to confirm again.
+    Abandoned = 5,
 }
 
 impl From<TransactionContext> for FFITransactionContextType {
@@ -695,6 +702,10 @@ impl From<TransactionContext> for FFITransactionContextType {
             TransactionContext::InChainLockedBlock(_) => {
                 FFITransactionContextType::InChainLockedBlock
             }
+            TransactionContext::Conflicted {
+                ..
+            } => FFITransactionContextType::Conflicted,
+            TransactionContext::Abandoned => FFITransactionContextType::Abandoned,
         }
     }
 }

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -115,13 +115,9 @@ impl ManagedCoreFundsAccount {
         self.spent_outpoints.contains(outpoint)
     }
 
-    /// Drop any UTXOs `tx` previously contributed and release the
-    /// outpoints it had marked as spent. Invoked when `tx` transitions
-    /// to an inactive context (`Conflicted`, `Abandoned`): its outputs
-    /// must leave the spendable set and the inputs it consumed are no
-    /// longer spent by this tx, so the previously spending marker is
-    /// cleared. Restoring the actual UTXOs the inputs referenced is
-    /// the rewind logic's responsibility, not this method's.
+    /// Drop any UTXOs `tx` previously contributed and release the outpoints it
+    /// had marked as spent. Restoring the actual UTXOs the inputs referenced is
+    /// the caller's responsibility.
     fn release_inactive_utxos(&mut self, tx: &Transaction) {
         let txid = tx.txid();
         let mut utxos_changed = false;

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -118,6 +118,12 @@ impl ManagedCoreFundsAccount {
     /// Drop any UTXOs `tx` previously contributed and release the outpoints it
     /// had marked as spent. Restoring the actual UTXOs the inputs referenced is
     /// the caller's responsibility.
+    ///
+    /// NOTE: no current caller restores the predecessor UTXOs, so a wallet with
+    /// a spend chain that includes a conflicted/abandoned transaction will
+    /// report a balance that does not include those re-released funds until
+    /// the predecessor transactions are re-processed. The full rewind path is
+    /// tracked in issue #145.
     fn release_inactive_utxos(&mut self, tx: &Transaction) {
         let txid = tx.txid();
         let mut utxos_changed = false;

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -746,6 +746,7 @@ impl<'de> Deserialize<'de> for ManagedCoreFundsAccount {
             .keys
             .transactions()
             .values()
+            .filter(|record| !record.context.is_inactive())
             .flat_map(|record| &record.transaction.input)
             .map(|input| input.previous_output)
             .collect();

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -115,6 +115,35 @@ impl ManagedCoreFundsAccount {
         self.spent_outpoints.contains(outpoint)
     }
 
+    /// Drop any UTXOs `tx` previously contributed and release the
+    /// outpoints it had marked as spent. Invoked when `tx` transitions
+    /// to an inactive context (`Conflicted`, `Abandoned`): its outputs
+    /// must leave the spendable set and the inputs it consumed are no
+    /// longer spent by this tx, so the previously spending marker is
+    /// cleared. Restoring the actual UTXOs the inputs referenced is
+    /// the rewind logic's responsibility, not this method's.
+    fn release_inactive_utxos(&mut self, tx: &Transaction) {
+        let txid = tx.txid();
+        let mut utxos_changed = false;
+        for vout in 0..tx.output.len() as u32 {
+            let outpoint = OutPoint {
+                txid,
+                vout,
+            };
+            if self.utxos.remove(&outpoint).is_some() {
+                utxos_changed = true;
+            }
+        }
+        for input in &tx.input {
+            if self.spent_outpoints.remove(&input.previous_output) {
+                utxos_changed = true;
+            }
+        }
+        if utxos_changed {
+            self.keys.bump_monitor_revision();
+        }
+    }
+
     /// Add new UTXOs for received outputs, remove spent ones.
     fn update_utxos(
         &mut self,
@@ -136,6 +165,10 @@ impl ManagedCoreFundsAccount {
             | ManagedAccountType::DashpayExternalAccount {
                 ..
             } => {
+                if context.is_inactive() {
+                    self.release_inactive_utxos(tx);
+                    return;
+                }
                 let involved_addrs: BTreeSet<_> = account_match
                     .account_type_match
                     .all_involved_addresses()

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -307,13 +307,16 @@ impl ManagedCoreFundsAccount {
             );
             if tx_record.context != context {
                 let was_confirmed = tx_record.context.confirmed();
+                let going_inactive = context.is_inactive();
                 tx_record.update_context(context.clone());
                 // Confirm-time upgrades within the confirmed state (e.g.
                 // InBlock → InChainLockedBlock) are not signaled here.
                 // Chainlock-driven promotions go through the dedicated
                 // `apply_chain_lock` path which emits a single batched
-                // ChainLockProcessed event.
-                changed = !was_confirmed;
+                // ChainLockProcessed event. A transition from a confirmed
+                // state to an inactive one (Conflicted/Abandoned) must
+                // still be signaled so callers can refresh balances.
+                changed = !was_confirmed || going_inactive;
             }
         }
 

--- a/key-wallet/src/tests/conflicted_abandoned_tests.rs
+++ b/key-wallet/src/tests/conflicted_abandoned_tests.rs
@@ -4,8 +4,9 @@
 //! state, plus the no-op behavior when an inactive transaction is
 //! first sighted by a fresh account.
 
+use dashcore::blockdata::transaction::OutPoint;
 use dashcore::hashes::Hash;
-use dashcore::{BlockHash, Transaction};
+use dashcore::{BlockHash, Transaction, TxIn, TxOut};
 
 use crate::managed_account::managed_account_trait::ManagedAccountTrait;
 use crate::test_utils::TestWalletContext;
@@ -111,6 +112,71 @@ async fn in_block_to_conflicted_releases_utxos_and_preserves_previous() {
         panic!("expected Conflicted context");
     };
     assert_eq!(**previous, pre, "previous context must round-trip");
+}
+
+/// Build a transaction that spends `outpoint` and pays to an
+/// unrelated script (an empty `script_pubkey`), so the spending tx
+/// has no outputs the wallet considers its own.
+fn spending_tx(outpoint: OutPoint, value: u64) -> Transaction {
+    Transaction {
+        version: 1,
+        lock_time: 0,
+        input: vec![TxIn {
+            previous_output: outpoint,
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value,
+            script_pubkey: Default::default(),
+        }],
+        special_transaction_payload: None,
+    }
+}
+
+#[tokio::test]
+async fn spending_tx_going_inactive_releases_input_outpoint() {
+    let (mut ctx, funding_tx) = funded_in_block().await;
+    let funded_outpoint = OutPoint {
+        txid: funding_tx.txid(),
+        vout: 0,
+    };
+    let spend = spending_tx(funded_outpoint, FUND_AMOUNT);
+
+    // Capture the AccountMatch before processing the spend, since the
+    // spend removes the input UTXO and subsequent lookups would fail.
+    let spend_match = ctx
+        .managed_wallet
+        .first_bip44_managed_account()
+        .expect("bip44 account")
+        .check_transaction_for_match(&spend, Some(0))
+        .expect("spend matches funded account before processing");
+
+    let result = ctx.check_transaction(&spend, block_context()).await;
+    assert!(result.state_modified, "spending tx must be recognised as ours");
+    assert!(
+        ctx.bip44_account().utxos.is_empty(),
+        "the spent UTXO must leave the spendable set once the spend confirms"
+    );
+
+    let account = ctx.managed_wallet.first_bip44_managed_account_mut().expect("bip44 account");
+    account.confirm_transaction(
+        &spend,
+        &spend_match,
+        TransactionContext::Abandoned,
+        TransactionType::Standard,
+    );
+
+    // With the spending tx abandoned, the funding outpoint is no longer
+    // considered spent. Reprocessing the funding tx must re-track its
+    // output as a UTXO, which exercises the `spent_outpoints` release
+    // branch inside `release_inactive_utxos`.
+    let result = ctx.check_transaction(&funding_tx, block_context()).await;
+    assert!(result.is_relevant);
+    assert_eq!(
+        ctx.bip44_account().utxos.len(),
+        1,
+        "UTXO must be re-trackable once its consumer is abandoned"
+    );
 }
 
 #[tokio::test]

--- a/key-wallet/src/tests/conflicted_abandoned_tests.rs
+++ b/key-wallet/src/tests/conflicted_abandoned_tests.rs
@@ -1,0 +1,138 @@
+//! Lifecycle tests for [`TransactionContext::Conflicted`] and
+//! [`TransactionContext::Abandoned`]. Covers UTXO release semantics
+//! when an existing record transitions from `InBlock` to an inactive
+//! state, plus the no-op behavior when an inactive transaction is
+//! first sighted by a fresh account.
+
+use dashcore::hashes::Hash;
+use dashcore::{BlockHash, Transaction};
+
+use crate::managed_account::managed_account_trait::ManagedAccountTrait;
+use crate::test_utils::TestWalletContext;
+use crate::transaction_checking::transaction_router::TransactionType;
+use crate::transaction_checking::{BlockInfo, TransactionContext};
+use crate::wallet::balance::WalletCoreBalance;
+use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+
+const BLOCK_HEIGHT: u32 = 200;
+const FUND_AMOUNT: u64 = 250_000;
+
+fn block_context() -> TransactionContext {
+    let hash = BlockHash::from_slice(&[0x42; 32]).expect("hash");
+    TransactionContext::InBlock(BlockInfo::new(BLOCK_HEIGHT, hash, 1_700_000_000))
+}
+
+/// Funds the wallet's receive address and promotes the funding tx into
+/// `InBlock`, ensuring a UTXO is recorded as confirmed before we drive
+/// it to an inactive context.
+async fn funded_in_block() -> (TestWalletContext, Transaction) {
+    let (mut ctx, tx) = TestWalletContext::new_random().with_mempool_funding(FUND_AMOUNT).await;
+    let result = ctx.check_transaction(&tx, block_context()).await;
+    assert!(result.state_modified);
+    assert_eq!(ctx.bip44_account().utxos.len(), 1);
+    (ctx, tx)
+}
+
+/// Promote an existing record from `InBlock` to the given inactive
+/// context via the low-level funds-account API. Mirrors what the
+/// rewind logic in #145 will do at the orchestration layer.
+fn transition_to_inactive(
+    ctx: &mut TestWalletContext,
+    tx: &Transaction,
+    inactive: TransactionContext,
+) {
+    let relevant = ctx
+        .managed_wallet
+        .first_bip44_managed_account()
+        .expect("bip44 account")
+        .check_transaction_for_match(tx, Some(0))
+        .expect("tx matches funded account");
+    let account = ctx.managed_wallet.first_bip44_managed_account_mut().expect("bip44 account");
+    account.confirm_transaction(tx, &relevant, inactive, TransactionType::Standard);
+}
+
+#[tokio::test]
+async fn fresh_account_with_conflicted_tx_keeps_empty_balance() {
+    let mut ctx = TestWalletContext::new_random();
+    let tx = Transaction::dummy(&ctx.receive_address, 0..1, &[FUND_AMOUNT]);
+    let conflicted = TransactionContext::Conflicted {
+        previous: Box::new(TransactionContext::Mempool),
+    };
+
+    let _ = ctx.check_transaction(&tx, conflicted.clone()).await;
+
+    assert!(
+        ctx.bip44_account().utxos.is_empty(),
+        "no UTXOs should be tracked for an inactive incoming tx"
+    );
+    ctx.managed_wallet.update_balance();
+    assert_eq!(ctx.managed_wallet.balance(), WalletCoreBalance::default());
+
+    let record = ctx
+        .managed_wallet
+        .first_bip44_managed_account()
+        .expect("bip44 account")
+        .transactions()
+        .get(&tx.txid())
+        .expect("record was inserted");
+    assert!(matches!(record.context, TransactionContext::Conflicted { .. }));
+}
+
+#[tokio::test]
+async fn in_block_to_conflicted_releases_utxos_and_preserves_previous() {
+    let (mut ctx, tx) = funded_in_block().await;
+    let pre = block_context();
+
+    transition_to_inactive(
+        &mut ctx,
+        &tx,
+        TransactionContext::Conflicted {
+            previous: Box::new(pre.clone()),
+        },
+    );
+
+    assert!(
+        ctx.bip44_account().utxos.is_empty(),
+        "conflicted tx must drop its outputs from the spendable set"
+    );
+    ctx.managed_wallet.update_balance();
+    assert_eq!(ctx.managed_wallet.balance(), WalletCoreBalance::default());
+
+    let record = ctx
+        .managed_wallet
+        .first_bip44_managed_account()
+        .expect("bip44 account")
+        .transactions()
+        .get(&tx.txid())
+        .expect("record still present after conflict");
+    let TransactionContext::Conflicted {
+        previous,
+    } = &record.context
+    else {
+        panic!("expected Conflicted context");
+    };
+    assert_eq!(**previous, pre, "previous context must round-trip");
+}
+
+#[tokio::test]
+async fn in_block_to_abandoned_releases_utxos() {
+    let (mut ctx, tx) = funded_in_block().await;
+
+    transition_to_inactive(&mut ctx, &tx, TransactionContext::Abandoned);
+
+    assert!(
+        ctx.bip44_account().utxos.is_empty(),
+        "abandoned tx must drop its outputs from the spendable set"
+    );
+    ctx.managed_wallet.update_balance();
+    assert_eq!(ctx.managed_wallet.balance(), WalletCoreBalance::default());
+
+    let record = ctx
+        .managed_wallet
+        .first_bip44_managed_account()
+        .expect("bip44 account")
+        .transactions()
+        .get(&tx.txid())
+        .expect("record still present after abandonment");
+    assert_eq!(record.context, TransactionContext::Abandoned);
+}

--- a/key-wallet/src/tests/conflicted_abandoned_tests.rs
+++ b/key-wallet/src/tests/conflicted_abandoned_tests.rs
@@ -185,6 +185,7 @@ async fn spending_tx_going_inactive_releases_input_outpoint() {
 /// `spent_outpoints`. Otherwise a round-trip would re-mark the funded outpoint
 /// as spent and the funding UTXO could not be re-tracked after its consumer
 /// has been abandoned.
+#[cfg(feature = "serde")]
 #[tokio::test]
 async fn serde_round_trip_does_not_resurrect_inactive_spent_outpoints() {
     let (mut ctx, funding_tx) = funded_in_block().await;

--- a/key-wallet/src/tests/conflicted_abandoned_tests.rs
+++ b/key-wallet/src/tests/conflicted_abandoned_tests.rs
@@ -34,8 +34,7 @@ async fn funded_in_block() -> (TestWalletContext, Transaction) {
 }
 
 /// Promote an existing record from `InBlock` to the given inactive
-/// context via the low-level funds-account API. Mirrors what the
-/// rewind logic in #145 will do at the orchestration layer.
+/// context via the low-level funds-account API.
 fn transition_to_inactive(
     ctx: &mut TestWalletContext,
     tx: &Transaction,

--- a/key-wallet/src/tests/conflicted_abandoned_tests.rs
+++ b/key-wallet/src/tests/conflicted_abandoned_tests.rs
@@ -9,6 +9,7 @@ use dashcore::hashes::Hash;
 use dashcore::{BlockHash, Transaction, TxIn, TxOut};
 
 use crate::managed_account::managed_account_trait::ManagedAccountTrait;
+use crate::managed_account::ManagedCoreFundsAccount;
 use crate::test_utils::TestWalletContext;
 use crate::transaction_checking::transaction_router::TransactionType;
 use crate::transaction_checking::{BlockInfo, TransactionContext};
@@ -176,6 +177,51 @@ async fn spending_tx_going_inactive_releases_input_outpoint() {
         ctx.bip44_account().utxos.len(),
         1,
         "UTXO must be re-trackable once its consumer is abandoned"
+    );
+}
+
+/// Regression: the `Deserialize` impl for `ManagedCoreFundsAccount` must skip
+/// inputs from inactive (`Conflicted`/`Abandoned`) records when rebuilding
+/// `spent_outpoints`. Otherwise a round-trip would re-mark the funded outpoint
+/// as spent and the funding UTXO could not be re-tracked after its consumer
+/// has been abandoned.
+#[tokio::test]
+async fn serde_round_trip_does_not_resurrect_inactive_spent_outpoints() {
+    let (mut ctx, funding_tx) = funded_in_block().await;
+    let funded_outpoint = OutPoint {
+        txid: funding_tx.txid(),
+        vout: 0,
+    };
+    let spend = spending_tx(funded_outpoint, FUND_AMOUNT);
+
+    let spend_match = ctx
+        .managed_wallet
+        .first_bip44_managed_account()
+        .expect("bip44 account")
+        .check_transaction_for_match(&spend, Some(0))
+        .expect("spend matches funded account");
+
+    let result = ctx.check_transaction(&spend, block_context()).await;
+    assert!(result.state_modified);
+
+    let account = ctx.managed_wallet.first_bip44_managed_account_mut().expect("bip44 account");
+    account.confirm_transaction(
+        &spend,
+        &spend_match,
+        TransactionContext::Abandoned,
+        TransactionType::Standard,
+    );
+
+    let json = serde_json::to_string(account).expect("serialize");
+    let deserialized: ManagedCoreFundsAccount = serde_json::from_str(&json).expect("deserialize");
+    *account = deserialized;
+
+    let result = ctx.check_transaction(&funding_tx, block_context()).await;
+    assert!(result.is_relevant);
+    assert_eq!(
+        ctx.bip44_account().utxos.len(),
+        1,
+        "funding UTXO must be re-trackable after serde round-trip with abandoned spend"
     );
 }
 

--- a/key-wallet/src/tests/mod.rs
+++ b/key-wallet/src/tests/mod.rs
@@ -6,6 +6,8 @@ mod account_tests;
 
 mod balance_tests;
 
+mod conflicted_abandoned_tests;
+
 mod address_pool_tests;
 
 mod advanced_transaction_tests;

--- a/key-wallet/src/transaction_checking/transaction_context.rs
+++ b/key-wallet/src/transaction_checking/transaction_context.rs
@@ -76,7 +76,26 @@ impl std::fmt::Display for TransactionContext {
             }
             TransactionContext::Conflicted {
                 previous,
-            } => write!(f, "conflicted (was {})", previous),
+            } => {
+                // The `Conflicted.previous` invariant forbids nesting, but
+                // a corrupted on-disk state could still deserialize a
+                // chain. Walk iteratively to avoid a stack overflow and
+                // bail out if the chain is unexpectedly deep.
+                const MAX_DEPTH: usize = 16;
+                let mut depth = 0usize;
+                let mut cur: &TransactionContext = previous;
+                while let TransactionContext::Conflicted {
+                    previous: inner,
+                } = cur
+                {
+                    depth += 1;
+                    if depth > MAX_DEPTH {
+                        return write!(f, "conflicted (deeply nested)");
+                    }
+                    cur = inner;
+                }
+                write!(f, "conflicted (was {})", cur)
+            }
             TransactionContext::Abandoned => write!(f, "abandoned"),
         }
     }
@@ -184,6 +203,17 @@ mod tests {
         let json = serde_json::to_string(&original).expect("serialize");
         let restored: TransactionContext = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn deeply_nested_conflicted_display_does_not_overflow() {
+        let mut ctx = TransactionContext::Mempool;
+        for _ in 0..1000 {
+            ctx = TransactionContext::Conflicted {
+                previous: Box::new(ctx),
+            };
+        }
+        assert_eq!(format!("{}", ctx), "conflicted (deeply nested)");
     }
 
     #[test]

--- a/key-wallet/src/transaction_checking/transaction_context.rs
+++ b/key-wallet/src/transaction_checking/transaction_context.rs
@@ -115,4 +115,15 @@ impl TransactionContext {
             }
         }
     }
+
+    /// Returns whether this record has been reorganized out and no
+    /// longer contributes to the spendable balance. True for both
+    /// [`TransactionContext::Conflicted`] and
+    /// [`TransactionContext::Abandoned`].
+    pub(crate) fn is_inactive(&self) -> bool {
+        matches!(
+            self,
+            TransactionContext::Conflicted { .. } | TransactionContext::Abandoned
+        )
+    }
 }

--- a/key-wallet/src/transaction_checking/transaction_context.rs
+++ b/key-wallet/src/transaction_checking/transaction_context.rs
@@ -51,6 +51,11 @@ pub enum TransactionContext {
     /// double-spending transaction on the active chain. `previous`
     /// remembers the last confirmed-or-mempool context so the UI can
     /// surface what state the tx was in before the conflict.
+    ///
+    /// Invariant: `previous` must be an active context (`Mempool`,
+    /// `InstantSend`, `InBlock`, `InChainLockedBlock`) — never another
+    /// `Conflicted` or `Abandoned`. The type does not enforce this, so
+    /// constructors must uphold it.
     Conflicted {
         previous: Box<TransactionContext>,
     },

--- a/key-wallet/src/transaction_checking/transaction_context.rs
+++ b/key-wallet/src/transaction_checking/transaction_context.rs
@@ -161,6 +161,26 @@ mod tests {
         assert_eq!(format!("{}", abandoned), "abandoned");
     }
 
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_round_trip_conflicted() {
+        let original = TransactionContext::Conflicted {
+            previous: Box::new(TransactionContext::InBlock(sample_block_info())),
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let restored: TransactionContext = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(original, restored);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_round_trip_abandoned() {
+        let original = TransactionContext::Abandoned;
+        let json = serde_json::to_string(&original).expect("serialize");
+        let restored: TransactionContext = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(original, restored);
+    }
+
     #[test]
     fn conflicted_preserves_previous_in_block_context() {
         let previous = TransactionContext::InBlock(sample_block_info());

--- a/key-wallet/src/transaction_checking/transaction_context.rs
+++ b/key-wallet/src/transaction_checking/transaction_context.rs
@@ -121,9 +121,58 @@ impl TransactionContext {
     /// [`TransactionContext::Conflicted`] and
     /// [`TransactionContext::Abandoned`].
     pub(crate) fn is_inactive(&self) -> bool {
-        matches!(
-            self,
-            TransactionContext::Conflicted { .. } | TransactionContext::Abandoned
-        )
+        matches!(self, TransactionContext::Conflicted { .. } | TransactionContext::Abandoned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dashcore::ephemerealdata::instant_lock::InstantLock;
+    use dashcore::hashes::Hash;
+    use dashcore::BlockHash;
+
+    fn sample_block_info() -> BlockInfo {
+        BlockInfo::new(100, BlockHash::all_zeros(), 1_700_000_000)
+    }
+
+    #[test]
+    fn conflicted_helpers_are_negative() {
+        let previous = TransactionContext::InstantSend(InstantLock::default());
+        let conflicted = TransactionContext::Conflicted {
+            previous: Box::new(previous),
+        };
+        assert!(!conflicted.confirmed());
+        assert!(!conflicted.is_instant_send());
+        assert!(!conflicted.is_chain_locked());
+        assert!(conflicted.is_inactive());
+        assert!(conflicted.block_info().is_none());
+        assert_eq!(format!("{}", conflicted), "conflicted (was instant send)");
+    }
+
+    #[test]
+    fn abandoned_helpers_are_negative() {
+        let abandoned = TransactionContext::Abandoned;
+        assert!(!abandoned.confirmed());
+        assert!(!abandoned.is_instant_send());
+        assert!(!abandoned.is_chain_locked());
+        assert!(abandoned.is_inactive());
+        assert!(abandoned.block_info().is_none());
+        assert_eq!(format!("{}", abandoned), "abandoned");
+    }
+
+    #[test]
+    fn conflicted_preserves_previous_in_block_context() {
+        let previous = TransactionContext::InBlock(sample_block_info());
+        let conflicted = TransactionContext::Conflicted {
+            previous: Box::new(previous.clone()),
+        };
+        let TransactionContext::Conflicted {
+            previous: restored,
+        } = conflicted
+        else {
+            panic!("expected Conflicted variant");
+        };
+        assert_eq!(*restored, previous);
     }
 }

--- a/key-wallet/src/transaction_checking/transaction_context.rs
+++ b/key-wallet/src/transaction_checking/transaction_context.rs
@@ -47,6 +47,17 @@ pub enum TransactionContext {
     InBlock(BlockInfo),
     /// Transaction is in a chain-locked block at the given height
     InChainLockedBlock(BlockInfo),
+    /// Transaction was reorganized out and is now superseded by a
+    /// double-spending transaction on the active chain. `previous`
+    /// remembers the last confirmed-or-mempool context so the UI can
+    /// surface what state the tx was in before the conflict.
+    Conflicted {
+        previous: Box<TransactionContext>,
+    },
+    /// Transaction was reorganized out and is not expected to confirm
+    /// again (e.g. its inputs have been spent elsewhere and the user
+    /// has chosen to drop it). Terminal state.
+    Abandoned,
 }
 
 impl std::fmt::Display for TransactionContext {
@@ -58,6 +69,10 @@ impl std::fmt::Display for TransactionContext {
             TransactionContext::InChainLockedBlock(info) => {
                 write!(f, "chainlocked block {}", info.height)
             }
+            TransactionContext::Conflicted {
+                previous,
+            } => write!(f, "conflicted (was {})", previous),
+            TransactionContext::Abandoned => write!(f, "abandoned"),
         }
     }
 }
@@ -74,7 +89,7 @@ impl TransactionContext {
     }
 
     /// Returns whether the transaction has been mined in a block that is
-    /// itself chainlocked — the strongest finality signal we have, and
+    /// itself chainlocked, the strongest finality signal we have, and
     /// the only one we treat as truly "finalized".
     ///
     /// `InBlock` alone is not enough (the block can still be reorganized
@@ -89,7 +104,12 @@ impl TransactionContext {
     /// Returns the block info if confirmed.
     pub fn block_info(&self) -> Option<&BlockInfo> {
         match self {
-            TransactionContext::Mempool | TransactionContext::InstantSend(_) => None,
+            TransactionContext::Mempool
+            | TransactionContext::InstantSend(_)
+            | TransactionContext::Conflicted {
+                ..
+            }
+            | TransactionContext::Abandoned => None,
             TransactionContext::InBlock(info) | TransactionContext::InChainLockedBlock(info) => {
                 Some(info)
             }


### PR DESCRIPTION
## Summary

Phase 4a of [#137](https://github.com/xdustinface/rust-dashcore/issues/137). Pre-req for [#145](https://github.com/xdustinface/rust-dashcore/issues/145) (wallet rewind).

- Adds `Conflicted { previous: Box<TransactionContext> }` and `Abandoned` variants to `TransactionContext`, with helper methods (`confirmed`, `is_instant_send`, `is_chain_locked`, `block_info`, `Display`) returning the inactive semantics for both, and a `pub(crate) is_inactive` predicate used by the funds account.
- `ManagedCoreFundsAccount` releases UTXOs and `spent_outpoints` when a transaction transitions to an inactive context, so neither variant contributes to spendable or unconfirmed balance.
- FFI mirror in `key-wallet-ffi` extended for exhaustive match coverage. Inbound construction across the FFI boundary returns `None` for both new discriminants (the boxed previous context cannot be safely surfaced and these states are wallet-internal, set by the rewind logic in [#145](https://github.com/xdustinface/rust-dashcore/issues/145)).
- 6 new tests covering helper booleans, balance-after-promotion, UTXO release, and previous-context preservation.

Closes [#144](https://github.com/xdustinface/rust-dashcore/issues/144).