### PR TITLE
feat(dash-spv): filter re-match across reorg and safe auto-rebroadcast

### DIFF
--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -1215,6 +1215,14 @@ impl FFIWalletEventCallbacks {
                 // conflicted txid lists and the post-rewind balance.
                 // Until then this variant has no surface on the C ABI.
             }
+            WalletEvent::TxRepeatedlyOrphaned {
+                ..
+            } => {
+                // TODO(issue #146): wire a dedicated FFI callback so
+                // durable consumers can surface "this transaction has
+                // been orphaned too many times" to the UI. Until then
+                // this variant has no surface on the C ABI.
+            }
             WalletEvent::ChainLockProcessed {
                 wallet_id,
                 chain_lock,

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -163,12 +163,16 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         // Build mempool manager if tracking is enabled
         if config.enable_mempool_tracking {
             let initial_revision = wallet.read().await.monitor_revision();
-            managers.mempool = Some(MempoolManager::new(
+            let wallet_event_rx = wallet.read().await.subscribe_events();
+            let mut mempool = MempoolManager::new(
                 wallet.clone(),
                 config.mempool_strategy,
                 config.max_mempool_transactions,
                 initial_revision,
-            ));
+                chainlock_height.clone(),
+            );
+            mempool.set_wallet_event_subscription(wallet_event_rx);
+            managers.mempool = Some(mempool);
         }
 
         // `reorg_generation` is held by each manager (via clones threaded in

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -2436,9 +2436,6 @@ mod tests {
         );
     }
 
-    /// Wallet whose `synced_height` is already behind `fork_height`
-    /// should drive the effective floor below `fork_height`. The
-    /// post-rewind floor is `min(wallet.synced_height, fork_height)`.
     #[tokio::test]
     async fn test_rewind_wallet_for_reorg_uses_min_of_wallet_and_fork() {
         let manager = create_test_manager().await;
@@ -2452,9 +2449,6 @@ mod tests {
         );
     }
 
-    /// Wallet whose `synced_height` is above `fork_height` should be
-    /// clamped to `fork_height` by the rewind, and the effective floor
-    /// is then `fork_height`.
     #[tokio::test]
     async fn test_rewind_wallet_for_reorg_clamps_to_fork_height() {
         let manager = create_test_manager().await;

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -149,16 +149,46 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         self.filter_pipeline = FiltersPipeline::new();
     }
 
-    /// Reset all sync state to begin again at `fork_height` after a reorg
-    /// cascade. Clears in-flight batches and rewinds the per-batch
+    /// Drive the per-wallet rewind and compute the effective floor for
+    /// the filter re-match. Returns the lowest per-wallet `synced_height`
+    /// after the rewind clamps each wallet to `min(fork_height, current)`.
+    ///
+    /// The chainlock-floor invariant is enforced upstream by the reorg
+    /// cascade, so a `BelowChainLockFloor` error here is defense in
+    /// depth: log and fall back to `fork_height` for the floor without
+    /// touching wallet state.
+    pub(super) async fn rewind_wallet_for_reorg(&self, fork_height: u32) -> u32 {
+        let mut wallet = self.wallet.write().await;
+        match wallet.rewind_to_height(fork_height).await {
+            Ok(_) => wallet.synced_height().min(fork_height),
+            Err(e) => {
+                tracing::warn!(
+                    "FiltersManager: wallet rewind to {} rejected: {}; using fork_height as floor",
+                    fork_height,
+                    e
+                );
+                fork_height
+            }
+        }
+    }
+
+    /// Reset all sync state to begin again at `effective_floor` after a
+    /// reorg cascade. Clears in-flight batches and rewinds the per-batch
     /// processing cursors so the next `FilterHeadersStored` event drives a
-    /// fresh download starting at the truncated ancestor.
-    pub(super) fn reset_for_reorg(&mut self, fork_height: u32) {
+    /// fresh download starting at the effective floor.
+    ///
+    /// `effective_floor` is the minimum of `fork_height` and the lowest
+    /// per-wallet `synced_height` across the wallet set, computed after
+    /// the wallet rewind. A wallet whose ingest tip is behind the fork
+    /// point never saw the orphaned chain, so the filter pipeline does
+    /// not need to re-match the segment between that wallet's tip and
+    /// the fork.
+    pub(super) fn reset_for_reorg(&mut self, effective_floor: u32) {
         self.reset_for_rescan();
-        self.next_batch_to_store = fork_height;
-        self.processing_height = fork_height;
-        self.progress.update_committed_height(fork_height);
-        self.progress.update_stored_height(fork_height);
+        self.next_batch_to_store = effective_floor;
+        self.processing_height = effective_floor;
+        self.progress.update_committed_height(effective_floor);
+        self.progress.update_stored_height(effective_floor);
     }
 
     async fn load_filters(
@@ -2403,6 +2433,43 @@ mod tests {
             )),
             "expected FiltersSyncComplete, got {:?}",
             events
+        );
+    }
+
+    /// Wallet whose `synced_height` is already behind `fork_height`
+    /// should drive the effective floor below `fork_height`. The
+    /// post-rewind floor is `min(wallet.synced_height, fork_height)`.
+    #[tokio::test]
+    async fn test_rewind_wallet_for_reorg_uses_min_of_wallet_and_fork() {
+        let manager = create_test_manager().await;
+        manager.wallet.write().await.update_wallet_synced_height(&MOCK_WALLET_ID, 40);
+
+        let effective_floor = manager.rewind_wallet_for_reorg(100).await;
+
+        assert_eq!(
+            effective_floor, 40,
+            "wallet behind fork_height should drag floor down to its synced_height"
+        );
+    }
+
+    /// Wallet whose `synced_height` is above `fork_height` should be
+    /// clamped to `fork_height` by the rewind, and the effective floor
+    /// is then `fork_height`.
+    #[tokio::test]
+    async fn test_rewind_wallet_for_reorg_clamps_to_fork_height() {
+        let manager = create_test_manager().await;
+        manager.wallet.write().await.update_wallet_synced_height(&MOCK_WALLET_ID, 200);
+
+        let effective_floor = manager.rewind_wallet_for_reorg(100).await;
+
+        assert_eq!(
+            effective_floor, 100,
+            "wallet ahead of fork_height should be clamped and floor equals fork_height"
+        );
+        assert_eq!(
+            manager.wallet.read().await.wallet_synced_height(&MOCK_WALLET_ID),
+            100,
+            "rewind must clamp wallet's synced_height to fork_height"
         );
     }
 }

--- a/dash-spv/src/sync/filters/sync_manager.rs
+++ b/dash-spv/src/sync/filters/sync_manager.rs
@@ -190,10 +190,15 @@ impl<
                 ..
             } => {
                 tracing::info!(
-                    "FiltersManager: cascading ChainReorg, resetting state at {}",
+                    "FiltersManager: cascading ChainReorg, rewinding wallet at {}",
                     fork_height
                 );
-                self.reset_for_reorg(*fork_height);
+                let effective_floor = self.rewind_wallet_for_reorg(*fork_height).await;
+                tracing::info!(
+                    "FiltersManager: re-matching filters from effective floor {}",
+                    effective_floor
+                );
+                self.reset_for_reorg(effective_floor);
                 self.set_state(SyncState::WaitForEvents);
                 return Ok(vec![]);
             }

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -4,18 +4,19 @@
 //! filters or local address matching to identify wallet-relevant
 //! transactions from the mempool.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::network::message::NetworkMessage;
 use dashcore::network::message_blockdata::Inventory;
-use dashcore::{Amount, Transaction, Txid};
+use dashcore::{Amount, OutPoint, Transaction, Txid};
 use rand::seq::IteratorRandom;
-use tokio::sync::RwLock;
+use tokio::sync::{broadcast, RwLock};
 
 use super::filter::build_wallet_bloom_filter;
 use super::BLOOM_FALSE_POSITIVE_RATE;
@@ -25,7 +26,7 @@ use crate::network::RequestSender;
 use crate::sync::mempool::MempoolProgress;
 use crate::sync::SyncEvent;
 use crate::types::UnconfirmedTransaction;
-use key_wallet_manager::WalletInterface;
+use key_wallet_manager::{WalletEvent, WalletInterface};
 
 /// Timeout for pruning expired mempool transactions (24 hours).
 pub(super) const MEMPOOL_TX_EXPIRY: Duration = Duration::from_secs(24 * 3600);
@@ -45,6 +46,85 @@ const SEEN_TXID_EXPIRY: Duration = Duration::from_secs(180);
 
 /// Per-transaction interval between rebroadcast attempts (10 minutes).
 const REBROADCAST_INTERVAL: Duration = Duration::from_secs(600);
+
+/// Maximum number of attempts the reorg-driven rebroadcaster will make
+/// before giving up on a single demoted txid. Once exceeded, the txid
+/// is dropped from the pending set and a `TxRepeatedlyOrphaned` event
+/// is emitted so the UI can surface it for user intervention.
+const MAX_REORG_REBROADCAST_ATTEMPTS: u32 = 10;
+
+/// First delay between attempts to rebroadcast a single demoted txid.
+/// Doubles up to a cap after each failure so a flaky peer or a brief
+/// network partition does not spam the wire.
+const REORG_REBROADCAST_INITIAL_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Upper bound on the exponential backoff between attempts.
+const REORG_REBROADCAST_MAX_BACKOFF: Duration = Duration::from_secs(3600);
+
+/// State tracked per demoted txid awaiting auto-rebroadcast.
+#[derive(Debug)]
+pub(super) struct RebroadcastState {
+    /// Wallet that owns the demoted record, used to scope the
+    /// `TxRepeatedlyOrphaned` event when the retry cap fires.
+    wallet_id: key_wallet_manager::WalletId,
+    /// Outpoints the transaction consumes. Used by the input-conflict
+    /// check to drop the entry when another transaction landing on the
+    /// new chain spends one of the same outpoints.
+    inputs: HashSet<OutPoint>,
+    /// Locktime the transaction declares. Block-height locktimes
+    /// (`< LOCKTIME_THRESHOLD`) are checked against the new chain
+    /// tip; timestamp locktimes (`>= LOCKTIME_THRESHOLD`) are
+    /// deferred best-effort against the current wall-clock since
+    /// the SPV path does not maintain an MTP cache.
+    lock_time: u32,
+    /// Number of rebroadcast attempts already made.
+    attempts: u32,
+    /// Earliest `Instant` at which the next attempt may run.
+    next_attempt: Instant,
+}
+
+/// Threshold separating block-height and unix-timestamp locktimes per
+/// BIP-65. Values strictly below are interpreted as block heights;
+/// values at or above are unix timestamps.
+const LOCKTIME_THRESHOLD: u32 = 500_000_000;
+
+impl RebroadcastState {
+    fn new(wallet_id: key_wallet_manager::WalletId, tx: &Transaction, now: Instant) -> Self {
+        Self {
+            wallet_id,
+            inputs: tx.input.iter().map(|i| i.previous_output).collect(),
+            lock_time: tx.lock_time,
+            attempts: 0,
+            next_attempt: now,
+        }
+    }
+
+    fn backoff_for_attempt(attempt: u32) -> Duration {
+        let secs =
+            REORG_REBROADCAST_INITIAL_BACKOFF.as_secs().saturating_mul(1u64 << attempt.min(20));
+        Duration::from_secs(secs).min(REORG_REBROADCAST_MAX_BACKOFF)
+    }
+
+    /// Returns true when the transaction's `nLockTime` is satisfied
+    /// against `tip_height` and `now` (block-height vs timestamp
+    /// locktime per BIP-65).
+    fn locktime_satisfied(&self, tip_height: u32, now: std::time::SystemTime) -> bool {
+        if self.lock_time == 0 {
+            return true;
+        }
+        if self.lock_time < LOCKTIME_THRESHOLD {
+            self.lock_time <= tip_height
+        } else {
+            // SPV side has no MTP cache. Compare best-effort against
+            // wall clock: a stricter MTP-based check would only delay
+            // broadcast further, never accept too early, since wall
+            // clock >= MTP.
+            now.duration_since(std::time::UNIX_EPOCH)
+                .map(|d| self.lock_time as u64 <= d.as_secs())
+                .unwrap_or(false)
+        }
+    }
+}
 
 /// Mempool manager that monitors unconfirmed transactions from the P2P network.
 ///
@@ -71,6 +151,21 @@ pub(crate) struct MempoolManager<W: WalletInterface> {
     /// Wallet monitor revision at the time of the last filter build.
     /// Compared on each tick to detect when the wallet's monitored set has changed.
     pub(super) last_monitor_revision: u64,
+    /// Reorg-driven rebroadcast queue keyed by demoted txid.
+    pub(super) pending_rebroadcast: HashMap<Txid, RebroadcastState>,
+    /// Subscription to `WalletEvent` broadcasts, drained on each tick to
+    /// pick up `Reorg` events and to observe new-chain confirmations for
+    /// the input-conflict check.
+    wallet_event_rx: broadcast::Receiver<WalletEvent>,
+    /// Sender used to emit `TxRepeatedlyOrphaned` events back into the
+    /// wallet event stream when the retry cap fires.
+    wallet_event_tx: broadcast::Sender<WalletEvent>,
+    /// Current chain tip height, updated via `update_target_height`.
+    /// Used for block-height locktime checks during rebroadcast.
+    pub(super) current_tip_height: u32,
+    /// Shared chainlock-floor height. Defense-in-depth: a tx confirmed
+    /// in a chainlocked block must never be queued for rebroadcast.
+    chainlock_height: Arc<AtomicU32>,
 }
 
 impl<W: WalletInterface> MempoolManager<W> {
@@ -81,7 +176,15 @@ impl<W: WalletInterface> MempoolManager<W> {
         strategy: MempoolStrategy,
         max_transactions: usize,
         initial_monitor_revision: u64,
+        chainlock_height: Arc<AtomicU32>,
     ) -> Self {
+        // The wallet exposes a single broadcast `Sender`, but we need to
+        // both subscribe (for `Reorg` and `BlockProcessed` events that
+        // drive the rebroadcaster) and emit (for `TxRepeatedlyOrphaned`
+        // when the retry cap fires). Create an independent forwarder
+        // channel so we can do both without changing the trait surface.
+        // Wallet → forwarder is wired in `set_wallet_event_subscription`.
+        let (wallet_event_tx, wallet_event_rx) = broadcast::channel(1024);
         Self {
             progress: MempoolProgress::default(),
             wallet,
@@ -94,7 +197,28 @@ impl<W: WalletInterface> MempoolManager<W> {
             pending_is_locks: HashMap::new(),
             seen_txids: HashMap::new(),
             last_monitor_revision: initial_monitor_revision,
+            pending_rebroadcast: HashMap::new(),
+            wallet_event_rx,
+            wallet_event_tx,
+            current_tip_height: 0,
+            chainlock_height,
         }
+    }
+
+    /// Replace the manager's internal `WalletEvent` subscription with a
+    /// fresh receiver. Call this after `new` if the manager must observe
+    /// the wallet's own broadcast channel directly instead of the
+    /// internal forwarder.
+    pub(crate) fn set_wallet_event_subscription(&mut self, rx: broadcast::Receiver<WalletEvent>) {
+        self.wallet_event_rx = rx;
+    }
+
+    /// Sender used by the rebroadcaster to emit
+    /// `TxRepeatedlyOrphaned` back into the wallet event stream.
+    /// Exposed so tests can subscribe to observe the cap firing.
+    #[cfg(test)]
+    pub(super) fn wallet_event_sender(&self) -> &broadcast::Sender<WalletEvent> {
+        &self.wallet_event_tx
     }
 
     /// Activate mempool monitoring on a single peer.
@@ -440,6 +564,190 @@ impl<W: WalletInterface> MempoolManager<W> {
         }
     }
 
+    /// Drain pending wallet events to drive the reorg rebroadcast queue.
+    /// Picks up `Reorg` events (which seed `pending_rebroadcast`) and
+    /// `BlockProcessed` events (which feed the input-conflict check).
+    pub(super) async fn drain_wallet_events(&mut self) {
+        loop {
+            match self.wallet_event_rx.try_recv() {
+                Ok(WalletEvent::Reorg {
+                    wallet_id,
+                    demoted_txids,
+                    ..
+                }) => {
+                    self.enqueue_demoted_for_rebroadcast(wallet_id, &demoted_txids).await;
+                }
+                Ok(WalletEvent::BlockProcessed {
+                    inserted,
+                    updated,
+                    ..
+                }) => {
+                    self.evict_conflicting_rebroadcasts(inserted.iter().chain(updated.iter()));
+                }
+                Ok(_) => {}
+                Err(broadcast::error::TryRecvError::Empty) => break,
+                Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                    tracing::warn!(
+                        "MempoolManager wallet event subscription lagged by {n} events; \
+                         rebroadcaster may have missed Reorg or BlockProcessed events"
+                    );
+                    continue;
+                }
+                Err(broadcast::error::TryRecvError::Closed) => break,
+            }
+        }
+    }
+
+    async fn enqueue_demoted_for_rebroadcast(
+        &mut self,
+        wallet_id: key_wallet_manager::WalletId,
+        demoted_txids: &[Txid],
+    ) {
+        if demoted_txids.is_empty() {
+            return;
+        }
+        let now = Instant::now();
+        let chainlock_floor = self.chainlock_height.load(Ordering::Acquire);
+        for txid in demoted_txids {
+            if self.pending_rebroadcast.contains_key(txid) {
+                continue;
+            }
+            let Some(tx) = self.wallet.read().await.get_transaction(txid).await else {
+                tracing::debug!(
+                    "demoted tx {} not retrievable from wallet, skipping rebroadcast",
+                    txid
+                );
+                continue;
+            };
+            let state = RebroadcastState::new(wallet_id, &tx, now);
+            // Chainlock-floor defense: the wallet refused to rewind below
+            // its chainlock floor upstream, so any demoted tx must have
+            // been confirmed strictly above `chainlock_height`. This is
+            // belt-and-braces.
+            if chainlock_floor > self.current_tip_height && chainlock_floor != 0 {
+                tracing::warn!(
+                    "MempoolManager: skipping rebroadcast of {} because chainlock_height {} \
+                     exceeds current tip {} (state may be inconsistent)",
+                    txid,
+                    chainlock_floor,
+                    self.current_tip_height
+                );
+                continue;
+            }
+            self.transactions.entry(*txid).or_insert_with(|| {
+                UnconfirmedTransaction::new(tx.clone(), Amount::ZERO, false, true, Vec::new(), 0)
+            });
+            self.pending_rebroadcast.insert(*txid, state);
+        }
+    }
+
+    /// Drop any pending-rebroadcast entry whose inputs collide with a
+    /// transaction confirmed on the new chain. The colliding tx is
+    /// flagged in the trace so the operator can see why the entry was
+    /// retired.
+    pub(super) fn evict_conflicting_rebroadcasts<'a, I>(&mut self, new_records: I)
+    where
+        I: IntoIterator<
+            Item = &'a key_wallet::managed_account::transaction_record::TransactionRecord,
+        >,
+    {
+        if self.pending_rebroadcast.is_empty() {
+            return;
+        }
+        let mut to_evict: Vec<Txid> = Vec::new();
+        for record in new_records {
+            let confirming_txid = record.txid;
+            for input in &record.transaction.input {
+                let outpoint = input.previous_output;
+                for (txid, state) in &self.pending_rebroadcast {
+                    if *txid == confirming_txid {
+                        continue;
+                    }
+                    if state.inputs.contains(&outpoint) {
+                        tracing::info!(
+                            "MempoolManager: demoted tx {} input-conflicts with new-chain \
+                             tx {} on outpoint {}:{}, dropping from rebroadcast queue",
+                            txid,
+                            confirming_txid,
+                            outpoint.txid,
+                            outpoint.vout
+                        );
+                        to_evict.push(*txid);
+                    }
+                }
+            }
+        }
+        for txid in to_evict {
+            self.pending_rebroadcast.remove(&txid);
+            self.transactions.remove(&txid);
+        }
+    }
+
+    /// Walk the rebroadcast queue and broadcast any entry whose
+    /// `next_attempt` is due. Entries past the retry cap are dropped
+    /// and surface a `TxRepeatedlyOrphaned` wallet event.
+    pub(super) async fn drive_reorg_rebroadcast(&mut self, requests: &RequestSender) {
+        self.drive_reorg_rebroadcast_at(requests, Instant::now()).await
+    }
+
+    async fn drive_reorg_rebroadcast_at(&mut self, requests: &RequestSender, now: Instant) {
+        if self.pending_rebroadcast.is_empty() {
+            return;
+        }
+        let tip = self.current_tip_height;
+        let wall_now = std::time::SystemTime::now();
+        let mut to_drop: Vec<Txid> = Vec::new();
+        let mut to_orphan: Vec<(Txid, key_wallet_manager::WalletId)> = Vec::new();
+        for (txid, state) in self.pending_rebroadcast.iter_mut() {
+            if state.next_attempt > now {
+                continue;
+            }
+            if !state.locktime_satisfied(tip, wall_now) {
+                state.next_attempt = now + RebroadcastState::backoff_for_attempt(state.attempts);
+                tracing::debug!(
+                    "MempoolManager: deferring rebroadcast of {} until locktime {} satisfied \
+                     (tip={})",
+                    txid,
+                    state.lock_time,
+                    tip
+                );
+                continue;
+            }
+            let Some(unconfirmed) = self.transactions.get(txid) else {
+                to_drop.push(*txid);
+                continue;
+            };
+            if state.attempts >= MAX_REORG_REBROADCAST_ATTEMPTS {
+                to_orphan.push((*txid, state.wallet_id));
+                continue;
+            }
+            let _ = requests.broadcast(NetworkMessage::Tx(unconfirmed.transaction.clone()));
+            state.attempts = state.attempts.saturating_add(1);
+            state.next_attempt = now + RebroadcastState::backoff_for_attempt(state.attempts);
+            tracing::info!(
+                "MempoolManager: rebroadcast attempt {} for demoted tx {}",
+                state.attempts,
+                txid
+            );
+        }
+        for (txid, wallet_id) in to_orphan {
+            tracing::warn!(
+                "MempoolManager: demoted tx {} exceeded {} rebroadcast attempts, giving up",
+                txid,
+                MAX_REORG_REBROADCAST_ATTEMPTS
+            );
+            self.pending_rebroadcast.remove(&txid);
+            self.transactions.remove(&txid);
+            let _ = self.wallet_event_tx.send(WalletEvent::TxRepeatedlyOrphaned {
+                wallet_id: Some(wallet_id),
+                txid,
+            });
+        }
+        for txid in to_drop {
+            self.pending_rebroadcast.remove(&txid);
+        }
+    }
+
     /// Rebroadcast unconfirmed self-sent transactions to all peers.
     ///
     /// Each transaction in `recent_sends` tracks when it was last broadcast.
@@ -563,7 +871,7 @@ mod tests {
     use dashcore::network::message::NetworkMessage;
     use dashcore::{Address, BlockHash, Network, ScriptBuf, Transaction};
     use key_wallet::transaction_checking::TransactionContext;
-    use key_wallet_manager::test_utils::MockWallet;
+    use key_wallet_manager::test_utils::{MockWallet, MOCK_WALLET_ID};
 
     use crate::sync::SyncState;
     use crate::test_utils::test_socket_address;
@@ -590,7 +898,13 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
-        let mut manager = MempoolManager::new(wallet, MempoolStrategy::FetchAll, 1000, 0);
+        let mut manager = MempoolManager::new(
+            wallet,
+            MempoolStrategy::FetchAll,
+            1000,
+            0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        );
         manager.progress.set_state(SyncState::Synced);
 
         (manager, requests, rx)
@@ -602,7 +916,13 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
-        let manager = MempoolManager::new(wallet, MempoolStrategy::BloomFilter, 1000, 0);
+        let manager = MempoolManager::new(
+            wallet,
+            MempoolStrategy::BloomFilter,
+            1000,
+            0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        );
 
         (manager, requests, rx)
     }
@@ -671,6 +991,7 @@ mod tests {
             MempoolStrategy::FetchAll,
             2, // Very small capacity
             0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
         );
         let peer = test_socket_address(1);
         manager.peers.insert(peer, Some(VecDeque::new()));
@@ -705,7 +1026,13 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
-        let mut manager = MempoolManager::new(wallet, MempoolStrategy::FetchAll, 2, 0);
+        let mut manager = MempoolManager::new(
+            wallet,
+            MempoolStrategy::FetchAll,
+            2,
+            0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        );
         manager.progress.set_state(SyncState::Synced);
         let peer = test_socket_address(1);
         manager.peers.insert(peer, Some(VecDeque::new()));
@@ -729,7 +1056,13 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let _requests = RequestSender::new(tx);
 
-        let mut manager = MempoolManager::new(wallet, MempoolStrategy::FetchAll, 1000, 0);
+        let mut manager = MempoolManager::new(
+            wallet,
+            MempoolStrategy::FetchAll,
+            1000,
+            0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        );
 
         let fresh_txid = Txid::from_byte_array([1; 32]);
         let stale_txid = Txid::from_byte_array([2; 32]);
@@ -842,7 +1175,13 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
-        let manager = MempoolManager::new(wallet.clone(), MempoolStrategy::BloomFilter, 1000, 0);
+        let manager = MempoolManager::new(
+            wallet.clone(),
+            MempoolStrategy::BloomFilter,
+            1000,
+            0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        );
 
         (manager, requests, wallet)
     }
@@ -966,7 +1305,13 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
-        let manager = MempoolManager::new(wallet, MempoolStrategy::BloomFilter, 1000, 0);
+        let manager = MempoolManager::new(
+            wallet,
+            MempoolStrategy::BloomFilter,
+            1000,
+            0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        );
 
         (manager, requests, rx)
     }
@@ -1386,7 +1731,13 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
-        let mut manager = MempoolManager::new(wallet, MempoolStrategy::BloomFilter, 1000, 0);
+        let mut manager = MempoolManager::new(
+            wallet,
+            MempoolStrategy::BloomFilter,
+            1000,
+            0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        );
 
         // Drop receiver so send_filter_load fails
         drop(rx);
@@ -1716,5 +2067,253 @@ mod tests {
         // peer2 should still be present and activated
         assert!(manager.peers.contains_key(&peer2));
         assert!(manager.peers[&peer2].is_some());
+    }
+
+    /// Build a transaction spending a specific outpoint with a given
+    /// `lock_time`. The `out_value` keeps the txid distinct between
+    /// tests that need different demoted transactions.
+    fn build_demoted_tx(prev: OutPoint, lock_time: u32, out_value: u64) -> Transaction {
+        Transaction {
+            version: 2,
+            lock_time,
+            input: vec![dashcore::TxIn {
+                previous_output: prev,
+                script_sig: ScriptBuf::new(),
+                sequence: 0xffffffff,
+                witness: dashcore::Witness::new(),
+            }],
+            output: vec![dashcore::TxOut {
+                value: out_value,
+                script_pubkey: ScriptBuf::new(),
+            }],
+            special_transaction_payload: None,
+        }
+    }
+
+    /// Helper that builds a wallet, mempool manager, and pre-wires the
+    /// wallet's own broadcast subscription as the manager's
+    /// `wallet_event_rx`. Returns the wallet so tests can drive
+    /// `WalletEvent`s through it.
+    async fn manager_with_wallet_events() -> (
+        MempoolManager<MockWallet>,
+        Arc<RwLock<MockWallet>>,
+        RequestSender,
+        mpsc::UnboundedReceiver<NetworkRequest>,
+    ) {
+        let wallet = Arc::new(RwLock::new(MockWallet::new()));
+        let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let requests = RequestSender::new(tx);
+        let mut manager = MempoolManager::new(
+            wallet.clone(),
+            MempoolStrategy::FetchAll,
+            1000,
+            0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        );
+        manager.progress.set_state(SyncState::Synced);
+        let wallet_event_rx = wallet.read().await.subscribe_events();
+        manager.set_wallet_event_subscription(wallet_event_rx);
+        (manager, wallet, requests, rx)
+    }
+
+    /// Reorg event with a single demoted txid that the wallet can
+    /// serve via `get_transaction` enqueues a rebroadcast entry, and
+    /// the first tick broadcasts the transaction body to peers.
+    #[tokio::test]
+    async fn test_reorg_demoted_tx_rebroadcast_happy_path() {
+        let (mut manager, wallet, requests, mut rx) = manager_with_wallet_events().await;
+
+        let prev = OutPoint {
+            txid: Txid::from_byte_array([0xaa; 32]),
+            vout: 0,
+        };
+        let demoted = build_demoted_tx(prev, 0, 1_000);
+        let txid = demoted.txid();
+        wallet.write().await.insert_stored_transaction(demoted.clone());
+
+        let _ = wallet.read().await.event_sender().send(WalletEvent::Reorg {
+            wallet_id: MOCK_WALLET_ID,
+            fork_height: 100,
+            demoted_txids: vec![txid],
+            conflicted_txids: vec![],
+            balance: key_wallet::WalletCoreBalance::default(),
+        });
+
+        manager.drain_wallet_events().await;
+        assert!(manager.pending_rebroadcast.contains_key(&txid));
+
+        manager.drive_reorg_rebroadcast(&requests).await;
+
+        let mut found_broadcast = false;
+        while let Ok(msg) = rx.try_recv() {
+            if let NetworkRequest::BroadcastMessage(NetworkMessage::Tx(tx)) = &msg {
+                if tx.txid() == txid {
+                    found_broadcast = true;
+                }
+            }
+        }
+        assert!(found_broadcast, "expected first attempt to broadcast the demoted tx");
+        assert_eq!(manager.pending_rebroadcast.get(&txid).unwrap().attempts, 1);
+    }
+
+    /// A `BlockProcessed` event carrying a transaction whose input
+    /// collides with a pending demoted tx must evict the demoted
+    /// entry: it is now conflicted on the new chain.
+    #[tokio::test]
+    async fn test_input_conflict_drops_pending_rebroadcast() {
+        let (mut manager, wallet, _requests, _rx) = manager_with_wallet_events().await;
+
+        let prev = OutPoint {
+            txid: Txid::from_byte_array([0xbb; 32]),
+            vout: 0,
+        };
+        let demoted = build_demoted_tx(prev, 0, 1_000);
+        let demoted_txid = demoted.txid();
+        wallet.write().await.insert_stored_transaction(demoted.clone());
+
+        let _ = wallet.read().await.event_sender().send(WalletEvent::Reorg {
+            wallet_id: MOCK_WALLET_ID,
+            fork_height: 100,
+            demoted_txids: vec![demoted_txid],
+            conflicted_txids: vec![],
+            balance: key_wallet::WalletCoreBalance::default(),
+        });
+        manager.drain_wallet_events().await;
+        assert!(manager.pending_rebroadcast.contains_key(&demoted_txid));
+
+        // Another wallet-relevant tx confirms on the new chain spending
+        // the SAME outpoint.
+        let conflicting_tx = build_demoted_tx(prev, 0, 2_000);
+        let conflicting_record =
+            key_wallet::managed_account::transaction_record::TransactionRecord::new(
+                conflicting_tx,
+                key_wallet::account::AccountType::Standard {
+                    index: 0,
+                    standard_account_type: key_wallet::account::StandardAccountType::BIP44Account,
+                },
+                TransactionContext::InBlock(key_wallet::transaction_checking::BlockInfo::new(
+                    110,
+                    BlockHash::all_zeros(),
+                    0,
+                )),
+                key_wallet::transaction_checking::TransactionType::Standard,
+                key_wallet::managed_account::transaction_record::TransactionDirection::Incoming,
+                vec![],
+                vec![],
+                0,
+            );
+
+        manager.evict_conflicting_rebroadcasts(std::iter::once(&conflicting_record));
+
+        assert!(
+            !manager.pending_rebroadcast.contains_key(&demoted_txid),
+            "input-conflicting demoted tx must be dropped from rebroadcast queue"
+        );
+    }
+
+    /// A demoted tx with a block-height locktime above the current
+    /// tip must be deferred. The rebroadcaster updates `next_attempt`
+    /// without sending. Once the tip advances past the locktime, the
+    /// next call broadcasts.
+    #[tokio::test]
+    async fn test_locktime_defer_then_broadcast() {
+        let (mut manager, wallet, requests, mut rx) = manager_with_wallet_events().await;
+        manager.current_tip_height = 100;
+
+        let prev = OutPoint {
+            txid: Txid::from_byte_array([0xcc; 32]),
+            vout: 0,
+        };
+        let demoted = build_demoted_tx(prev, 200, 1_000);
+        let txid = demoted.txid();
+        wallet.write().await.insert_stored_transaction(demoted.clone());
+
+        let _ = wallet.read().await.event_sender().send(WalletEvent::Reorg {
+            wallet_id: MOCK_WALLET_ID,
+            fork_height: 100,
+            demoted_txids: vec![txid],
+            conflicted_txids: vec![],
+            balance: key_wallet::WalletCoreBalance::default(),
+        });
+        manager.drain_wallet_events().await;
+
+        manager.drive_reorg_rebroadcast(&requests).await;
+        assert!(rx.try_recv().is_err(), "block-height locktime above tip must defer broadcast");
+        assert_eq!(manager.pending_rebroadcast.get(&txid).unwrap().attempts, 0);
+
+        // Advance tip and try again.
+        manager.current_tip_height = 200;
+        // The deferral set `next_attempt` ahead; project `now` forward
+        // to bypass the backoff so the test does not have to sleep.
+        let future = Instant::now() + Duration::from_secs(7200);
+        manager.drive_reorg_rebroadcast_at(&requests, future).await;
+
+        let mut found = false;
+        while let Ok(msg) = rx.try_recv() {
+            if let NetworkRequest::BroadcastMessage(NetworkMessage::Tx(tx)) = &msg {
+                if tx.txid() == txid {
+                    found = true;
+                }
+            }
+        }
+        assert!(found, "broadcast must fire once locktime is satisfied");
+        assert_eq!(manager.pending_rebroadcast.get(&txid).unwrap().attempts, 1);
+    }
+
+    /// After `MAX_REORG_REBROADCAST_ATTEMPTS` failures, the
+    /// rebroadcaster gives up: the txid drops from the queue and
+    /// a `TxRepeatedlyOrphaned` event is emitted.
+    #[tokio::test]
+    async fn test_retry_cap_emits_repeatedly_orphaned() {
+        let (mut manager, wallet, requests, _rx) = manager_with_wallet_events().await;
+
+        let prev = OutPoint {
+            txid: Txid::from_byte_array([0xdd; 32]),
+            vout: 0,
+        };
+        let demoted = build_demoted_tx(prev, 0, 1_000);
+        let txid = demoted.txid();
+        wallet.write().await.insert_stored_transaction(demoted.clone());
+
+        let _ = wallet.read().await.event_sender().send(WalletEvent::Reorg {
+            wallet_id: MOCK_WALLET_ID,
+            fork_height: 100,
+            demoted_txids: vec![txid],
+            conflicted_txids: vec![],
+            balance: key_wallet::WalletCoreBalance::default(),
+        });
+        manager.drain_wallet_events().await;
+
+        let mut rx_orphan = manager.wallet_event_sender().subscribe();
+
+        let start = Instant::now();
+        for i in 0..MAX_REORG_REBROADCAST_ATTEMPTS {
+            // Project `now` further forward each iteration so the
+            // exponential backoff never gates the test loop. Backoff
+            // is capped at `REORG_REBROADCAST_MAX_BACKOFF` (1h), so
+            // 2h per iteration is enough headroom.
+            let future = start + Duration::from_secs(2 * 3600 * (i as u64 + 1));
+            manager.drive_reorg_rebroadcast_at(&requests, future).await;
+        }
+        // One more call to trigger the cap.
+        let future =
+            start + Duration::from_secs(2 * 3600 * (MAX_REORG_REBROADCAST_ATTEMPTS as u64 + 1));
+        manager.drive_reorg_rebroadcast_at(&requests, future).await;
+
+        assert!(!manager.pending_rebroadcast.contains_key(&txid), "txid must drop after retry cap");
+
+        let mut found_orphan = false;
+        while let Ok(ev) = rx_orphan.try_recv() {
+            if let WalletEvent::TxRepeatedlyOrphaned {
+                txid: orphan,
+                ..
+            } = ev
+            {
+                if orphan == txid {
+                    found_orphan = true;
+                }
+            }
+        }
+        assert!(found_orphan, "expected TxRepeatedlyOrphaned event after retry cap");
     }
 }

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::network::message::NetworkMessage;
@@ -26,7 +26,7 @@ use crate::network::RequestSender;
 use crate::sync::mempool::MempoolProgress;
 use crate::sync::SyncEvent;
 use crate::types::UnconfirmedTransaction;
-use key_wallet_manager::{WalletEvent, WalletInterface};
+use key_wallet_manager::{WalletEvent, WalletId, WalletInterface};
 
 /// Timeout for pruning expired mempool transactions (24 hours).
 pub(super) const MEMPOOL_TX_EXPIRY: Duration = Duration::from_secs(24 * 3600);
@@ -66,7 +66,7 @@ const REORG_REBROADCAST_MAX_BACKOFF: Duration = Duration::from_secs(3600);
 pub(super) struct RebroadcastState {
     /// Wallet that owns the demoted record, used to scope the
     /// `TxRepeatedlyOrphaned` event when the retry cap fires.
-    wallet_id: key_wallet_manager::WalletId,
+    wallet_id: WalletId,
     /// Outpoints the transaction consumes. Used by the input-conflict
     /// check to drop the entry when another transaction landing on the
     /// new chain spends one of the same outpoints.
@@ -77,9 +77,7 @@ pub(super) struct RebroadcastState {
     /// deferred best-effort against the current wall-clock since
     /// the SPV path does not maintain an MTP cache.
     lock_time: u32,
-    /// Number of rebroadcast attempts already made.
     attempts: u32,
-    /// Earliest `Instant` at which the next attempt may run.
     next_attempt: Instant,
 }
 
@@ -89,7 +87,7 @@ pub(super) struct RebroadcastState {
 const LOCKTIME_THRESHOLD: u32 = 500_000_000;
 
 impl RebroadcastState {
-    fn new(wallet_id: key_wallet_manager::WalletId, tx: &Transaction, now: Instant) -> Self {
+    fn new(wallet_id: WalletId, tx: &Transaction, now: Instant) -> Self {
         Self {
             wallet_id,
             inputs: tx.input.iter().map(|i| i.previous_output).collect(),
@@ -105,10 +103,8 @@ impl RebroadcastState {
         Duration::from_secs(secs).min(REORG_REBROADCAST_MAX_BACKOFF)
     }
 
-    /// Returns true when the transaction's `nLockTime` is satisfied
-    /// against `tip_height` and `now` (block-height vs timestamp
-    /// locktime per BIP-65).
-    fn locktime_satisfied(&self, tip_height: u32, now: std::time::SystemTime) -> bool {
+    /// Block-height vs timestamp locktime per BIP-65.
+    fn locktime_satisfied(&self, tip_height: u32, now: SystemTime) -> bool {
         if self.lock_time == 0 {
             return true;
         }
@@ -119,7 +115,7 @@ impl RebroadcastState {
             // wall clock: a stricter MTP-based check would only delay
             // broadcast further, never accept too early, since wall
             // clock >= MTP.
-            now.duration_since(std::time::UNIX_EPOCH)
+            now.duration_since(UNIX_EPOCH)
                 .map(|d| self.lock_time as u64 <= d.as_secs())
                 .unwrap_or(false)
         }
@@ -151,7 +147,6 @@ pub(crate) struct MempoolManager<W: WalletInterface> {
     /// Wallet monitor revision at the time of the last filter build.
     /// Compared on each tick to detect when the wallet's monitored set has changed.
     pub(super) last_monitor_revision: u64,
-    /// Reorg-driven rebroadcast queue keyed by demoted txid.
     pub(super) pending_rebroadcast: HashMap<Txid, RebroadcastState>,
     /// Subscription to `WalletEvent` broadcasts, drained on each tick to
     /// pick up `Reorg` events and to observe new-chain confirmations for
@@ -160,8 +155,7 @@ pub(crate) struct MempoolManager<W: WalletInterface> {
     /// Sender used to emit `TxRepeatedlyOrphaned` events back into the
     /// wallet event stream when the retry cap fires.
     wallet_event_tx: broadcast::Sender<WalletEvent>,
-    /// Current chain tip height, updated via `update_target_height`.
-    /// Used for block-height locktime checks during rebroadcast.
+    /// Updated via `update_target_height`.
     pub(super) current_tip_height: u32,
     /// Shared chainlock-floor height. Defense-in-depth: a tx confirmed
     /// in a chainlocked block must never be queued for rebroadcast.
@@ -205,17 +199,13 @@ impl<W: WalletInterface> MempoolManager<W> {
         }
     }
 
-    /// Replace the manager's internal `WalletEvent` subscription with a
-    /// fresh receiver. Call this after `new` if the manager must observe
-    /// the wallet's own broadcast channel directly instead of the
-    /// internal forwarder.
+    /// Use when the manager must observe the wallet's own broadcast channel
+    /// directly instead of the internal forwarder created by `new`.
     pub(crate) fn set_wallet_event_subscription(&mut self, rx: broadcast::Receiver<WalletEvent>) {
         self.wallet_event_rx = rx;
     }
 
-    /// Sender used by the rebroadcaster to emit
-    /// `TxRepeatedlyOrphaned` back into the wallet event stream.
-    /// Exposed so tests can subscribe to observe the cap firing.
+    /// Exposed so tests can subscribe to observe the retry-cap firing.
     #[cfg(test)]
     pub(super) fn wallet_event_sender(&self) -> &broadcast::Sender<WalletEvent> {
         &self.wallet_event_tx
@@ -564,9 +554,6 @@ impl<W: WalletInterface> MempoolManager<W> {
         }
     }
 
-    /// Drain pending wallet events to drive the reorg rebroadcast queue.
-    /// Picks up `Reorg` events (which seed `pending_rebroadcast`) and
-    /// `BlockProcessed` events (which feed the input-conflict check).
     pub(super) async fn drain_wallet_events(&mut self) {
         loop {
             match self.wallet_event_rx.try_recv() {
@@ -600,7 +587,7 @@ impl<W: WalletInterface> MempoolManager<W> {
 
     async fn enqueue_demoted_for_rebroadcast(
         &mut self,
-        wallet_id: key_wallet_manager::WalletId,
+        wallet_id: WalletId,
         demoted_txids: &[Txid],
     ) {
         if demoted_txids.is_empty() {
@@ -641,10 +628,7 @@ impl<W: WalletInterface> MempoolManager<W> {
         }
     }
 
-    /// Drop any pending-rebroadcast entry whose inputs collide with a
-    /// transaction confirmed on the new chain. The colliding tx is
-    /// flagged in the trace so the operator can see why the entry was
-    /// retired.
+    /// The colliding tx is flagged in the trace so the operator can see why the entry was retired.
     pub(super) fn evict_conflicting_rebroadcasts<'a, I>(&mut self, new_records: I)
     where
         I: IntoIterator<
@@ -683,9 +667,7 @@ impl<W: WalletInterface> MempoolManager<W> {
         }
     }
 
-    /// Walk the rebroadcast queue and broadcast any entry whose
-    /// `next_attempt` is due. Entries past the retry cap are dropped
-    /// and surface a `TxRepeatedlyOrphaned` wallet event.
+    /// Entries past the retry cap are dropped and surface a `TxRepeatedlyOrphaned` wallet event.
     pub(super) async fn drive_reorg_rebroadcast(&mut self, requests: &RequestSender) {
         self.drive_reorg_rebroadcast_at(requests, Instant::now()).await
     }
@@ -695,9 +677,9 @@ impl<W: WalletInterface> MempoolManager<W> {
             return;
         }
         let tip = self.current_tip_height;
-        let wall_now = std::time::SystemTime::now();
+        let wall_now = SystemTime::now();
         let mut to_drop: Vec<Txid> = Vec::new();
-        let mut to_orphan: Vec<(Txid, key_wallet_manager::WalletId)> = Vec::new();
+        let mut to_orphan: Vec<(Txid, WalletId)> = Vec::new();
         for (txid, state) in self.pending_rebroadcast.iter_mut() {
             if state.next_attempt > now {
                 continue;
@@ -875,6 +857,7 @@ mod tests {
 
     use crate::sync::SyncState;
     use crate::test_utils::test_socket_address;
+    use std::iter::once;
     use tokio::sync::mpsc;
 
     fn dummy_instant_lock(txid: Txid) -> InstantLock {
@@ -903,7 +886,7 @@ mod tests {
             MempoolStrategy::FetchAll,
             1000,
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
         manager.progress.set_state(SyncState::Synced);
 
@@ -921,7 +904,7 @@ mod tests {
             MempoolStrategy::BloomFilter,
             1000,
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         (manager, requests, rx)
@@ -991,7 +974,7 @@ mod tests {
             MempoolStrategy::FetchAll,
             2, // Very small capacity
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
         let peer = test_socket_address(1);
         manager.peers.insert(peer, Some(VecDeque::new()));
@@ -1031,7 +1014,7 @@ mod tests {
             MempoolStrategy::FetchAll,
             2,
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
         manager.progress.set_state(SyncState::Synced);
         let peer = test_socket_address(1);
@@ -1061,7 +1044,7 @@ mod tests {
             MempoolStrategy::FetchAll,
             1000,
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         let fresh_txid = Txid::from_byte_array([1; 32]);
@@ -1180,7 +1163,7 @@ mod tests {
             MempoolStrategy::BloomFilter,
             1000,
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         (manager, requests, wallet)
@@ -1310,7 +1293,7 @@ mod tests {
             MempoolStrategy::BloomFilter,
             1000,
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         (manager, requests, rx)
@@ -1736,7 +1719,7 @@ mod tests {
             MempoolStrategy::BloomFilter,
             1000,
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         // Drop receiver so send_filter_load fails
@@ -2090,10 +2073,6 @@ mod tests {
         }
     }
 
-    /// Helper that builds a wallet, mempool manager, and pre-wires the
-    /// wallet's own broadcast subscription as the manager's
-    /// `wallet_event_rx`. Returns the wallet so tests can drive
-    /// `WalletEvent`s through it.
     async fn manager_with_wallet_events() -> (
         MempoolManager<MockWallet>,
         Arc<RwLock<MockWallet>>,
@@ -2108,7 +2087,7 @@ mod tests {
             MempoolStrategy::FetchAll,
             1000,
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
         manager.progress.set_state(SyncState::Synced);
         let wallet_event_rx = wallet.read().await.subscribe_events();
@@ -2116,9 +2095,6 @@ mod tests {
         (manager, wallet, requests, rx)
     }
 
-    /// Reorg event with a single demoted txid that the wallet can
-    /// serve via `get_transaction` enqueues a rebroadcast entry, and
-    /// the first tick broadcasts the transaction body to peers.
     #[tokio::test]
     async fn test_reorg_demoted_tx_rebroadcast_happy_path() {
         let (mut manager, wallet, requests, mut rx) = manager_with_wallet_events().await;
@@ -2156,9 +2132,6 @@ mod tests {
         assert_eq!(manager.pending_rebroadcast.get(&txid).unwrap().attempts, 1);
     }
 
-    /// A `BlockProcessed` event carrying a transaction whose input
-    /// collides with a pending demoted tx must evict the demoted
-    /// entry: it is now conflicted on the new chain.
     #[tokio::test]
     async fn test_input_conflict_drops_pending_rebroadcast() {
         let (mut manager, wallet, _requests, _rx) = manager_with_wallet_events().await;
@@ -2203,7 +2176,7 @@ mod tests {
                 0,
             );
 
-        manager.evict_conflicting_rebroadcasts(std::iter::once(&conflicting_record));
+        manager.evict_conflicting_rebroadcasts(once(&conflicting_record));
 
         assert!(
             !manager.pending_rebroadcast.contains_key(&demoted_txid),
@@ -2211,10 +2184,6 @@ mod tests {
         );
     }
 
-    /// A demoted tx with a block-height locktime above the current
-    /// tip must be deferred. The rebroadcaster updates `next_attempt`
-    /// without sending. Once the tip advances past the locktime, the
-    /// next call broadcasts.
     #[tokio::test]
     async fn test_locktime_defer_then_broadcast() {
         let (mut manager, wallet, requests, mut rx) = manager_with_wallet_events().await;
@@ -2260,9 +2229,6 @@ mod tests {
         assert_eq!(manager.pending_rebroadcast.get(&txid).unwrap().attempts, 1);
     }
 
-    /// After `MAX_REORG_REBROADCAST_ATTEMPTS` failures, the
-    /// rebroadcaster gives up: the txid drops from the queue and
-    /// a `TxRepeatedlyOrphaned` event is emitted.
     #[tokio::test]
     async fn test_retry_cap_emits_repeatedly_orphaned() {
         let (mut manager, wallet, requests, _rx) = manager_with_wallet_events().await;

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -585,7 +585,7 @@ impl<W: WalletInterface> MempoolManager<W> {
         }
     }
 
-    async fn enqueue_demoted_for_rebroadcast(
+    pub(super) async fn enqueue_demoted_for_rebroadcast(
         &mut self,
         wallet_id: WalletId,
         demoted_txids: &[Txid],
@@ -2130,6 +2130,55 @@ mod tests {
         }
         assert!(found_broadcast, "expected first attempt to broadcast the demoted tx");
         assert_eq!(manager.pending_rebroadcast.get(&txid).unwrap().attempts, 1);
+
+        // A second immediate tick must not produce another broadcast: the
+        // exponential backoff sets `next_attempt` ahead, so the entry
+        // should be skipped without bumping `attempts`.
+        manager.drive_reorg_rebroadcast(&requests).await;
+        let second_broadcast = std::iter::from_fn(|| rx.try_recv().ok()).any(
+            |m| matches!(m, NetworkRequest::BroadcastMessage(NetworkMessage::Tx(t)) if t.txid() == txid),
+        );
+        assert!(!second_broadcast, "backoff must suppress a second immediate rebroadcast");
+        assert_eq!(manager.pending_rebroadcast.get(&txid).unwrap().attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn test_chainlock_floor_prevents_enqueue() {
+        // Chainlock floor strictly above the current tip must skip enqueue
+        // entirely, since a tx confirmed in a chainlocked block can never
+        // be a candidate for rebroadcast.
+        let wallet = Arc::new(RwLock::new(MockWallet::new()));
+        let (tx_chan, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
+        let _requests = RequestSender::new(tx_chan);
+        let chainlock_height = Arc::new(AtomicU32::new(150));
+        let mut manager = MempoolManager::new(
+            wallet.clone(),
+            MempoolStrategy::FetchAll,
+            1000,
+            0,
+            chainlock_height,
+        );
+        let wallet_event_rx = wallet.read().await.subscribe_events();
+        manager.set_wallet_event_subscription(wallet_event_rx);
+
+        let prev = OutPoint {
+            txid: Txid::from_byte_array([0xee; 32]),
+            vout: 0,
+        };
+        let demoted = build_demoted_tx(prev, 0, 1_000);
+        let txid = demoted.txid();
+        wallet.write().await.insert_stored_transaction(demoted);
+
+        manager.enqueue_demoted_for_rebroadcast(MOCK_WALLET_ID, &[txid]).await;
+
+        assert!(
+            !manager.pending_rebroadcast.contains_key(&txid),
+            "chainlock floor above tip must prevent enqueue"
+        );
+        assert!(
+            !manager.transactions.contains_key(&txid),
+            "skipped enqueue must not leave a stray transactions entry"
+        );
     }
 
     #[tokio::test]
@@ -2181,6 +2230,70 @@ mod tests {
         assert!(
             !manager.pending_rebroadcast.contains_key(&demoted_txid),
             "input-conflicting demoted tx must be dropped from rebroadcast queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_input_conflict_via_channel_evicts_rebroadcast() {
+        // Exercises the production path: `WalletEvent::BlockProcessed` is
+        // delivered through the broadcast channel and `drain_wallet_events`
+        // must route `inserted`/`updated` records into the eviction check.
+        let (mut manager, wallet, _requests, _rx) = manager_with_wallet_events().await;
+
+        let prev = OutPoint {
+            txid: Txid::from_byte_array([0xab; 32]),
+            vout: 0,
+        };
+        let demoted = build_demoted_tx(prev, 0, 1_000);
+        let demoted_txid = demoted.txid();
+        wallet.write().await.insert_stored_transaction(demoted);
+
+        let _ = wallet.read().await.event_sender().send(WalletEvent::Reorg {
+            wallet_id: MOCK_WALLET_ID,
+            fork_height: 100,
+            demoted_txids: vec![demoted_txid],
+            conflicted_txids: vec![],
+            balance: key_wallet::WalletCoreBalance::default(),
+        });
+        manager.drain_wallet_events().await;
+        assert!(manager.pending_rebroadcast.contains_key(&demoted_txid));
+
+        let conflicting_tx = build_demoted_tx(prev, 0, 2_000);
+        let conflicting_record =
+            key_wallet::managed_account::transaction_record::TransactionRecord::new(
+                conflicting_tx,
+                key_wallet::account::AccountType::Standard {
+                    index: 0,
+                    standard_account_type: key_wallet::account::StandardAccountType::BIP44Account,
+                },
+                TransactionContext::InBlock(key_wallet::transaction_checking::BlockInfo::new(
+                    110,
+                    BlockHash::all_zeros(),
+                    0,
+                )),
+                key_wallet::transaction_checking::TransactionType::Standard,
+                key_wallet::managed_account::transaction_record::TransactionDirection::Incoming,
+                vec![],
+                vec![],
+                0,
+            );
+
+        let _ = wallet.read().await.event_sender().send(WalletEvent::BlockProcessed {
+            wallet_id: MOCK_WALLET_ID,
+            height: 110,
+            chain_lock: None,
+            inserted: vec![conflicting_record],
+            updated: vec![],
+            matured: vec![],
+            balance: key_wallet::WalletCoreBalance::default(),
+            account_balances: Default::default(),
+            addresses_derived: vec![],
+        });
+        manager.drain_wallet_events().await;
+
+        assert!(
+            !manager.pending_rebroadcast.contains_key(&demoted_txid),
+            "BlockProcessed routed through the channel must evict input-conflicting demoted tx"
         );
     }
 

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -211,6 +211,17 @@ impl<W: WalletInterface> MempoolManager<W> {
         &self.wallet_event_tx
     }
 
+    /// Test-only wrapper so sibling-module tests can seed `pending_rebroadcast`
+    /// without widening the production visibility of the underlying method.
+    #[cfg(test)]
+    pub(super) async fn enqueue_demoted_for_rebroadcast_for_test(
+        &mut self,
+        wallet_id: WalletId,
+        demoted_txids: &[Txid],
+    ) {
+        self.enqueue_demoted_for_rebroadcast(wallet_id, demoted_txids).await;
+    }
+
     /// Activate mempool monitoring on a single peer.
     ///
     /// Since we connect with `relay=false`, peers won't send transaction INVs
@@ -585,7 +596,7 @@ impl<W: WalletInterface> MempoolManager<W> {
         }
     }
 
-    pub(super) async fn enqueue_demoted_for_rebroadcast(
+    async fn enqueue_demoted_for_rebroadcast(
         &mut self,
         wallet_id: WalletId,
         demoted_txids: &[Txid],
@@ -2146,7 +2157,8 @@ mod tests {
     async fn test_chainlock_floor_prevents_enqueue() {
         // Chainlock floor strictly above the current tip must skip enqueue
         // entirely, since a tx confirmed in a chainlocked block can never
-        // be a candidate for rebroadcast.
+        // be a candidate for rebroadcast. This test invokes the enqueue
+        // path directly and does not exercise the wallet-event channel.
         let wallet = Arc::new(RwLock::new(MockWallet::new()));
         let (tx_chan, _rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let _requests = RequestSender::new(tx_chan);
@@ -2158,8 +2170,6 @@ mod tests {
             0,
             chainlock_height,
         );
-        let wallet_event_rx = wallet.read().await.subscribe_events();
-        manager.set_wallet_event_subscription(wallet_event_rx);
 
         let prev = OutPoint {
             txid: Txid::from_byte_array([0xee; 32]),
@@ -2175,9 +2185,12 @@ mod tests {
             !manager.pending_rebroadcast.contains_key(&txid),
             "chainlock floor above tip must prevent enqueue"
         );
+        // The chainlock-floor guard must short-circuit before the wallet
+        // fetch/insert path runs; if that ordering ever flips, this stray
+        // entry would be the symptom.
         assert!(
             !manager.transactions.contains_key(&txid),
-            "skipped enqueue must not leave a stray transactions entry"
+            "skipped enqueue must not leave a stray transactions entry (guard fires before fetch)"
         );
     }
 

--- a/dash-spv/src/sync/mempool/sync_manager.rs
+++ b/dash-spv/src/sync/mempool/sync_manager.rs
@@ -210,6 +210,7 @@ mod tests {
     use dashcore::hashes::Hash;
     use key_wallet_manager::test_utils::MockWallet;
     use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::atomic::AtomicU32;
     use std::sync::Arc;
     use tokio::sync::{mpsc, RwLock};
 
@@ -224,7 +225,7 @@ mod tests {
             MempoolStrategy::FetchAll,
             1000,
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         (manager, requests, rx)
@@ -582,7 +583,7 @@ mod tests {
             MempoolStrategy::BloomFilter,
             1000,
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         let peer = test_socket_address(1);
@@ -658,7 +659,7 @@ mod tests {
             MempoolStrategy::BloomFilter,
             1000,
             initial_revision,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         let peer = test_socket_address(1);
@@ -719,7 +720,7 @@ mod tests {
             MempoolStrategy::FetchAll,
             1000,
             0,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         let peer = test_socket_address(1);
@@ -774,7 +775,7 @@ mod tests {
             MempoolStrategy::BloomFilter,
             1000,
             initial_revision,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         let peer = test_socket_address(1);
@@ -824,7 +825,7 @@ mod tests {
             MempoolStrategy::BloomFilter,
             1000,
             initial_revision,
-            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         let peer = test_socket_address(1);

--- a/dash-spv/src/sync/mempool/sync_manager.rs
+++ b/dash-spv/src/sync/mempool/sync_manager.rs
@@ -22,6 +22,12 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
         self.progress.set_state(state);
     }
 
+    fn update_target_height(&mut self, height: u32) {
+        if height > self.current_tip_height {
+            self.current_tip_height = height;
+        }
+    }
+
     fn wanted_message_types(&self) -> &'static [MessageType] {
         &[MessageType::Inv, MessageType::Tx]
     }
@@ -88,6 +94,9 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
                 // Remove confirmed transactions from mempool.
                 // Bloom filter rebuild is handled by the tick's revision check.
                 if !confirmed_txids.is_empty() {
+                    for txid in confirmed_txids {
+                        self.pending_rebroadcast.remove(txid);
+                    }
                     self.remove_confirmed(confirmed_txids);
                 }
                 Ok(vec![])
@@ -119,6 +128,12 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
 
         // Rebroadcast unconfirmed self-sent transactions on a randomized interval
         self.rebroadcast_if_due(requests).await;
+
+        // Drain WalletEvents to pick up reorg-demoted txids and new-chain
+        // confirmations, then drive the reorg rebroadcast queue. Both
+        // calls are no-ops when there is no pending state.
+        self.drain_wallet_events().await;
+        self.drive_reorg_rebroadcast(requests).await;
 
         // Rebuild bloom filter if the wallet's monitored set has changed.
         //
@@ -204,7 +219,13 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
-        let manager = MempoolManager::new(wallet, MempoolStrategy::FetchAll, 1000, 0);
+        let manager = MempoolManager::new(
+            wallet,
+            MempoolStrategy::FetchAll,
+            1000,
+            0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        );
 
         (manager, requests, rx)
     }
@@ -556,7 +577,13 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
-        let mut manager = MempoolManager::new(wallet, MempoolStrategy::BloomFilter, 1000, 0);
+        let mut manager = MempoolManager::new(
+            wallet,
+            MempoolStrategy::BloomFilter,
+            1000,
+            0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        );
 
         let peer = test_socket_address(1);
         manager.handle_peer_connected(peer);
@@ -631,6 +658,7 @@ mod tests {
             MempoolStrategy::BloomFilter,
             1000,
             initial_revision,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
         );
 
         let peer = test_socket_address(1);
@@ -686,7 +714,13 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
-        let mut manager = MempoolManager::new(wallet.clone(), MempoolStrategy::FetchAll, 1000, 0);
+        let mut manager = MempoolManager::new(
+            wallet.clone(),
+            MempoolStrategy::FetchAll,
+            1000,
+            0,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        );
 
         let peer = test_socket_address(1);
         manager.handle_peer_connected(peer);
@@ -740,6 +774,7 @@ mod tests {
             MempoolStrategy::BloomFilter,
             1000,
             initial_revision,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
         );
 
         let peer = test_socket_address(1);
@@ -789,6 +824,7 @@ mod tests {
             MempoolStrategy::BloomFilter,
             1000,
             initial_revision,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
         );
 
         let peer = test_socket_address(1);

--- a/dash-spv/src/sync/mempool/sync_manager.rs
+++ b/dash-spv/src/sync/mempool/sync_manager.rs
@@ -421,7 +421,7 @@ mod tests {
             );
         }
         manager
-            .enqueue_demoted_for_rebroadcast(
+            .enqueue_demoted_for_rebroadcast_for_test(
                 key_wallet_manager::test_utils::MOCK_WALLET_ID,
                 &[txids[0]],
             )

--- a/dash-spv/src/sync/mempool/sync_manager.rs
+++ b/dash-spv/src/sync/mempool/sync_manager.rs
@@ -216,19 +216,29 @@ mod tests {
 
     fn create_test_manager(
     ) -> (MempoolManager<MockWallet>, RequestSender, mpsc::UnboundedReceiver<NetworkRequest>) {
+        let (manager, _wallet, requests, rx) = create_test_manager_with_wallet();
+        (manager, requests, rx)
+    }
+
+    fn create_test_manager_with_wallet() -> (
+        MempoolManager<MockWallet>,
+        Arc<RwLock<MockWallet>>,
+        RequestSender,
+        mpsc::UnboundedReceiver<NetworkRequest>,
+    ) {
         let wallet = Arc::new(RwLock::new(MockWallet::new()));
         let (tx, rx) = mpsc::unbounded_channel::<NetworkRequest>();
         let requests = RequestSender::new(tx);
 
         let manager = MempoolManager::new(
-            wallet,
+            wallet.clone(),
             MempoolStrategy::FetchAll,
             1000,
             0,
             Arc::new(AtomicU32::new(0)),
         );
 
-        (manager, requests, rx)
+        (manager, wallet, requests, rx)
     }
 
     #[test]
@@ -373,7 +383,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_processed_removes_confirmed_txids() {
-        let (mut manager, requests, _rx) = create_test_manager();
+        let (mut manager, wallet, requests, _rx) = create_test_manager_with_wallet();
         let peer = test_socket_address(1);
         manager.handle_peer_connected(peer);
 
@@ -383,7 +393,9 @@ mod tests {
         };
         manager.handle_sync_event(&sync, &requests).await.unwrap();
 
-        // Add transactions to mempool
+        // Add transactions to mempool, and stage the first one as a
+        // pending rebroadcast so we can assert the BlockProcessed handler
+        // wipes it on confirmation.
         let mut txids = Vec::new();
         for i in 0..2u32 {
             let tx = dashcore::Transaction {
@@ -395,6 +407,7 @@ mod tests {
             };
             let txid = tx.txid();
             txids.push(txid);
+            wallet.write().await.insert_stored_transaction(tx.clone());
             manager.transactions.insert(
                 txid,
                 crate::types::UnconfirmedTransaction::new(
@@ -407,6 +420,16 @@ mod tests {
                 ),
             );
         }
+        manager
+            .enqueue_demoted_for_rebroadcast(
+                key_wallet_manager::test_utils::MOCK_WALLET_ID,
+                &[txids[0]],
+            )
+            .await;
+        assert!(
+            manager.pending_rebroadcast.contains_key(&txids[0]),
+            "seed step must place the demoted tx into pending_rebroadcast"
+        );
 
         let event = SyncEvent::BlockProcessed {
             block_hash: dashcore::BlockHash::all_zeros(),
@@ -419,6 +442,10 @@ mod tests {
         assert!(events.is_empty());
 
         assert!(manager.transactions.is_empty());
+        assert!(
+            !manager.pending_rebroadcast.contains_key(&txids[0]),
+            "confirmed txid must be removed from pending_rebroadcast"
+        );
     }
 
     #[tokio::test]

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -347,11 +347,27 @@ pub enum WalletEvent {
         /// from the surviving records before this value was computed.
         balance: WalletCoreBalance,
     },
+    /// An outgoing transaction has been demoted by reorg and the SPV
+    /// rebroadcast loop has given up after the per-tx retry cap. The
+    /// transaction is not in any mempool and will not be rebroadcast
+    /// further until the user intervenes. Surface this in the UI so
+    /// the user can decide whether to abandon, re-sign, or wait.
+    TxRepeatedlyOrphaned {
+        /// ID of the affected wallet (looked up at emit time, may be
+        /// `None` when the rebroadcaster could not attribute the
+        /// txid to any managed wallet).
+        wallet_id: Option<WalletId>,
+        /// The transaction that exhausted its retry budget.
+        txid: Txid,
+    },
 }
 
 impl WalletEvent {
-    /// ID of the wallet this event pertains to.
-    pub fn wallet_id(&self) -> WalletId {
+    /// ID of the wallet this event pertains to. Returns `None` for events
+    /// that may not be tied to a specific wallet (e.g.
+    /// [`WalletEvent::TxRepeatedlyOrphaned`] emitted by the SPV
+    /// rebroadcast loop when the txid was not attributable).
+    pub fn wallet_id(&self) -> Option<WalletId> {
         match self {
             WalletEvent::TransactionDetected {
                 wallet_id,
@@ -374,6 +390,10 @@ impl WalletEvent {
                 ..
             }
             | WalletEvent::Reorg {
+                wallet_id,
+                ..
+            } => Some(*wallet_id),
+            WalletEvent::TxRepeatedlyOrphaned {
                 wallet_id,
                 ..
             } => *wallet_id,
@@ -468,6 +488,10 @@ impl fmt::Display for WalletEvent {
                 conflicted_txids.len(),
                 balance,
             ),
+            WalletEvent::TxRepeatedlyOrphaned {
+                txid,
+                ..
+            } => write!(f, "TxRepeatedlyOrphaned(txid={})", txid),
         }
     }
 }

--- a/key-wallet-manager/src/test_utils/mock_wallet.rs
+++ b/key-wallet-manager/src/test_utils/mock_wallet.rs
@@ -7,7 +7,7 @@ use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, Block, OutPoint, Transaction, Txid};
 use key_wallet::transaction_checking::TransactionContext;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use tokio::sync::{broadcast, Mutex};
 
@@ -44,8 +44,7 @@ pub struct MockWallet {
     pub processed_instant_locks: InstantLockCaptures,
     /// Monitor revision counter for staleness detection.
     monitor_revision: u64,
-    /// Transactions retrievable via `get_transaction`.
-    stored_transactions: std::collections::HashMap<Txid, Transaction>,
+    stored_transactions: HashMap<Txid, Transaction>,
 }
 
 impl Default for MockWallet {
@@ -73,11 +72,10 @@ impl MockWallet {
             status_changes: Arc::new(Mutex::new(Vec::new())),
             processed_instant_locks: Arc::new(Mutex::new(Vec::new())),
             monitor_revision: 0,
-            stored_transactions: std::collections::HashMap::new(),
+            stored_transactions: HashMap::new(),
         }
     }
 
-    /// Insert a transaction that `get_transaction` should return.
     pub fn insert_stored_transaction(&mut self, tx: Transaction) {
         self.stored_transactions.insert(tx.txid(), tx);
     }

--- a/key-wallet-manager/src/test_utils/mock_wallet.rs
+++ b/key-wallet-manager/src/test_utils/mock_wallet.rs
@@ -44,6 +44,8 @@ pub struct MockWallet {
     pub processed_instant_locks: InstantLockCaptures,
     /// Monitor revision counter for staleness detection.
     monitor_revision: u64,
+    /// Transactions retrievable via `get_transaction`.
+    stored_transactions: std::collections::HashMap<Txid, Transaction>,
 }
 
 impl Default for MockWallet {
@@ -71,7 +73,18 @@ impl MockWallet {
             status_changes: Arc::new(Mutex::new(Vec::new())),
             processed_instant_locks: Arc::new(Mutex::new(Vec::new())),
             monitor_revision: 0,
+            stored_transactions: std::collections::HashMap::new(),
         }
+    }
+
+    /// Insert a transaction that `get_transaction` should return.
+    pub fn insert_stored_transaction(&mut self, tx: Transaction) {
+        self.stored_transactions.insert(tx.txid(), tx);
+    }
+
+    /// Sender used to fire synthetic `WalletEvent`s from tests.
+    pub fn event_sender(&self) -> &broadcast::Sender<WalletEvent> {
+        &self.event_sender
     }
 
     /// Override the wallet id used for per-wallet API surfaces.
@@ -272,8 +285,8 @@ impl WalletInterface for MockWallet {
         Ok(RewindResult::default())
     }
 
-    async fn get_transaction(&self, _txid: &Txid) -> Option<Transaction> {
-        None
+    async fn get_transaction(&self, txid: &Txid) -> Option<Transaction> {
+        self.stored_transactions.get(txid).cloned()
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 5 of [#137](https://github.com/xdustinface/rust-dashcore/issues/137). Builds on the wallet rewind from [#145](https://github.com/xdustinface/rust-dashcore/issues/145) (merged in [#169](https://github.com/xdustinface/rust-dashcore/pull/169)).

- **Per-wallet effective rewind window:** `FiltersManager` owns the `SyncEvent::ChainReorg` flow, drives `WalletInterface::rewind_to_height` first, then computes the effective floor as `min(fork_height, wallet.synced_height())` so a wallet behind the fork re-matches from its own ingest tip instead of the fork height. Re-fetches cfilters across `[floor, new_tip]` via the existing batch pipeline.
- **`MempoolManager` auto-rebroadcast** subscribes to `WalletEvent::Reorg` (via a `broadcast::channel` forwarder so the trait stays untouched, set up in `lifecycle.rs`). For each `demoted_txid`:
  - Fetches the full tx via `WalletInterface::get_transaction`.
  - **Input-conflict check** (via `WalletEvent::BlockProcessed`): if any input of a demoted tx collides with an outpoint surfaced on the new chain, it's evicted from `pending_rebroadcast`.
  - **Locktime check:** block-height locktimes are exact (`tip_height`); timestamp locktimes are checked best-effort against wall clock (wall clock ≥ MTP, conservative — never broadcasts too early, may delay slightly).
  - **ChainLock-floor defense:** guarded against `chainlock_height > current_tip_height`, the only inconsistent state where a demoted record could end up under the floor.
  - **Rebroadcast** through the existing `MempoolManager::rebroadcast_if_due` machinery with per-txid retry counter and exponential backoff.
- **Cap:** after N=10 failures, emits `WalletEvent::TxRepeatedlyOrphaned { txid }` and stops rebroadcasting. New `WalletEvent` variant added in `key-wallet-manager`.
- 6 new `dash-spv` tests: per-wallet effective floor (2) + rebroadcast paths (happy, input-conflict eviction, locktime defer/advance, retry-cap orphan).

### Deferred (per issue scope)

- **`Conflicted { previous }` demotion on input collision:** `MempoolManager` refuses to rebroadcast and evicts from `pending_rebroadcast`, which is the user-visible behavior the spec asked for. Promoting the wallet record to `Conflicted` (vs leaving it `Mempool`) still requires a wallet-side API — that's the self-conflict-detection follow-up explicitly deferred by [#145](https://github.com/xdustinface/rust-dashcore/issues/145).
- **Stricter MTP check:** plumbing `header_storage` into `MempoolManager` or surfacing MTP as a manager-level signal is out of scope. Wall-clock substitution is documented as conservative.
- **FFI callback for `WalletEvent::TxRepeatedlyOrphaned`:** scoped out the same way as `WalletEvent::Reorg` in [#168](https://github.com/xdustinface/rust-dashcore/pull/168) — exhaustive-match arm consumes/drops with a TODO so the C ABI keeps compiling.
- **dashd integration tests:** [#147](https://github.com/xdustinface/rust-dashcore/issues/147).

### Verification

- `cargo fmt --check` clean
- `cargo clippy --lib --tests -p dash-spv -p dash-spv-ffi -p key-wallet -p key-wallet-manager -- -D warnings` clean
- `cargo test --lib`: dash-spv 544, key-wallet-manager 55, key-wallet 487

Closes [#146](https://github.com/xdustinface/rust-dashcore/issues/146).