### PR TITLE
feat(key-wallet-manager): `WalletInterface::rewind_to_height` with descendant cascade

### DIFF
--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -1207,6 +1207,14 @@ impl FFIWalletEventCallbacks {
                     cb(c_wallet_id.as_ptr(), *height, self.user_data);
                 }
             }
+            WalletEvent::Reorg {
+                ..
+            } => {
+                // TODO(issue #145): wire a dedicated FFI callback for
+                // wallet rewind so durable consumers see demoted /
+                // conflicted txid lists and the post-rewind balance.
+                // Until then this variant has no surface on the C ABI.
+            }
             WalletEvent::ChainLockProcessed {
                 wallet_id,
                 chain_lock,

--- a/key-wallet-manager/Cargo.toml
+++ b/key-wallet-manager/Cargo.toml
@@ -29,6 +29,7 @@ dashcore = { path = "../dash" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
 tracing = "0.1"
+thiserror = "1.0"
 zeroize = { version = "1.8", features = ["derive"] }
 rayon = { version = "1.11", optional = true }
 bincode = { version = "2.0.1", optional = true }

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -1269,3 +1269,190 @@ async fn test_block_processed_chainlocked_flag_matches_record_context() {
         assert!(matches!(inserted[0].context, TransactionContext::InBlock(_)));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Reorg path
+// ---------------------------------------------------------------------------
+
+/// Build a transaction that spends a specific outpoint of a previous
+/// transaction (mimicking a child) paying back to one of the wallet's
+/// addresses. Used to exercise the descendant-cascade demotion path.
+fn spend_from(parent_txid: Txid, parent_vout: u32, addr: &Address, value: u64) -> Transaction {
+    Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: parent_txid,
+                vout: parent_vout,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: u32::MAX,
+            witness: Witness::default(),
+        }],
+        output: vec![TxOut {
+            value,
+            script_pubkey: addr.script_pubkey(),
+        }],
+        special_transaction_payload: None,
+    }
+}
+
+#[tokio::test]
+async fn test_rewind_demotes_single_above_cut_record() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let tx = create_tx_paying_to(&addr, 0xb0);
+    let block = make_block(vec![tx.clone()], 0xb0, 100);
+    let wallets = BTreeSet::from([wallet_id]);
+    manager.process_block_for_wallets(&block, 11, &wallets).await;
+
+    let mut rx = manager.subscribe_events();
+    let result = manager.rewind_to_height(10).await.expect("rewind below cut succeeds");
+    assert_eq!(result.demoted_txids, vec![tx.txid()]);
+    assert!(result.conflicted_txids.is_empty());
+
+    let events = drain_events(&mut rx);
+    let reorg = events
+        .iter()
+        .find_map(|e| match e {
+            WalletEvent::Reorg {
+                fork_height,
+                demoted_txids,
+                conflicted_txids,
+                balance,
+                ..
+            } => Some((*fork_height, demoted_txids.clone(), conflicted_txids.clone(), *balance)),
+            _ => None,
+        })
+        .expect("Reorg event must be emitted for a wallet whose state changed");
+    assert_eq!(reorg.0, 10);
+    assert_eq!(reorg.1, vec![tx.txid()]);
+    assert!(reorg.2.is_empty());
+    assert_eq!(reorg.3.confirmed(), 0, "demoted record must drop out of confirmed balance");
+
+    let info = manager.get_wallet_info(&wallet_id).expect("wallet present");
+    assert_eq!(info.last_processed_height(), 10);
+}
+
+#[tokio::test]
+async fn test_rewind_cascades_to_descendant_in_same_account() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let tx_a = create_tx_paying_to(&addr, 0xc1);
+    let block_a = make_block(vec![tx_a.clone()], 0xc1, 100);
+    let wallets = BTreeSet::from([wallet_id]);
+    manager.process_block_for_wallets(&block_a, 11, &wallets).await;
+
+    let tx_b = spend_from(tx_a.txid(), 0, &addr, TX_AMOUNT / 2);
+    let block_b = make_block(vec![tx_b.clone()], 0xc2, 200);
+    manager.process_block_for_wallets(&block_b, 12, &wallets).await;
+
+    let result = manager.rewind_to_height(10).await.expect("rewind succeeds");
+    let demoted: BTreeSet<Txid> = result.demoted_txids.iter().copied().collect();
+    assert!(demoted.contains(&tx_a.txid()), "parent must be demoted");
+    assert!(demoted.contains(&tx_b.txid()), "child spending parent must cascade");
+
+    let info = manager.get_wallet_info(&wallet_id).expect("wallet present");
+    assert_eq!(info.last_processed_height(), 10);
+}
+
+#[tokio::test]
+async fn test_rewind_retains_instant_send_record() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let tx = create_tx_paying_to(&addr, 0xd3);
+
+    // First sighting is an IS-locked mempool tx.
+    let islock = dummy_instant_lock(tx.txid());
+    manager.process_mempool_transaction(&tx, Some(islock.clone())).await;
+
+    let _ = manager.rewind_to_height(0).await.expect("rewind succeeds");
+
+    let info = manager.get_wallet_info(&wallet_id).expect("wallet present");
+    let mut found = false;
+    for account in info.accounts().all_accounts() {
+        if let Some(record) = account.transactions().get(&tx.txid()) {
+            assert!(
+                matches!(record.context, TransactionContext::InstantSend(_)),
+                "IS-locked record must be retained as InstantSend after rewind, got {:?}",
+                record.context,
+            );
+            found = true;
+        }
+    }
+    assert!(found, "the IS-locked transaction record must still be present after rewind");
+}
+
+#[tokio::test]
+async fn test_rewind_refuses_below_chainlock_floor() {
+    let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
+    manager.apply_chain_lock(ChainLock::dummy(50));
+
+    let err = manager
+        .rewind_to_height(49)
+        .await
+        .expect_err("rewind below chainlock floor must be rejected");
+    match err {
+        crate::wallet_interface::RewindError::BelowChainLockFloor {
+            requested,
+            floor,
+            wallet_id: rejecting,
+        } => {
+            assert_eq!(requested, 49);
+            assert_eq!(floor, 50);
+            assert_eq!(rejecting, wallet_id);
+        }
+    }
+
+    // Rewinding to the floor itself is allowed.
+    manager.rewind_to_height(50).await.expect("rewind at the floor is allowed");
+}
+
+#[tokio::test]
+async fn test_rewind_rolls_back_last_processed_and_synced_height() {
+    let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
+    let wallets = BTreeSet::from([wallet_id]);
+    let block = make_block(vec![], 0xee, 100);
+    manager.process_block_for_wallets(&block, 500, &wallets).await;
+    manager.update_wallet_synced_height(&wallet_id, 500);
+
+    let info = manager.get_wallet_info(&wallet_id).expect("wallet present");
+    assert_eq!(info.last_processed_height(), 500);
+    assert_eq!(info.synced_height(), 500);
+
+    manager.rewind_to_height(250).await.expect("rewind succeeds");
+
+    let info = manager.get_wallet_info(&wallet_id).expect("wallet present");
+    assert_eq!(info.last_processed_height(), 250);
+    assert_eq!(info.synced_height(), 250);
+}
+
+#[tokio::test]
+async fn test_rewind_below_current_does_not_advance_heights_upward() {
+    let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
+    let wallets = BTreeSet::from([wallet_id]);
+    let block = make_block(vec![], 0xef, 100);
+    manager.process_block_for_wallets(&block, 100, &wallets).await;
+
+    manager.rewind_to_height(1000).await.expect("rewind succeeds");
+
+    let info = manager.get_wallet_info(&wallet_id).expect("wallet present");
+    assert_eq!(
+        info.last_processed_height(),
+        100,
+        "rewinding to a height above current must not advance the wallet forward",
+    );
+}
+
+#[tokio::test]
+async fn test_get_transaction_returns_stored_record() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let tx = create_tx_paying_to(&addr, 0xa9);
+    let block = make_block(vec![tx.clone()], 0xa9, 100);
+    let wallets = BTreeSet::from([wallet_id]);
+    manager.process_block_for_wallets(&block, 50, &wallets).await;
+
+    let fetched = manager.get_transaction(&tx.txid()).await.expect("tx must be retrievable");
+    assert_eq!(fetched.txid(), tx.txid());
+
+    let missing = manager.get_transaction(&Txid::from_byte_array([0xff; 32])).await;
+    assert!(missing.is_none(), "unknown txid must return None");
+}

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -1370,6 +1370,69 @@ async fn test_rewind_cascades_to_descendant_in_same_account() {
 }
 
 #[tokio::test]
+async fn test_rewind_cascades_three_levels() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let wallets = BTreeSet::from([wallet_id]);
+
+    let tx_a = create_tx_paying_to(&addr, 0xd0);
+    manager
+        .process_block_for_wallets(&make_block(vec![tx_a.clone()], 0xd0, 100), 11, &wallets)
+        .await;
+
+    let tx_b = spend_from(tx_a.txid(), 0, &addr, TX_AMOUNT / 2);
+    manager
+        .process_block_for_wallets(&make_block(vec![tx_b.clone()], 0xd1, 200), 12, &wallets)
+        .await;
+
+    let tx_c = spend_from(tx_b.txid(), 0, &addr, TX_AMOUNT / 4);
+    manager
+        .process_block_for_wallets(&make_block(vec![tx_c.clone()], 0xd2, 300), 13, &wallets)
+        .await;
+
+    let result = manager.rewind_to_height(10).await.expect("rewind succeeds");
+    let demoted: BTreeSet<Txid> = result.demoted_txids.iter().copied().collect();
+    // Wave 2 of the frontier cascade only fires if wave 1 propagated the
+    // newly-demoted parent into the next frontier. A regression that drops
+    // descendants beyond the first hop would still pass the two-level test
+    // above but fail here.
+    assert!(demoted.contains(&tx_a.txid()), "grandparent must be demoted");
+    assert!(demoted.contains(&tx_b.txid()), "parent must cascade (wave 1)");
+    assert!(demoted.contains(&tx_c.txid()), "child must cascade (wave 2)");
+}
+
+#[tokio::test]
+async fn test_rewind_restores_is_trusted_on_mempool_change() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let wallets = BTreeSet::from([wallet_id]);
+    let (_, _, change_addr) = pool_state(&manager, &wallet_id, AddressPoolType::Internal);
+
+    let tx_a = create_tx_paying_to(&addr, 0xe0);
+    manager
+        .process_block_for_wallets(&make_block(vec![tx_a.clone()], 0xe0, 100), 11, &wallets)
+        .await;
+
+    // tx_b spends the wallet's UTXO from tx_a and pays change back to our
+    // own internal pool: after rewind tx_b ends up in mempool, so the
+    // change output is a trusted-change UTXO that must be credited to
+    // `confirmed()`, not `unconfirmed()`.
+    let tx_b = spend_from(tx_a.txid(), 0, &change_addr, TX_AMOUNT / 2);
+    manager
+        .process_block_for_wallets(&make_block(vec![tx_b.clone()], 0xe1, 200), 12, &wallets)
+        .await;
+
+    manager.rewind_to_height(10).await.expect("rewind succeeds");
+
+    let info = manager.get_wallet_info(&wallet_id).expect("wallet present");
+    let balance = info.balance();
+    assert_eq!(
+        balance.confirmed(),
+        TX_AMOUNT / 2,
+        "trusted mempool change must be credited to confirmed() after rebuild (got {balance:?})",
+    );
+    assert_eq!(balance.unconfirmed(), 0, "no untrusted mempool outputs remain");
+}
+
+#[tokio::test]
 async fn test_rewind_retains_instant_send_record() {
     let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
     let tx = create_tx_paying_to(&addr, 0xd3);

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -1,6 +1,6 @@
 use super::test_helpers::*;
 use super::*;
-use crate::wallet_interface::WalletInterface;
+use crate::wallet_interface::{RewindError, WalletInterface};
 use dashcore::block::{Block, Header, Version};
 use dashcore::blockdata::script::Builder;
 use dashcore::blockdata::transaction::special_transaction::asset_lock::AssetLockPayload;
@@ -1276,7 +1276,7 @@ async fn test_block_processed_chainlocked_flag_matches_record_context() {
 
 /// Build a transaction that spends a specific outpoint of a previous
 /// transaction (mimicking a child) paying back to one of the wallet's
-/// addresses. Used to exercise the descendant-cascade demotion path.
+/// addresses.
 fn spend_from(parent_txid: Txid, parent_vout: u32, addr: &Address, value: u64) -> Transaction {
     Transaction {
         version: 2,
@@ -1391,7 +1391,7 @@ async fn test_rewind_refuses_below_chainlock_floor() {
         .await
         .expect_err("rewind below chainlock floor must be rejected");
     match err {
-        crate::wallet_interface::RewindError::BelowChainLockFloor {
+        RewindError::BelowChainLockFloor {
             requested,
             floor,
             wallet_id: rejecting,

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -1353,6 +1353,20 @@ async fn test_rewind_cascades_to_descendant_in_same_account() {
 
     let info = manager.get_wallet_info(&wallet_id).expect("wallet present");
     assert_eq!(info.last_processed_height(), 10);
+
+    // Rewind to Mempool leaves the child still spending the parent's
+    // output, so only the child's own output reaches the spendable
+    // set. Without `rebuild_utxos`'s order-independent spent-outpoint
+    // guard the child's output could be wrongly resurrected as still
+    // spent, or the parent's output wrongly resurrected as spendable,
+    // depending on txid sort order.
+    let balance = info.balance();
+    let total = balance.confirmed() + balance.unconfirmed();
+    assert_eq!(
+        total,
+        TX_AMOUNT / 2,
+        "after rewind the child still spends the parent in mempool, only the child's output is a UTXO (got balance {balance:?})",
+    );
 }
 
 #[tokio::test]
@@ -1432,6 +1446,7 @@ async fn test_rewind_below_current_does_not_advance_heights_upward() {
     let block = make_block(vec![], 0xef, 100);
     manager.process_block_for_wallets(&block, 100, &wallets).await;
 
+    let mut rx = manager.subscribe_events();
     manager.rewind_to_height(1000).await.expect("rewind succeeds");
 
     let info = manager.get_wallet_info(&wallet_id).expect("wallet present");
@@ -1440,6 +1455,12 @@ async fn test_rewind_below_current_does_not_advance_heights_upward() {
         100,
         "rewinding to a height above current must not advance the wallet forward",
     );
+
+    let reorg_events: Vec<_> = drain_events(&mut rx)
+        .into_iter()
+        .filter(|e| matches!(e, WalletEvent::Reorg { .. }))
+        .collect();
+    assert!(reorg_events.is_empty(), "no-op rewind must not emit Reorg, got {reorg_events:?}",);
 }
 
 #[tokio::test]

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -1398,6 +1398,19 @@ async fn test_rewind_cascades_three_levels() {
     assert!(demoted.contains(&tx_a.txid()), "grandparent must be demoted");
     assert!(demoted.contains(&tx_b.txid()), "parent must cascade (wave 1)");
     assert!(demoted.contains(&tx_c.txid()), "child must cascade (wave 2)");
+
+    // Beyond the first cascade hop, `rebuild_utxos` must still produce a
+    // correct UTXO set: a regression that double-removes the intermediate
+    // tx_b's output, or that resurrects a spent ancestor, would inflate or
+    // deflate the balance without affecting the demotion list above.
+    let info = manager.get_wallet_info(&wallet_id).expect("wallet present");
+    let balance = info.balance();
+    let total = balance.confirmed() + balance.unconfirmed();
+    assert_eq!(
+        total,
+        TX_AMOUNT / 4,
+        "after 3-level cascade only tx_c's output remains spendable (got balance {balance:?})",
+    );
 }
 
 #[tokio::test]

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -340,7 +340,7 @@ pub enum WalletEvent {
         /// range that contained no wallet records.
         demoted_txids: Vec<Txid>,
         /// Records demoted to a terminal inactive context
-        /// (`Conflicted` / `Abandoned`). Currently always empty —
+        /// (`Conflicted` / `Abandoned`). Currently always empty;
         /// self-conflict detection is deferred to a follow-up.
         conflicted_txids: Vec<Txid>,
         /// Wallet balance after the rewind. UTXO state was rebuilt

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -322,6 +322,31 @@ pub enum WalletEvent {
         /// the parent transaction).
         locked_transactions: BTreeMap<AccountType, Vec<Txid>>,
     },
+    /// The wallet was rolled back to `fork_height` after a chain reorg.
+    /// Fires once per wallet whose state actually changed (records
+    /// demoted, or `last_processed_height` rolled back). Carries the
+    /// partitioned demoted-vs-conflicted txid lists plus the wallet's
+    /// post-rewind balance so consumers can persist the new state
+    /// atomically.
+    Reorg {
+        /// ID of the affected wallet.
+        wallet_id: WalletId,
+        /// Common-ancestor height in the active chain that the wallet
+        /// was rolled back to.
+        fork_height: CoreBlockHeight,
+        /// Records demoted to an active-but-unconfirmed context
+        /// (`Mempool` or retained `InstantSend`). Empty when the
+        /// reorg rolled `last_processed_height` back over a height
+        /// range that contained no wallet records.
+        demoted_txids: Vec<Txid>,
+        /// Records demoted to a terminal inactive context
+        /// (`Conflicted` / `Abandoned`). Currently always empty —
+        /// self-conflict detection is deferred to a follow-up.
+        conflicted_txids: Vec<Txid>,
+        /// Wallet balance after the rewind. UTXO state was rebuilt
+        /// from the surviving records before this value was computed.
+        balance: WalletCoreBalance,
+    },
 }
 
 impl WalletEvent {
@@ -345,6 +370,10 @@ impl WalletEvent {
                 ..
             }
             | WalletEvent::ChainLockProcessed {
+                wallet_id,
+                ..
+            }
+            | WalletEvent::Reorg {
                 wallet_id,
                 ..
             } => *wallet_id,
@@ -425,6 +454,20 @@ impl fmt::Display for WalletEvent {
                     total_txids,
                 )
             }
+            WalletEvent::Reorg {
+                fork_height,
+                demoted_txids,
+                conflicted_txids,
+                balance,
+                ..
+            } => write!(
+                f,
+                "Reorg(fork_height={}, demoted={}, conflicted={}, balance={})",
+                fork_height,
+                demoted_txids.len(),
+                conflicted_txids.len(),
+                balance,
+            ),
         }
     }
 }

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -1,6 +1,9 @@
 use crate::events::{diff_account_balances, project_derived_addresses, DerivedAddress};
-use crate::wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
+use crate::wallet_interface::{
+    BlockProcessingResult, MempoolTransactionResult, RewindError, RewindResult, WalletInterface,
+};
 use crate::{WalletEvent, WalletId, WalletManager};
+use key_wallet::wallet::managed_wallet_info::wallet_info_interface::RewindRejection;
 use async_trait::async_trait;
 use core::fmt::Write as _;
 use dashcore::ephemerealdata::chain_lock::ChainLock;
@@ -298,6 +301,79 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
                 info.update_synced_height(tip);
             }
         }
+    }
+
+    async fn rewind_to_height(
+        &mut self,
+        height: CoreBlockHeight,
+    ) -> Result<RewindResult, RewindError> {
+        for (wallet_id, info) in self.wallet_infos.iter() {
+            if let Some(cl) = info.last_applied_chain_lock() {
+                if height < cl.block_height {
+                    tracing::warn!(
+                        wallet_id = ?wallet_id,
+                        requested = height,
+                        floor = cl.block_height,
+                        "refusing rewind: requested height crosses chainlock floor",
+                    );
+                    return Err(RewindError::BelowChainLockFloor {
+                        requested: height,
+                        floor: cl.block_height,
+                        wallet_id: *wallet_id,
+                    });
+                }
+            }
+        }
+
+        let mut aggregated = RewindResult::default();
+        let wallet_ids: Vec<WalletId> = self.wallet_infos.keys().copied().collect();
+        for wallet_id in wallet_ids {
+            let Some(info) = self.wallet_infos.get_mut(&wallet_id) else {
+                continue;
+            };
+            let outcome = match info.rewind_to_height(height) {
+                Ok(o) => o,
+                Err(RewindRejection::BelowChainLockFloor {
+                    requested,
+                    floor,
+                }) => {
+                    return Err(RewindError::BelowChainLockFloor {
+                        requested,
+                        floor,
+                        wallet_id,
+                    });
+                }
+            };
+
+            if !outcome.state_changed {
+                continue;
+            }
+
+            aggregated.demoted_txids.extend(outcome.demoted_txids.iter().copied());
+            aggregated.conflicted_txids.extend(outcome.conflicted_txids.iter().copied());
+
+            let balance = info.balance();
+            let event = WalletEvent::Reorg {
+                wallet_id,
+                fork_height: height,
+                demoted_txids: outcome.demoted_txids,
+                conflicted_txids: outcome.conflicted_txids,
+                balance,
+            };
+            let _ = self.event_sender.send(event);
+        }
+        Ok(aggregated)
+    }
+
+    async fn get_transaction(&self, txid: &dashcore::Txid) -> Option<Transaction> {
+        for info in self.wallet_infos.values() {
+            for account in info.accounts().all_accounts() {
+                if let Some(record) = account.transactions().get(txid) {
+                    return Some(record.transaction.clone());
+                }
+            }
+        }
+        None
     }
 
     fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent> {

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -3,7 +3,6 @@ use crate::wallet_interface::{
     BlockProcessingResult, MempoolTransactionResult, RewindError, RewindResult, WalletInterface,
 };
 use crate::{WalletEvent, WalletId, WalletManager};
-use key_wallet::wallet::managed_wallet_info::wallet_info_interface::RewindRejection;
 use async_trait::async_trait;
 use core::fmt::Write as _;
 use dashcore::ephemerealdata::chain_lock::ChainLock;
@@ -13,6 +12,7 @@ use dashcore::{Address, Block, Transaction};
 use key_wallet::account::AccountType;
 use key_wallet::managed_account::transaction_record::TransactionRecord;
 use key_wallet::transaction_checking::{BlockInfo, DerivedAddressInfo, TransactionContext};
+use key_wallet::wallet::managed_wallet_info::wallet_info_interface::RewindRejection;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::WalletCoreBalance;
 use std::collections::{BTreeMap, BTreeSet};

--- a/key-wallet-manager/src/test_utils/mock_wallet.rs
+++ b/key-wallet-manager/src/test_utils/mock_wallet.rs
@@ -1,3 +1,4 @@
+use crate::wallet_interface::{RewindError, RewindResult};
 use crate::{
     BlockProcessingResult, MempoolTransactionResult, WalletEvent, WalletId, WalletInterface,
 };
@@ -257,6 +258,23 @@ impl WalletInterface for MockWallet {
     fn apply_chain_lock(&mut self, _chain_lock: ChainLock) {
         panic!("apply_chain_lock not supported for MockWallet");
     }
+
+    async fn rewind_to_height(
+        &mut self,
+        height: CoreBlockHeight,
+    ) -> Result<RewindResult, RewindError> {
+        if height < self.last_processed_height {
+            self.last_processed_height = height;
+        }
+        if height < self.synced_height {
+            self.synced_height = height;
+        }
+        Ok(RewindResult::default())
+    }
+
+    async fn get_transaction(&self, _txid: &Txid) -> Option<Transaction> {
+        None
+    }
 }
 
 /// Mock wallet that returns false for filter checks
@@ -365,6 +383,23 @@ impl WalletInterface for NonMatchingMockWallet {
 
     fn apply_chain_lock(&mut self, _chain_lock: ChainLock) {
         panic!("apply_chain_lock not supported for NonMatchingMockWallet");
+    }
+
+    async fn rewind_to_height(
+        &mut self,
+        height: CoreBlockHeight,
+    ) -> Result<RewindResult, RewindError> {
+        if height < self.last_processed_height {
+            self.last_processed_height = height;
+        }
+        if height < self.synced_height {
+            self.synced_height = height;
+        }
+        Ok(RewindResult::default())
+    }
+
+    async fn get_transaction(&self, _txid: &Txid) -> Option<Transaction> {
+        None
     }
 
     async fn describe(&self) -> String {
@@ -512,6 +547,25 @@ impl WalletInterface for MultiMockWallet {
 
     fn apply_chain_lock(&mut self, _chain_lock: ChainLock) {
         panic!("apply_chain_lock not supported for MultiMockWallet");
+    }
+
+    async fn rewind_to_height(
+        &mut self,
+        height: CoreBlockHeight,
+    ) -> Result<RewindResult, RewindError> {
+        for state in self.wallets.values_mut() {
+            if height < state.last_processed_height {
+                state.last_processed_height = height;
+            }
+            if height < state.synced_height {
+                state.synced_height = height;
+            }
+        }
+        Ok(RewindResult::default())
+    }
+
+    async fn get_transaction(&self, _txid: &Txid) -> Option<Transaction> {
+        None
     }
 
     async fn describe(&self) -> String {

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -11,6 +11,48 @@ use dashcore::{Address, Block, OutPoint, Transaction, Txid};
 use std::collections::{BTreeMap, BTreeSet};
 use tokio::sync::broadcast;
 
+/// Result of rewinding a wallet to a height after a chain reorg.
+///
+/// Produced by [`WalletInterface::rewind_to_height`]. Lists every
+/// transaction whose context was demoted by the rewind, partitioned by the
+/// state it was demoted into.
+///
+/// `demoted_txids` are records that lost their confirmation but are still
+/// expected to confirm again (e.g. demoted from `InBlock` to `Mempool` or
+/// kept as `InstantSend`). `conflicted_txids` are records demoted to a
+/// terminal inactive state (`Conflicted` or `Abandoned`). Self-conflict
+/// detection is deferred, so `conflicted_txids` is currently always
+/// empty (see issue 146).
+#[derive(Debug, Default, Clone)]
+pub struct RewindResult {
+    /// Transactions demoted to an active-but-unconfirmed context
+    /// (`Mempool` or `InstantSend`).
+    pub demoted_txids: Vec<Txid>,
+    /// Transactions demoted to `Conflicted` or `Abandoned`. Reserved for
+    /// the follow-up self-conflict detection work.
+    pub conflicted_txids: Vec<Txid>,
+}
+
+/// Failure cases for [`WalletInterface::rewind_to_height`].
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum RewindError {
+    /// The requested rewind height crosses a chainlock boundary that has
+    /// already been applied to one or more wallets. Rewinding below the
+    /// chainlock floor would invalidate finality that consumers have
+    /// already observed, so the operation is rejected.
+    #[error(
+        "rewind to height {requested} crosses chainlock floor at {floor} for wallet {wallet_id:?}"
+    )]
+    BelowChainLockFloor {
+        /// The height the caller asked to rewind to.
+        requested: CoreBlockHeight,
+        /// The wallet's `last_applied_chain_lock.block_height`.
+        floor: CoreBlockHeight,
+        /// The wallet whose chainlock floor was crossed.
+        wallet_id: crate::WalletId,
+    },
+}
+
 /// Result of processing a block through the wallet
 #[derive(Debug, Default, Clone)]
 pub struct BlockProcessingResult {
@@ -147,6 +189,42 @@ pub trait WalletInterface: Send + Sync + 'static {
     /// so eagerly during ordinary operation, not from inside this call, so the
     /// startup path remains infallible.
     async fn clamp_heights_to(&mut self, _tip: CoreBlockHeight) {}
+
+    /// Roll every managed wallet back to `height` after a chain reorg.
+    ///
+    /// Demotes confirmed records mined above `height` (and their
+    /// in-account spend descendants) back to a pre-confirmation context,
+    /// rebuilds per-account UTXO state and spent-outpoint tracking from
+    /// the surviving records, and rolls each wallet's
+    /// `last_processed_height` and `synced_height` back to `min(height,
+    /// current)`. A single [`WalletEvent::Reorg`] is emitted carrying the
+    /// fork height plus the partitioned demoted-vs-conflicted txid lists.
+    ///
+    /// Refuses to operate when `height` is strictly below any wallet's
+    /// `last_applied_chain_lock.block_height`. Crossing the chainlock
+    /// floor would invalidate finality consumers have already observed.
+    /// The SPV side's reorg cascade enforces the same invariant
+    /// upstream, so this branch is defense-in-depth.
+    ///
+    /// The `&mut self` receiver is the trait-level lock contract: while
+    /// a rewind is in flight no other `WalletInterface` mutator
+    /// (`process_block_for_wallets`, `process_mempool_transaction`,
+    /// `apply_chain_lock`, …) can run concurrently. Implementations must
+    /// not internally yield the lock mid-rewind.
+    async fn rewind_to_height(
+        &mut self,
+        height: CoreBlockHeight,
+    ) -> Result<RewindResult, RewindError>;
+
+    /// Look up a transaction stored in any managed wallet by txid.
+    ///
+    /// Returns `None` when the txid is not present in any wallet, or
+    /// when it has been pruned (default `keep-finalized-transactions=OFF`
+    /// drops the full record once a chainlock lands and retains only the
+    /// txid marker). Used by the auto-rebroadcast path that re-submits
+    /// rewound transactions to the mempool after a reorg, where the
+    /// caller needs the raw bytes of demoted records.
+    async fn get_transaction(&self, txid: &Txid) -> Option<Transaction>;
 
     /// Return a revision counter that increments whenever the set of monitored
     /// addresses or watched outpoints changes. The mempool manager uses this to

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -49,7 +49,7 @@ pub enum RewindError {
         /// The wallet's `last_applied_chain_lock.block_height`.
         floor: CoreBlockHeight,
         /// The wallet whose chainlock floor was crossed.
-        wallet_id: crate::WalletId,
+        wallet_id: WalletId,
     },
 }
 

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -507,6 +507,130 @@ impl ManagedCoreFundsAccount {
         self.keys.apply_chain_lock(cl_height)
     }
 
+    /// Demote every transaction record on this account whose mined
+    /// height is strictly greater than `height` back to a
+    /// pre-confirmation context, and return the demoted txids in the
+    /// order they were visited (highest height first).
+    ///
+    /// `InBlock` / `InChainLockedBlock` above the cut are demoted to
+    /// [`TransactionContext::Mempool`]. Records currently in
+    /// `InstantSend` are retained as-is even when their (formerly
+    /// confirmed) block height is above the cut, since the IS lock
+    /// itself is independent of the demoted block. Re-validating the
+    /// IS lock against the post-reorg quorum set is the caller's
+    /// responsibility (the wallet has no view of the masternode list).
+    /// Records already in an inactive context (`Conflicted`,
+    /// `Abandoned`) are left alone.
+    ///
+    /// This routine only mutates `transactions`. UTXO / spent-outpoint
+    /// state must be rebuilt afterwards via [`Self::rebuild_utxos`]
+    /// once the wallet-level descendant cascade has fully converged,
+    /// so the rebuild observes the final post-rewind context for every
+    /// record.
+    pub(crate) fn demote_records_above(&mut self, height: CoreBlockHeight) -> Vec<Txid> {
+        let mut demoted = Vec::new();
+        let to_demote: Vec<Txid> = self
+            .keys
+            .transactions()
+            .iter()
+            .filter_map(|(txid, record)| match record.context.block_info() {
+                Some(info) if info.height() > height => Some(*txid),
+                _ => None,
+            })
+            .collect();
+        for txid in to_demote {
+            if let Some(record) = self.keys.transactions_mut().get_mut(&txid) {
+                record.update_context(TransactionContext::Mempool);
+                demoted.push(txid);
+            }
+        }
+        demoted
+    }
+
+    /// Demote a specific transaction by txid to `Mempool` (used for
+    /// the wallet-level descendant cascade). Returns `true` when the
+    /// record existed and was actually demoted (i.e. was not already
+    /// in `Mempool` / `InstantSend` / inactive).
+    pub(crate) fn demote_record(&mut self, txid: &Txid) -> bool {
+        let Some(record) = self.keys.transactions_mut().get_mut(txid) else {
+            return false;
+        };
+        if record.context.block_info().is_none() {
+            return false;
+        }
+        record.update_context(TransactionContext::Mempool);
+        true
+    }
+
+    /// Drop the cached UTXO set and spent-outpoint tracking, then
+    /// rebuild both from the current `transactions` map in height
+    /// order. Mirrors the post-deserialization rebuild used by the
+    /// serde `Deserialize` impl.
+    ///
+    /// Records with an inactive context (`Conflicted`, `Abandoned`) are
+    /// excluded from both the UTXO inserts and the spent-outpoint
+    /// inserts so their outputs do not pollute the spendable set and
+    /// their inputs do not block predecessor UTXOs from being
+    /// re-credited.
+    pub(crate) fn rebuild_utxos(&mut self) {
+        self.utxos.clear();
+        self.spent_outpoints.clear();
+        if !matches!(
+            self.keys.managed_account_type(),
+            ManagedAccountType::Standard { .. }
+                | ManagedAccountType::CoinJoin { .. }
+                | ManagedAccountType::DashpayReceivingFunds { .. }
+                | ManagedAccountType::DashpayExternalAccount { .. }
+        ) {
+            self.keys.bump_monitor_revision();
+            return;
+        }
+
+        let network = self.keys.network();
+        let mut records: Vec<&TransactionRecord> = self
+            .keys
+            .transactions()
+            .values()
+            .filter(|record| !record.context.is_inactive())
+            .collect();
+        records.sort_by_key(|record| record.context.block_info().map(|info| info.height()));
+
+        for record in records {
+            let tx = &record.transaction;
+            let txid = tx.txid();
+            let context = &record.context;
+
+            for (vout, output) in tx.output.iter().enumerate() {
+                let Ok(addr) = Address::from_script(&output.script_pubkey, network) else {
+                    continue;
+                };
+                if !self.keys.managed_account_type().contains_address(&addr) {
+                    continue;
+                }
+                let outpoint = OutPoint {
+                    txid,
+                    vout: vout as u32,
+                };
+                let txout = dashcore::TxOut {
+                    value: output.value,
+                    script_pubkey: output.script_pubkey.clone(),
+                };
+                let block_height = context.block_info().map_or(0, |info| info.height);
+                let mut utxo = Utxo::new(outpoint, txout, addr, block_height, tx.is_coin_base());
+                utxo.is_confirmed = context.confirmed();
+                utxo.is_instantlocked = matches!(context, TransactionContext::InstantSend(_));
+                self.utxos.insert(outpoint, utxo);
+            }
+
+            for input in &tx.input {
+                self.spent_outpoints.insert(input.previous_output);
+                self.utxos.remove(&input.previous_output);
+            }
+        }
+
+        self.keys.bump_monitor_revision();
+    }
+
     /// Update the account balance.
     ///
     /// Mature, non-locked UTXOs land in either the `confirmed` bucket

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -600,6 +600,9 @@ impl ManagedCoreFundsAccount {
             let txid = tx.txid();
             let context = &record.context;
 
+            let has_owned_input =
+                tx.input.iter().any(|input| self.spent_outpoints.contains(&input.previous_output));
+
             for (vout, output) in tx.output.iter().enumerate() {
                 let Ok(addr) = Address::from_script(&output.script_pubkey, network) else {
                     continue;
@@ -611,6 +614,19 @@ impl ManagedCoreFundsAccount {
                     txid,
                     vout: vout as u32,
                 };
+                // Order-independence: a record processed earlier in the
+                // sort may have already claimed this outpoint as spent.
+                // Inserting now would resurrect a spent UTXO into the
+                // spendable set.
+                if self.spent_outpoints.contains(&outpoint) {
+                    continue;
+                }
+                let is_change = self
+                    .keys
+                    .managed_account_type()
+                    .address_pools()
+                    .iter()
+                    .any(|pool| pool.is_internal() && pool.contains_address(&addr));
                 let txout = dashcore::TxOut {
                     value: output.value,
                     script_pubkey: output.script_pubkey.clone(),
@@ -619,6 +635,7 @@ impl ManagedCoreFundsAccount {
                 let mut utxo = Utxo::new(outpoint, txout, addr, block_height, tx.is_coin_base());
                 utxo.is_confirmed = context.confirmed();
                 utxo.is_instantlocked = matches!(context, TransactionContext::InstantSend(_));
+                utxo.is_trusted = has_owned_input && is_change;
                 self.utxos.insert(outpoint, utxo);
             }
 

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -572,13 +572,35 @@ impl ManagedCoreFundsAccount {
             .collect();
         records.sort_by_key(|record| record.context.block_info().map(|info| info.height()));
 
+        // Collect every owned outpoint up front so `has_owned_input` below
+        // is independent of record visit order. The in-loop `spent_outpoints`
+        // set cannot serve here: it only sees already-processed inputs, so a
+        // mempool child sorted before its block parent would observe an
+        // empty set and miss the trusted-change signal.
+        let account_type = self.keys.managed_account_type();
+        let mut owned_outpoints: HashSet<OutPoint> = HashSet::new();
+        for record in &records {
+            let txid = record.transaction.txid();
+            for (vout, output) in record.transaction.output.iter().enumerate() {
+                let Ok(addr) = Address::from_script(&output.script_pubkey, network) else {
+                    continue;
+                };
+                if account_type.contains_address(&addr) {
+                    owned_outpoints.insert(OutPoint {
+                        txid,
+                        vout: vout as u32,
+                    });
+                }
+            }
+        }
+
         for record in records {
             let tx = &record.transaction;
             let txid = tx.txid();
             let context = &record.context;
 
             let has_owned_input =
-                tx.input.iter().any(|input| self.spent_outpoints.contains(&input.previous_output));
+                tx.input.iter().any(|input| owned_outpoints.contains(&input.previous_output));
 
             for (vout, output) in tx.output.iter().enumerate() {
                 let Ok(addr) = Address::from_script(&output.script_pubkey, network) else {

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -528,23 +528,7 @@ impl ManagedCoreFundsAccount {
     /// so the rebuild observes the final post-rewind context for every
     /// record.
     pub(crate) fn demote_records_above(&mut self, height: CoreBlockHeight) -> Vec<Txid> {
-        let mut demoted = Vec::new();
-        let to_demote: Vec<Txid> = self
-            .keys
-            .transactions()
-            .iter()
-            .filter_map(|(txid, record)| match record.context.block_info() {
-                Some(info) if info.height() > height => Some(*txid),
-                _ => None,
-            })
-            .collect();
-        for txid in to_demote {
-            if let Some(record) = self.keys.transactions_mut().get_mut(&txid) {
-                record.update_context(TransactionContext::Mempool);
-                demoted.push(txid);
-            }
-        }
-        demoted
+        self.keys.demote_records_above(height)
     }
 
     /// Demote a specific transaction by txid to `Mempool` (used for
@@ -552,14 +536,7 @@ impl ManagedCoreFundsAccount {
     /// record existed and was actually demoted (i.e. was not already
     /// in `Mempool` / `InstantSend` / inactive).
     pub(crate) fn demote_record(&mut self, txid: &Txid) -> bool {
-        let Some(record) = self.keys.transactions_mut().get_mut(txid) else {
-            return false;
-        };
-        if record.context.block_info().is_none() {
-            return false;
-        }
-        record.update_context(TransactionContext::Mempool);
-        true
+        self.keys.demote_record(txid)
     }
 
     /// Drop the cached UTXO set and spent-outpoint tracking, then

--- a/key-wallet/src/managed_account/managed_core_keys_account.rs
+++ b/key-wallet/src/managed_account/managed_core_keys_account.rs
@@ -149,6 +149,47 @@ impl ManagedCoreKeysAccount {
         promoted
     }
 
+    /// Demote every transaction record whose mined height is strictly
+    /// greater than `height` back to [`TransactionContext::Mempool`]
+    /// and return the demoted txids. Mirrors
+    /// [`ManagedCoreFundsAccount::demote_records_above`] for the
+    /// keys-only side, where there is no UTXO state to rebuild.
+    ///
+    /// Records currently in `InstantSend`, `Conflicted`, or
+    /// `Abandoned` are left alone (see `demote_records_above` for the
+    /// rationale).
+    pub(crate) fn demote_records_above(&mut self, height: CoreBlockHeight) -> Vec<Txid> {
+        let mut demoted = Vec::new();
+        let to_demote: Vec<Txid> = self
+            .transactions
+            .iter()
+            .filter_map(|(txid, record)| match record.context.block_info() {
+                Some(info) if info.height() > height => Some(*txid),
+                _ => None,
+            })
+            .collect();
+        for txid in to_demote {
+            if let Some(record) = self.transactions.get_mut(&txid) {
+                record.update_context(TransactionContext::Mempool);
+                demoted.push(txid);
+            }
+        }
+        demoted
+    }
+
+    /// Demote a specific transaction by txid to `Mempool`. Returns
+    /// `true` when the record existed and was actually demoted.
+    pub(crate) fn demote_record(&mut self, txid: &Txid) -> bool {
+        let Some(record) = self.transactions.get_mut(txid) else {
+            return false;
+        };
+        if record.context.block_info().is_none() {
+            return false;
+        }
+        record.update_context(TransactionContext::Mempool);
+        true
+    }
+
     /// Create a `ManagedCoreKeysAccount` from an [`Account`](super::super::Account).
     pub fn from_account(account: &super::super::Account) -> Self {
         let key_source = address_pool::KeySource::Public(account.account_xpub);

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -224,10 +224,8 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// [`RewindRejection::BelowChainLockFloor`] in that case.
     fn rewind_to_height(
         &mut self,
-        _height: CoreBlockHeight,
-    ) -> Result<RewindOutcome, RewindRejection> {
-        Ok(RewindOutcome::default())
-    }
+        height: CoreBlockHeight,
+    ) -> Result<RewindOutcome, RewindRejection>;
 
     /// Update chain state and process any matured transactions
     /// This should be called when the chain tip advances to a new height
@@ -483,12 +481,17 @@ impl WalletInfoInterface for ManagedWalletInfo {
         // their outputs, so any in-wallet transaction (possibly on a
         // different account) whose inputs spend those outputs must
         // also demote. Iterate to a fixed point.
+        //
+        // `frontier` carries only the txids demoted in the previous
+        // wave: any newly reachable descendant must spend an output of
+        // that wave, so re-scanning earlier waves would be wasted work.
         let mut already_demoted: BTreeSet<Txid> = demoted_txids.iter().copied().collect();
+        let mut frontier: Vec<Txid> = demoted_txids.clone();
         loop {
             let mut released_outpoints: BTreeSet<OutPoint> = BTreeSet::new();
             for account in self.accounts.all_accounts() {
                 let txs = account.transactions();
-                for txid in &already_demoted {
+                for txid in &frontier {
                     if let Some(record) = txs.get(txid) {
                         for vout in 0..record.transaction.output.len() as u32 {
                             released_outpoints.insert(OutPoint {
@@ -538,7 +541,8 @@ impl WalletInfoInterface for ManagedWalletInfo {
             for txid in &new_demoted {
                 already_demoted.insert(*txid);
             }
-            demoted_txids.extend(new_demoted);
+            demoted_txids.extend(new_demoted.iter().copied());
+            frontier = new_demoted;
         }
 
         // UTXO rebuild on every funds account so the spendable set

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -33,8 +33,8 @@ pub struct RewindOutcome {
     /// self-conflict detection work; currently always empty.
     pub conflicted_txids: Vec<Txid>,
     /// `true` iff this wallet's `last_processed_height` was rolled back
-    /// (or any record was demoted). Lets the caller filter wallets that
-    /// were untouched by the reorg out of the event stream.
+    /// or any record was demoted; `false` when the reorg had no
+    /// observable effect on this wallet's state.
     pub state_changed: bool,
 }
 
@@ -213,11 +213,11 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// `min(height, current)`. Refreshes cached balances.
     ///
     /// `used_addresses` markers on every address pool are intentionally
-    /// preserved. Address usage is monotonic from a wallet's
-    /// perspective — even if the reorg removes the on-chain evidence
-    /// for that usage, the user has still committed the addresses and
-    /// could publish them again. Resurrecting unused addresses also
-    /// risks recycling them across separate counterparties.
+    /// preserved. Address usage is monotonic from a wallet's perspective:
+    /// even if the reorg removes the on-chain evidence for that usage,
+    /// the user has still committed the addresses and could publish them
+    /// again. Resurrecting unused addresses also risks recycling them
+    /// across separate counterparties.
     ///
     /// Refuses the rewind when `height` is strictly below this
     /// wallet's `last_applied_chain_lock.block_height` and returns

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -16,7 +16,41 @@ use crate::{Network, Utxo, Wallet, WalletCoreBalance};
 use dashcore::ephemerealdata::chain_lock::ChainLock;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
-use dashcore::{Address as DashAddress, Transaction, Txid};
+use dashcore::{Address as DashAddress, OutPoint, Transaction, Txid};
+
+/// Outcome of [`WalletInfoInterface::rewind_to_height`].
+///
+/// Captures the per-wallet rewind effects so the manager-level emitter
+/// (in `key-wallet-manager`) can fire a single atomic
+/// `WalletEvent::Reorg` per wallet whose state changed.
+#[derive(Debug, Clone, Default)]
+pub struct RewindOutcome {
+    /// Records demoted to an active-but-unconfirmed context
+    /// (`Mempool` or retained `InstantSend`).
+    pub demoted_txids: Vec<Txid>,
+    /// Records demoted to a terminal inactive context
+    /// (`Conflicted` / `Abandoned`). Reserved for the follow-up
+    /// self-conflict detection work; currently always empty.
+    pub conflicted_txids: Vec<Txid>,
+    /// `true` iff this wallet's `last_processed_height` was rolled back
+    /// (or any record was demoted). Lets the caller filter wallets that
+    /// were untouched by the reorg out of the event stream.
+    pub state_changed: bool,
+}
+
+/// Why a [`WalletInfoInterface::rewind_to_height`] call rejected the rewind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RewindRejection {
+    /// `height` is strictly below this wallet's
+    /// `last_applied_chain_lock.block_height`. Crossing the chainlock
+    /// floor would invalidate finality the wallet has already accepted.
+    BelowChainLockFloor {
+        /// The height the caller asked to rewind to.
+        requested: CoreBlockHeight,
+        /// The wallet's chainlock floor.
+        floor: CoreBlockHeight,
+    },
+}
 
 /// Outcome of [`WalletInfoInterface::apply_chain_lock`].
 ///
@@ -167,6 +201,32 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// records disappear.
     fn apply_chain_lock(&mut self, _chain_lock: ChainLock) -> ApplyChainLockOutcome {
         ApplyChainLockOutcome::default()
+    }
+
+    /// Roll this wallet back to `height` after a chain reorg.
+    ///
+    /// Demotes every confirmed record on every account whose mined
+    /// block height is strictly greater than `height`, plus the
+    /// transitive in-wallet spend descendants of those records.
+    /// Rebuilds per-account UTXO state from the surviving records.
+    /// Clamps `last_processed_height` and `synced_height` to
+    /// `min(height, current)`. Refreshes cached balances.
+    ///
+    /// `used_addresses` markers on every address pool are intentionally
+    /// preserved. Address usage is monotonic from a wallet's
+    /// perspective — even if the reorg removes the on-chain evidence
+    /// for that usage, the user has still committed the addresses and
+    /// could publish them again. Resurrecting unused addresses also
+    /// risks recycling them across separate counterparties.
+    ///
+    /// Refuses the rewind when `height` is strictly below this
+    /// wallet's `last_applied_chain_lock.block_height` and returns
+    /// [`RewindRejection::BelowChainLockFloor`] in that case.
+    fn rewind_to_height(
+        &mut self,
+        _height: CoreBlockHeight,
+    ) -> Result<RewindOutcome, RewindRejection> {
+        Ok(RewindOutcome::default())
     }
 
     /// Update chain state and process any matured transactions
@@ -376,6 +436,137 @@ impl WalletInfoInterface for ManagedWalletInfo {
         self.metadata.last_processed_height = current_height;
         // Update cached balance
         self.update_balance();
+    }
+
+    fn rewind_to_height(
+        &mut self,
+        height: CoreBlockHeight,
+    ) -> Result<RewindOutcome, RewindRejection> {
+        if let Some(cl) = self.metadata.last_applied_chain_lock.as_ref() {
+            if height < cl.block_height {
+                return Err(RewindRejection::BelowChainLockFloor {
+                    requested: height,
+                    floor: cl.block_height,
+                });
+            }
+        }
+
+        // TODO(issue #146): self-conflict detection. Once the wallet
+        // can prove that an in-wallet record's inputs are spent by a
+        // surviving chain transaction, demote those records to
+        // `Conflicted { previous: .. }` and surface them via
+        // `conflicted_txids` instead of `demoted_txids`.
+        //
+        // TODO(issue #145, follow-up): ISLock-quorum re-validation.
+        // Records currently in `InstantSend(islock)` are retained
+        // through the rewind (their context carries no block height
+        // so the cut below does not touch them). If the post-reorg
+        // masternode list no longer contains the signing quorum the
+        // record's IS lock claims, the lock is no longer
+        // verifiable and the record should be demoted to `Mempool`.
+        // That decision requires masternode-list knowledge the
+        // wallet does not have, so the caller (SPV side) is expected
+        // to drive a follow-up demotion via the existing
+        // `process_mempool_transaction(tx, None)` path.
+        let mut demoted_txids: Vec<Txid> = Vec::new();
+        let conflicted_txids: Vec<Txid> = Vec::new();
+
+        for mut account in self.accounts.all_accounts_mut() {
+            let local = match &mut account {
+                ManagedAccountRefMut::Funds(funds) => funds.demote_records_above(height),
+                ManagedAccountRefMut::Keys(keys) => keys.demote_records_above(height),
+            };
+            demoted_txids.extend(local);
+        }
+
+        // Cross-account descendant cascade. Demoted records release
+        // their outputs, so any in-wallet transaction (possibly on a
+        // different account) whose inputs spend those outputs must
+        // also demote. Iterate to a fixed point.
+        let mut already_demoted: BTreeSet<Txid> = demoted_txids.iter().copied().collect();
+        loop {
+            let mut released_outpoints: BTreeSet<OutPoint> = BTreeSet::new();
+            for account in self.accounts.all_accounts() {
+                let txs = account.transactions();
+                for txid in &already_demoted {
+                    if let Some(record) = txs.get(txid) {
+                        for vout in 0..record.transaction.output.len() as u32 {
+                            released_outpoints.insert(OutPoint {
+                                txid: *txid,
+                                vout,
+                            });
+                        }
+                    }
+                }
+            }
+            if released_outpoints.is_empty() {
+                break;
+            }
+            let mut new_demoted: Vec<Txid> = Vec::new();
+            for mut account in self.accounts.all_accounts_mut() {
+                let candidates: Vec<Txid> = account
+                    .transactions()
+                    .iter()
+                    .filter(|(txid, record)| {
+                        if already_demoted.contains(*txid) {
+                            return false;
+                        }
+                        if record.context.is_inactive() {
+                            return false;
+                        }
+                        record
+                            .transaction
+                            .input
+                            .iter()
+                            .any(|input| released_outpoints.contains(&input.previous_output))
+                    })
+                    .map(|(txid, _)| *txid)
+                    .collect();
+                for txid in candidates {
+                    let did = match &mut account {
+                        ManagedAccountRefMut::Funds(funds) => funds.demote_record(&txid),
+                        ManagedAccountRefMut::Keys(keys) => keys.demote_record(&txid),
+                    };
+                    if did {
+                        new_demoted.push(txid);
+                    }
+                }
+            }
+            if new_demoted.is_empty() {
+                break;
+            }
+            for txid in &new_demoted {
+                already_demoted.insert(*txid);
+            }
+            demoted_txids.extend(new_demoted);
+        }
+
+        // UTXO rebuild on every funds account so the spendable set
+        // reflects the final post-rewind context for every record.
+        for funds in self.accounts.all_funding_accounts_mut() {
+            funds.rebuild_utxos();
+        }
+
+        let prior_last_processed = self.metadata.last_processed_height;
+        let prior_synced = self.metadata.synced_height;
+        let new_last_processed = prior_last_processed.min(height);
+        let new_synced = prior_synced.min(height);
+        self.metadata.last_processed_height = new_last_processed;
+        self.metadata.synced_height = new_synced;
+
+        // Refresh cached balances now that UTXOs and heights are settled.
+        self.update_balance();
+
+        let state_changed = !demoted_txids.is_empty()
+            || !conflicted_txids.is_empty()
+            || new_last_processed != prior_last_processed
+            || new_synced != prior_synced;
+
+        Ok(RewindOutcome {
+            demoted_txids,
+            conflicted_txids,
+            state_changed,
+        })
     }
 
     fn update_synced_height(&mut self, current_height: u32) {


### PR DESCRIPTION
## Summary

Phase 4b of [#137](https://github.com/xdustinface/rust-dashcore/issues/137). Builds on the `Conflicted` / `Abandoned` variants from [#144](https://github.com/xdustinface/rust-dashcore/issues/144) (merged in [#168](https://github.com/xdustinface/rust-dashcore/pull/168)).

- `WalletInterface::rewind_to_height(&mut self, height)` returning `RewindResult { demoted_txids, conflicted_txids }`. `&mut self` makes the lock contract compile-time.
- `WalletInterface::get_transaction(txid)` for the auto-rebroadcast path in [#146](https://github.com/xdustinface/rust-dashcore/issues/146).
- `ManagedAccountTrait` gains `rewind_to_height` with a fixed-point **descendant cascade**: walks `transactions` in reverse height order, demotes each record above the fork height, then iteratively demotes any in-account `TxB` whose inputs spend a demoted record's outputs.
- UTXO and `spent_outpoints` rebuild from the rewind point (full rebuild for v1, optimise later if profiling justifies).
- Rolls back `last_processed_height` and `synced_height` to `min(h, current)`, per-wallet and aggregated.
- Defense-in-depth: refuses rewind if `h < last_applied_chain_lock.height`, returns `RewindError::BelowChainLockFloor`.
- Emits `WalletEvent::Reorg { fork_height, demoted_txids, conflicted_txids }`.
- FFI exhaustive match arm in `dash-spv-ffi/src/callbacks.rs` handles the new event (full FFI callback surface deferred — TODO).
- 7 new `key-wallet-manager` tests cover single demotion, descendant chains, IS retention, chainlock floor refuse, persisted rollback, get_transaction lookup, lock contract.

### Deferred (per issue scope)

- **ISLock quorum re-validation:** the wallet crate has no access to the masternode list engine that lives in `dash-spv`. Records currently in `InstantSend(islock)` are retained through the cut-by-height filter (the safer half is automatic). Demoting an IS record whose signing quorum no longer exists post-reorg requires SPV-side wiring driven via `process_mempool_transaction(tx, None)`. TODO comment in `wallet_info_interface.rs`.
- **SPV-side `SyncEvent::ChainReorg` → `rewind_to_height` plumbing** lives in a follow-up — not in this PR's task list. Existing SPV reorg handlers don't call into the wallet today, so adding the method doesn't break downstream.
- **Self-conflict detection** (mark `Conflicted` rather than `Mempool` when a new-chain block spends the same input as a demoted outgoing tx) deferred to [#146](https://github.com/xdustinface/rust-dashcore/issues/146). TODO comment in code.
- **Dedicated FFI callback for `WalletEvent::Reorg`** scoped out — exhaustive match arm consumes/drops the event with a TODO so the C ABI keeps compiling.

### Verification

- `cargo fmt --check` clean
- `cargo clippy --all-targets -p key-wallet -p key-wallet-manager -p dash-spv -p dash-spv-ffi -- -D warnings` clean
- `cargo test --lib -p key-wallet -p key-wallet-manager -p dash-spv` all pass (487 + 53 + 538)
- `pre-commit run --all-files --hook-stage pre-push` all hooks pass

Closes [#145](https://github.com/xdustinface/rust-dashcore/issues/145).